### PR TITLE
PPU: generic host-overlay extraction (additive, opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ To keep new games consistent and free of leftover game-specific naming:
 - `recompiler/` — Python code that decodes 65816 ROM bytes,
   reconstructs control flow, and emits C.
 - `runner/` — C runtime that the generated code links against (CPU
-  state, memory mapping, debug server, always-on trace rings).
+  state, memory mapping, PPU/APU/DSP, debug server, always-on trace rings).
+  Its PPU can also export arbitrary BG/OBJ rectangles for independent host
+  composition; see [`docs/HOST_OVERLAY_EXTRACTION.md`](docs/HOST_OVERLAY_EXTRACTION.md).
 - `tests/` — framework tests (decoder, CFG, SSA placement, etc.) and
   L3 fixtures.
 - `fuzz/` — differential fuzzer over synthetic 65816 snippets.

--- a/docs/HOST_OVERLAY_EXTRACTION.md
+++ b/docs/HOST_OVERLAY_EXTRACTION.md
@@ -1,0 +1,107 @@
+# Host-overlay extraction
+
+The PPU can export selected, already-rendered SNES graphics into transparent
+ARGB surfaces without modifying emulated VRAM, OAM, WRAM, registers, DMA, or
+savestate data. This is a renderer capability; each game still owns the policy
+that identifies a HUD, portrait, logo, menu panel, or other promotable graphic.
+
+This capability is **opt-in and additive**. With no surface bound and no capture
+rectangle configured, every source is a deterministic no-op: each layer is drawn
+straight into the normal composition buffer and the sprite/backdrop paths behave
+exactly as before, so authentic/headless/oracle output is byte-identical. It was
+ported (additively, preserving this engine's existing widescreen layer-policy
+API) from Derrick Gold's ActRaiser fork; see the attribution below.
+
+## Boundary of responsibility
+
+| Owner | Responsibility |
+|---|---|
+| PPU runner | Isolate BG1-BG4/OBJ pixels, apply tile decode, scroll, windows, mosaic, palette and master brightness, optionally omit the captured rectangle from the game framebuffer |
+| Game policy | Decide the source, screen-space rectangle, OAM slots, and game states in which capture is valid |
+| Host frontend | Crop pieces from the surface, anchor/scale them, substitute higher-resolution art, and choose final presentation order |
+
+The runner deliberately does not depend on SDL, OpenGL, or a particular host
+layout. Independent post-upscale composition remains a frontend operation.
+
+## Lifecycle
+
+Bindings are persistent host resources; capture rectangles are per-frame game
+policy:
+
+```c
+PpuClearOverlayBindings(ppu);
+PpuBindOverlaySurface(ppu, kPpuOverlaySource_Bg3,
+                      bg3_argb, framebuffer_pitch);
+PpuBindOverlaySurface(ppu, kPpuOverlaySource_Obj,
+                      obj_argb, framebuffer_pitch);
+
+/* Once per emulated frame, before scanout. */
+PpuClearOverlayCaptures(ppu);
+PpuSetOverlayCapture(ppu, kPpuOverlaySource_Bg3,
+                     0, 0, 256, 40,
+                     kPpuOverlayFlag_RemoveFromGame);
+PpuSetOverlayCapture(ppu, kPpuOverlaySource_Obj,
+                     0, 0, 256, 40,
+                     kPpuOverlayFlag_RemoveFromGame);
+PpuSetOverlayOamRange(ppu, 0, 4);
+```
+
+Each source owns one bounding rectangle and one full-frame output surface. A
+frontend may crop several disjoint graphics from that rectangle. Separate
+sources can be captured simultaneously. Passing flags `0` makes a diagnostic
+copy while retaining the source in the normal framebuffer;
+`RemoveFromGame` promotes it by omitting the rectangle from both the SNES main
+and subscreen paths.
+
+Coordinates are visible screen space after scroll/window/mosaic processing.
+The authentic screen is `x=[0,256)`; widescreen margins may use negative X or X
+greater than 255. Output surfaces share the game framebuffer's pitch and
+coordinate system, so authentic X zero is stored after the surface's left
+centering budget.
+
+OBJ capture additionally requires an OAM range. The runner treats slot identity
+as opaque; the game must validate that the slots still represent the intended
+graphic before selecting them. Rectangle clipping is per pixel, so partially
+intersecting sprites retain their non-captured pixels in the normal OBJ plane.
+
+## Rendering semantics
+
+- Transparent BG/OBJ pixels remain alpha zero. Palette and master brightness
+  are resolved before export.
+- BG capture uses an isolated priority buffer. Outside a promoted rectangle,
+  the isolated layer is merged back using the normal per-pixel priority word.
+- The exported ARGB comes from the main-screen layer pass. The subscreen pass
+  is isolated too when removal is requested, but is not exported; promoting a
+  layer used only for subscreen color math needs a future screen-selection or
+  intermediate-composition extension.
+- Promotion is applied to main and subscreen so removed graphics cannot leave a
+  color-math ghost underneath the host copy.
+- Bindings survive `ppu_reset`; capture policy does not. A NULL binding is a
+  deterministic no-op and preserves pure-headless/oracle output.
+- The host overlay is above the already-flattened framebuffer. HUDs and topmost
+  UI are therefore direct. Replacing scenery that must remain behind sprites or
+  foreground BG priority requires exporting those occluding planes too, or a
+  future intermediate-composition hook.
+
+## Current coverage
+
+The descriptor namespace includes BG1-BG4 and OBJ. This engine's renderer draws
+SNES Modes 1, 2, 3, and 7; capture is currently wired for **Mode 1 BG1/BG2
+(4bpp) and BG3 (2bpp), and Mode 7 BG1**. Modes 2 and 3 render normally but do
+not yet feed the overlay path; wiring them (and BG4, once a mode that draws it
+lands) is a mechanical follow-up that reuses the same
+`PpuBeginBackgroundOverlay`/`PpuFinishBackgroundOverlay` seam. The old PPU
+renderer (`PpuDrawWholeLineOldPpu`) does not implement host-overlay extraction.
+
+This port leaves the engine's existing widescreen layer-policy controls
+(`PpuSetWidescreenLayerClamp`/`Mirror`/`Repeat`, the clamp/repeat bands, the
+margin gap, the BG3 widen/HUD-split, and the Mode-2 layer capture) fully intact;
+overlay extraction is an orthogonal, independently opt-in capability.
+
+## Attribution
+
+Ported from Derrick Gold's ActRaiser SNES recompilation fork
+(`DerrickGold/snesrecomp`, commit `c6ad43a` "PPU: generalize host overlay
+extraction"). ActRaiser is the first consumer: it captures the authentic BG3
+status rectangle and a validated four-slot OBJ graphic, then performs its
+game-specific left/center/right composition after SDL has upscaled the world.

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -36,10 +36,16 @@ void ppu_reset(Ppu* ppu) {
     size_t pitch = ppu->renderPitch;
     uint8_t *renderBuffer = ppu->renderBuffer;
     uint32_t renderFlags = ppu->renderFlags;
+    uint32_t overlayPitch[kPpuOverlaySource_Count];
+    uint8_t *overlayBuffer[kPpuOverlaySource_Count];
+    memcpy(overlayPitch, ppu->overlayRenderPitch, sizeof(overlayPitch));
+    memcpy(overlayBuffer, ppu->overlayRenderBuffer, sizeof(overlayBuffer));
     memset(ppu, 0, sizeof(*ppu));
     ppu->renderBuffer = renderBuffer;
     ppu->renderPitch = (uint32_t)pitch;
     ppu->renderFlags = renderFlags;
+    memcpy(ppu->overlayRenderPitch, overlayPitch, sizeof(overlayPitch));
+    memcpy(ppu->overlayRenderBuffer, overlayBuffer, sizeof(overlayBuffer));
   }
   ppu->vramIncrement = 1;
 }
@@ -57,6 +63,66 @@ void PpuBeginDrawing(Ppu *ppu, uint8_t *pixels, size_t pitch, uint32_t render_fl
   ppu->renderPitch = (uint)pitch;
   ppu->renderBuffer = pixels;
   ppu->renderFlags = render_flags;
+}
+
+void PpuClearOverlayCaptures(Ppu *ppu) {
+  memset(ppu->overlayCaptures, 0, sizeof(ppu->overlayCaptures));
+}
+
+void PpuClearOverlayBindings(Ppu *ppu) {
+  memset(ppu->overlayRenderBuffer, 0, sizeof(ppu->overlayRenderBuffer));
+  memset(ppu->overlayRenderPitch, 0, sizeof(ppu->overlayRenderPitch));
+  PpuClearOverlayCaptures(ppu);
+}
+
+bool PpuBindOverlaySurface(Ppu *ppu, PpuOverlaySource source,
+                           uint8_t *pixels, size_t pitch) {
+  if ((unsigned)source >= kPpuOverlaySource_Count ||
+      (pixels && (!pitch || pitch % sizeof(uint32_t) != 0 ||
+                  pitch / sizeof(uint32_t) < kPpuXPixels ||
+                  pitch / sizeof(uint32_t) > kPpuBufWidth)))
+    return false;
+  ppu->overlayRenderBuffer[source] = pixels;
+  ppu->overlayRenderPitch[source] = pixels ? (uint32_t)pitch : 0;
+  if (!pixels)
+    memset(&ppu->overlayCaptures[source], 0,
+           sizeof(ppu->overlayCaptures[source]));
+  return true;
+}
+
+bool PpuSetOverlayCapture(Ppu *ppu, PpuOverlaySource source,
+                          int x, int y, int width, int height, uint8_t flags) {
+  if ((unsigned)source >= kPpuOverlaySource_Count || width <= 0 || height <= 0)
+    return false;
+  int64_t requested_x1 = (int64_t)x + width;
+  int64_t requested_y1 = (int64_t)y + height;
+  int x0 = IntMax(x, -kPpuExtraLeftRight);
+  int x1 = requested_x1 < kPpuXPixels + kPpuExtraLeftRight
+      ? (int)requested_x1 : kPpuXPixels + kPpuExtraLeftRight;
+  int y0 = IntMax(y, 0);
+  int y1 = requested_y1 < 240 ? (int)requested_y1 : 240;
+  if (x1 <= x0 || y1 <= y0)
+    return false;
+  PpuOverlayCapture *capture = &ppu->overlayCaptures[source];
+  capture->x0 = (int16_t)x0;
+  capture->x1 = (int16_t)x1;
+  capture->y0 = (int16_t)y0;
+  capture->y1 = (int16_t)y1;
+  capture->flags = flags & kPpuOverlayFlag_RemoveFromGame;
+  capture->oamFirst = 0;
+  capture->oamCount = 0;
+  return true;
+}
+
+bool PpuSetOverlayOamRange(Ppu *ppu, uint8_t first, uint8_t count) {
+  PpuOverlayCapture *capture =
+      &ppu->overlayCaptures[kPpuOverlaySource_Obj];
+  if (first >= 128 || !count || count > 128 - first ||
+      capture->x1 <= capture->x0 || capture->y1 <= capture->y0)
+    return false;
+  capture->oamFirst = first;
+  capture->oamCount = count;
+  return true;
 }
 
 static inline void PpuResetLayerPolicies(Ppu *ppu) {
@@ -237,6 +303,9 @@ void ppu_runLine(Ppu* ppu, int line) {
 
     // evaluate sprites
     ClearBackdrop(&ppu->objBuffer);
+    if (ppu->overlayRenderBuffer[kPpuOverlaySource_Obj])
+      memset(&ppu->overlayBuffers[kPpuOverlaySource_Obj], 0,
+             sizeof(ppu->overlayBuffers[kPpuOverlaySource_Obj]));
     ppu->lineHasSprites = !PPU_forcedBlank(ppu) && ppu_evaluateSprites(ppu, line - 1);
 
     if (g_new_ppu) {
@@ -761,7 +830,7 @@ static void PpuDrawBackground_4bpp_opt(Ppu *ppu, uint y, bool sub, uint layer,
 }
 
 // Draw a whole line of a 2bpp background layer into bgBuffers
-static void PpuDrawBackground_2bpp(Ppu *ppu, uint y, bool sub, uint layer, PpuZbufType zhi, PpuZbufType zlo) {
+static void PpuDrawBackground_2bpp(Ppu *ppu, PpuPixelPrioBufs *dstbuf, uint y, bool sub, uint layer, PpuZbufType zhi, PpuZbufType zlo) {
 #define DO_PIXEL(i) do { \
   pixel = (bits >> i) & 1 | (bits >> (7 + i)) & 2; \
   if (pixel && z > dstz[i]) dstz[i] = z + pixel; } while (0)
@@ -786,7 +855,8 @@ static void PpuDrawBackground_2bpp(Ppu *ppu, uint y, bool sub, uint layer, PpuZb
   // window shape (e.g. the level-start iris) keeps the authentic centered
   // HUD for those frames — split + real windows don't compose.
   int16 ws_bias[8] = { 0 };
-  if (layer == 2 && y < ppu->wsHudSplitHeight &&
+  if (dstbuf == &ppu->bgBuffers[sub] &&
+      layer == 2 && y < ppu->wsHudSplitHeight &&
       ppu->extraLeftRight &&
       win.nr == 1 && win.bits == 0) {
     win.nr = 5;
@@ -819,7 +889,7 @@ static void PpuDrawBackground_2bpp(Ppu *ppu, uint y, bool sub, uint layer, PpuZb
       continue;  // layer is disabled for this window part
     uint x = win.edges[windex] + ppu->hScroll[layer] + ws_bias[windex];
     uint w = win.edges[windex + 1] - win.edges[windex];
-    PpuZbufType *dstz = ppu->bgBuffers[sub].data + win.edges[windex] + kPpuExtraLeftRight;
+    PpuZbufType *dstz = dstbuf->data + win.edges[windex] + kPpuExtraLeftRight;
     const uint16 *tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
     const uint16 *tp_last = tps[x >> 8 & 1] + 31;
     const uint16 *tp_next = tps[(x >> 8 & 1) ^ 1];
@@ -958,10 +1028,10 @@ static void PpuDrawBackground_4bpp_mosaic(Ppu *ppu,
 // Merge one isolated layer into the live priority buffer, padding only that
 // layer's side margins so transparent pixels never duplicate lower layers or
 // sprites. `repeat` selects cyclic continuation; otherwise reflect the edge.
-static void PpuMergePaddedBackground(Ppu *ppu, bool sub,
+static void PpuMergePaddedBackground(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
                                      const PpuPixelPrioBufs *layerbuf,
                                      bool repeat) {
-  PpuZbufType *dst = ppu->bgBuffers[sub].data;
+  PpuZbufType *dst = dstbuf->data;
   const PpuZbufType *src = layerbuf->data;
   for (int x = 0; x < kPpuXPixels; x++) {
     int i = x + kPpuExtraLeftRight;
@@ -982,7 +1052,8 @@ static void PpuMergePaddedBackground(Ppu *ppu, bool sub,
   }
 }
 
-static void PpuDrawBackground_4bpp_policy(Ppu *ppu, uint y, bool sub,
+static void PpuDrawBackground_4bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
+                                          uint y, bool sub,
                                           uint layer, PpuZbufType zhi,
                                           PpuZbufType zlo, bool mosaic) {
   uint8_t padding = ppu->wsLayerMirror | ppu->wsLayerRepeat;
@@ -991,10 +1062,10 @@ static void PpuDrawBackground_4bpp_policy(Ppu *ppu, uint y, bool sub,
       y >= ppu->wsRepeatY0[layer] && y < ppu->wsRepeatY1[layer];
   if (!(padding & (1u << layer)) && !repeat_band) {
     if (mosaic)
-      PpuDrawBackground_4bpp_mosaic(ppu, &ppu->bgBuffers[sub], y, sub,
+      PpuDrawBackground_4bpp_mosaic(ppu, dstbuf, y, sub,
                                     layer, zhi, zlo);
     else
-      PpuDrawBackground_4bpp(ppu, &ppu->bgBuffers[sub], y, sub, layer,
+      PpuDrawBackground_4bpp(ppu, dstbuf, y, sub, layer,
                              zhi, zlo);
     return;
   }
@@ -1005,13 +1076,13 @@ static void PpuDrawBackground_4bpp_policy(Ppu *ppu, uint y, bool sub,
     PpuDrawBackground_4bpp_mosaic(ppu, &layerbuf, y, sub, layer, zhi, zlo);
   else
     PpuDrawBackground_4bpp(ppu, &layerbuf, y, sub, layer, zhi, zlo);
-  PpuMergePaddedBackground(ppu, sub, &layerbuf,
+  PpuMergePaddedBackground(ppu, dstbuf, &layerbuf,
                            repeat_band ||
                            (ppu->wsLayerRepeat & (1u << layer)) != 0);
 }
 
 // Draw a whole line of a 2bpp background layer into bgBuffers, with mosaic applied
-static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, int y, bool sub, uint layer, PpuZbufType zhi, PpuZbufType zlo) {
+static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, PpuPixelPrioBufs *dstbuf, int y, bool sub, uint layer, PpuZbufType zhi, PpuZbufType zlo) {
 #define GET_PIXEL() pixel = (bits) & 1 | (bits >> 7) & 2
 #define GET_PIXEL_HFLIP() pixel = (bits >> 7) & 1 | (bits >> 14) & 2
 #define READ_BITS(ta, tile) (addr = &ppu->vram[((ta) + (tile) * 8) & 0x7fff], addr[0])
@@ -1035,8 +1106,8 @@ static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, int y, bool sub, uint layer,
     if (win.bits & (1 << windex))
       continue;  // layer is disabled for this window part
     int sx = win.edges[windex];
-    PpuZbufType *dstz = ppu->bgBuffers[sub].data + sx + kPpuExtraLeftRight;
-    PpuZbufType *dstz_end = ppu->bgBuffers[sub].data + win.edges[windex + 1] + kPpuExtraLeftRight;
+    PpuZbufType *dstz = dstbuf->data + sx + kPpuExtraLeftRight;
+    PpuZbufType *dstz_end = dstbuf->data + win.edges[windex + 1] + kPpuExtraLeftRight;
     uint x = sx + ppu->hScroll[layer];
     const uint16 *tp = tps[x >> 8 & 1] + ((x >> 3) & 0x1f);
     const uint16 *tp_last = tps[x >> 8 & 1] + 31, *tp_next = tps[(x >> 8 & 1) ^ 1];
@@ -1071,7 +1142,7 @@ static void PpuDrawBackground_2bpp_mosaic(Ppu *ppu, int y, bool sub, uint layer,
 
 
 // Assumes it's drawn on an empty backdrop
-static void PpuDrawBackground_mode7(Ppu *ppu, uint y, bool sub, PpuZbufType z) {
+static void PpuDrawBackground_mode7(Ppu *ppu, PpuPixelPrioBufs *dstbuf, uint y, bool sub, PpuZbufType z) {
   int layer = 0;
   if (!IS_SCREEN_ENABLED(ppu, sub, layer))
     return;  // layer is completely hidden
@@ -1099,8 +1170,8 @@ static void PpuDrawBackground_mode7(Ppu *ppu, uint y, bool sub, PpuZbufType z) {
     if (win.bits & (1 << windex))
       continue;  // layer is disabled for this window part
     int x = win.edges[windex], x2 = win.edges[windex + 1], tile;
-    PpuZbufType *dstz = ppu->bgBuffers[sub].data + x + kPpuExtraLeftRight;
-    PpuZbufType *dstz_end = ppu->bgBuffers[sub].data + x2 + kPpuExtraLeftRight;
+    PpuZbufType *dstz = dstbuf->data + x + kPpuExtraLeftRight;
+    PpuZbufType *dstz_end = dstbuf->data + x2 + kPpuExtraLeftRight;
     uint32 rx = PPU_m7xFlip(ppu) ? 255 - x : x;
     uint32 xpos = m7startX + ppu->m7matrix[0] * rx;
     uint32 ypos = m7startY + ppu->m7matrix[2] * rx;
@@ -1166,6 +1237,108 @@ static void PpuDrawSprites(Ppu *ppu, uint y, uint sub, bool clear_backdrop) {
   }
 }
 
+static bool PpuOverlayActiveOnLine(Ppu *ppu, PpuOverlaySource source,
+                                   int screen_y) {
+  if ((unsigned)source >= kPpuOverlaySource_Count ||
+      !ppu->overlayRenderBuffer[source] ||
+      !ppu->overlayRenderPitch[source])
+    return false;
+  const PpuOverlayCapture *capture = &ppu->overlayCaptures[source];
+  return capture->x1 > capture->x0 && capture->y1 > capture->y0 &&
+         screen_y >= capture->y0 && screen_y < capture->y1;
+}
+
+static uint32 PpuOverlayColor(Ppu *ppu, PpuZbufType pixel) {
+  /* Isolated layer buffers may contain the priority-only backdrop marker.
+   * A zero palette index is still transparent for a captured BG/OBJ plane. */
+  if (!(pixel & 0xff)) return 0;
+  uint32 color = ppu->cgram[pixel & 0xff];
+  return 0xff000000u |
+      (uint32)ppu->brightnessMult[color & 0x1f] << 16 |
+      (uint32)ppu->brightnessMult[(color >> 5) & 0x1f] << 8 |
+      ppu->brightnessMult[(color >> 10) & 0x1f];
+}
+
+static void PpuClearOverlayRenderLine(Ppu *ppu, uint y) {
+  if (y == 0) return;
+  int screen_y = (int)y - 1;
+  for (int source = 0; source < kPpuOverlaySource_Count; source++) {
+    uint8_t *pixels = ppu->overlayRenderBuffer[source];
+    uint32_t pitch = ppu->overlayRenderPitch[source];
+    if (pixels && pitch)
+      memset(pixels + (size_t)screen_y * pitch, 0, pitch);
+  }
+}
+
+static void PpuWriteOverlayRenderLine(Ppu *ppu, PpuOverlaySource source,
+                                      uint y) {
+  if (y == 0) return;
+  int screen_y = (int)y - 1;
+  if (!PpuOverlayActiveOnLine(ppu, source, screen_y))
+    return;
+
+  uint32_t pitch = ppu->overlayRenderPitch[source];
+  int width = (int)(pitch / sizeof(uint32));
+  int texture_extra = IntMax((width - kPpuXPixels) / 2, 0);
+  int screen_min = -texture_extra;
+  int screen_max = width - texture_extra;
+  const PpuOverlayCapture *capture = &ppu->overlayCaptures[source];
+  int x0 = IntMax(capture->x0, screen_min);
+  int x1 = IntMin(capture->x1, screen_max);
+  if (x1 <= x0 || x0 + kPpuExtraLeftRight < 0 ||
+      x1 + kPpuExtraLeftRight > kPpuBufWidth)
+    return;
+
+  uint32 *dst = (uint32 *)(ppu->overlayRenderBuffer[source] +
+                            (size_t)screen_y * pitch);
+  const PpuZbufType *src = ppu->overlayBuffers[source].data;
+  for (int x = x0; x < x1; x++)
+    dst[x + texture_extra] =
+        PpuOverlayColor(ppu, src[x + kPpuExtraLeftRight]);
+}
+
+// Choose the destination priority buffer for a background layer. When the
+// layer's overlay source is active on this line, draw it in isolation into a
+// dedicated buffer (so it can be captured and optionally removed). Otherwise
+// return the normal composition buffer, leaving the draw path byte-identical.
+static PpuPixelPrioBufs *PpuBeginBackgroundOverlay(Ppu *ppu, uint y,
+                                                   bool sub, uint layer) {
+  int screen_y = (int)y - 1;
+  PpuOverlaySource source = (PpuOverlaySource)layer;
+  if (!PpuOverlayActiveOnLine(ppu, source, screen_y))
+    return &ppu->bgBuffers[sub];
+  memset(&ppu->overlayBuffers[source], 0,
+         sizeof(ppu->overlayBuffers[source]));
+  return &ppu->overlayBuffers[source];
+}
+
+// Merge an isolated overlay layer back into the composition buffer (skipping
+// the captured rectangle when RemoveFromGame is set) and export the captured
+// pixels to the bound host surface. A no-op when the layer was drawn straight
+// into bgBuffers (overlay inactive).
+static void PpuFinishBackgroundOverlay(Ppu *ppu, uint y, bool sub,
+                                       uint layer,
+                                       PpuPixelPrioBufs *layerbuf) {
+  PpuOverlaySource source = (PpuOverlaySource)layer;
+  if (layerbuf != &ppu->overlayBuffers[source])
+    return;
+
+  if (!sub)
+    PpuWriteOverlayRenderLine(ppu, source, y);
+
+  const PpuOverlayCapture *capture = &ppu->overlayCaptures[source];
+  PpuZbufType *dst = ppu->bgBuffers[sub].data;
+  const PpuZbufType *src = layerbuf->data;
+  bool remove = (capture->flags & kPpuOverlayFlag_RemoveFromGame) != 0;
+  for (int i = 0; i < kPpuBufWidth; i++) {
+    int x = i - kPpuExtraLeftRight;
+    if (remove && x >= capture->x0 && x < capture->x1)
+      continue;
+    if (src[i] > dst[i])
+      dst[i] = src[i];
+  }
+}
+
 static void PpuDrawBackgrounds(Ppu *ppu, int y, bool sub) {
   // Top 4 bits contain the prio level, and bottom 4 bits the layer type.
   // SPRITE_PRIO_TO_PRIO can be used to convert from obj prio to this prio.
@@ -1192,18 +1365,25 @@ static void PpuDrawBackgrounds(Ppu *ppu, int y, bool sub) {
     }
 
     bool mosaic_size = PPU_mosaicSize(ppu) > 1;
+    PpuPixelPrioBufs *layerbuf = PpuBeginBackgroundOverlay(ppu, y, sub, 0);
     PpuDrawBackground_4bpp_policy(
-        ppu, y, sub, 0, 0xc000, 0x8000,
+        ppu, layerbuf, y, sub, 0, 0xc000, 0x8000,
         mosaic_size && PPU_mosaicEnabled(ppu, 0));
+    PpuFinishBackgroundOverlay(ppu, y, sub, 0, layerbuf);
+
+    layerbuf = PpuBeginBackgroundOverlay(ppu, y, sub, 1);
     PpuDrawBackground_4bpp_policy(
-        ppu, y, sub, 1, 0xb100, 0x7100,
+        ppu, layerbuf, y, sub, 1, 0xb100, 0x7100,
         mosaic_size && PPU_mosaicEnabled(ppu, 1));
+    PpuFinishBackgroundOverlay(ppu, y, sub, 1, layerbuf);
 
     uint bg3prio = PPU_bg3priority(ppu) ? 0xf200 : 0x3200;
+    layerbuf = PpuBeginBackgroundOverlay(ppu, y, sub, 2);
     if (mosaic_size && PPU_mosaicEnabled(ppu, 2))
-      PpuDrawBackground_2bpp_mosaic(ppu, y, sub, 2, bg3prio, 0x1200);
+      PpuDrawBackground_2bpp_mosaic(ppu, layerbuf, y, sub, 2, bg3prio, 0x1200);
     else
-      PpuDrawBackground_2bpp(ppu, y, sub, 2, bg3prio, 0x1200);
+      PpuDrawBackground_2bpp(ppu, layerbuf, y, sub, 2, bg3prio, 0x1200);
+    PpuFinishBackgroundOverlay(ppu, y, sub, 2, layerbuf);
   } else if (PPU_mode(ppu) == 2) {
     if (ppu->lineHasSprites)
       PpuDrawSprites(ppu, y, sub, true);
@@ -1217,13 +1397,16 @@ static void PpuDrawBackgrounds(Ppu *ppu, int y, bool sub) {
                            0xb100, 0x7100);
   } else {
     // mode 7
-    PpuDrawBackground_mode7(ppu, y, sub, 0x5000);
+    PpuPixelPrioBufs *layerbuf = PpuBeginBackgroundOverlay(ppu, y, sub, 0);
+    PpuDrawBackground_mode7(ppu, layerbuf, y, sub, 0x5000);
+    PpuFinishBackgroundOverlay(ppu, y, sub, 0, layerbuf);
     if (ppu->lineHasSprites)
       PpuDrawSprites(ppu, y, sub, false);
   }
 }
 
 static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
+  PpuClearOverlayRenderLine(ppu, y);
   if (PPU_forcedBlank(ppu)) {
     uint8 *dst = &ppu->renderBuffer[(y - 1) * ppu->renderPitch];
     size_t n = sizeof(uint32) * (256 + ppu->extraLeftRight * 2);
@@ -1315,6 +1498,7 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
     }
   } while (cw_clip_math >>= 1, ++windex < cwin.nr);
 
+  PpuWriteOverlayRenderLine(ppu, kPpuOverlaySource_Obj, y);
 }
 
 static bool ppu_evaluateSprites(Ppu* ppu, int line) {
@@ -1394,12 +1578,41 @@ static bool ppu_evaluateSprites(Ppu* ppu, int line) {
             int px_right = IntMin(256 + kPpuExtraLeftRight - (col + x), 8);
             PpuZbufType *dst = ppu->objBuffer.data + col + x + px_left + kPpuExtraLeftRight;
 
+            // Host-overlay OBJ extraction: capture the pixels of a validated
+            // OAM slot range inside the capture rect into a separate surface,
+            // optionally removing them from the world object buffer. Inactive
+            // (capture_slot false) when no OBJ surface is bound, leaving the
+            // draw byte-identical.
+            int slot = index >> 1;
+            PpuOverlayCapture *obj_capture =
+                &ppu->overlayCaptures[kPpuOverlaySource_Obj];
+            bool capture_slot = PpuOverlayActiveOnLine(
+                ppu, kPpuOverlaySource_Obj, line) &&
+                obj_capture->oamCount && slot >= obj_capture->oamFirst &&
+                slot < obj_capture->oamFirst + obj_capture->oamCount;
+            bool obj_remove = capture_slot &&
+                (obj_capture->flags & kPpuOverlayFlag_RemoveFromGame) != 0;
+
             for (int px = px_left; px < px_right; px++, dst++) {
               int shift = oam1 & 0x4000 ? px : 7 - px;
               uint32 bits = plane >> shift;
               int pixel = (bits >> 0) & 1 | (bits >> 7) & 2 | (bits >> 14) & 4 | (bits >> 21) & 8;
+              if (pixel == 0)
+                continue;
+              if (capture_slot) {
+                int screen_x = col + x + px;
+                if (screen_x >= obj_capture->x0 && screen_x < obj_capture->x1) {
+                  PpuZbufType *overlay =
+                      &ppu->overlayBuffers[kPpuOverlaySource_Obj]
+                           .data[dst - ppu->objBuffer.data];
+                  if ((*overlay & 0xff) == 0)
+                    *overlay = z + pixel;
+                  if (obj_remove)
+                    continue;
+                }
+              }
               // draw it in the buffer if there is a pixel here, and the buffer there is still empty
-              if (pixel != 0 && (dst[0] & 0xff) == 0)
+              if ((dst[0] & 0xff) == 0)
                 dst[0] = z + pixel;
             }
 

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -45,6 +45,38 @@ typedef struct PpuPixelPrioBufs {
   PpuZbufType data[kPpuBufWidth];
 } PpuPixelPrioBufs;
 
+/* Renderer-neutral host-overlay extraction. BG source values deliberately
+ * match the PPU layer indices; OBJ is the fifth screen layer. Each source can
+ * own one screen-space capture rectangle and one full-frame ARGB destination
+ * surface. A caller can crop several independently placed graphics from one
+ * captured bounding rectangle after scanout. */
+typedef enum PpuOverlaySource {
+  kPpuOverlaySource_Bg1 = 0,
+  kPpuOverlaySource_Bg2 = 1,
+  kPpuOverlaySource_Bg3 = 2,
+  kPpuOverlaySource_Bg4 = 3,
+  kPpuOverlaySource_Obj = 4,
+  kPpuOverlaySource_Count = 5,
+} PpuOverlaySource;
+
+enum {
+  /* Do not merge captured pixels back into either main or subscreen. The host
+   * can then reinsert them without a duplicate remaining in renderBuffer. */
+  kPpuOverlayFlag_RemoveFromGame = 1,
+};
+
+typedef struct PpuOverlayCapture {
+  /* SNES screen coordinates after scroll/window/mosaic processing. X may be
+   * negative or exceed 255 when a widescreen margin is active. Endpoints are
+   * exclusive. y uses visible output coordinates (0 is the first scanline). */
+  int16_t x0, x1;
+  int16_t y0, y1;
+  uint8_t flags;
+  /* OBJ-only selector. A zero count captures no objects. Games validate any
+   * semantic identity (HUD icon, portrait, etc.) before supplying the range. */
+  uint8_t oamFirst, oamCount;
+} PpuOverlayCapture;
+
 enum {
   kPpuRenderFlags_NewRenderer = 1,
   // Render mode7 upsampled by 4x4
@@ -173,8 +205,13 @@ struct Ppu {
   uint32_t renderFlags;
   PpuPixelPrioBufs bgBuffers[2];
   PpuPixelPrioBufs objBuffer;
+  /* Per-source isolated priority pixels for generic host-overlay captures. */
+  PpuPixelPrioBufs overlayBuffers[kPpuOverlaySource_Count];
+  PpuOverlayCapture overlayCaptures[kPpuOverlaySource_Count];
   uint32_t renderPitch;
   uint8_t *renderBuffer;
+  uint32_t overlayRenderPitch[kPpuOverlaySource_Count];
+  uint8_t *overlayRenderBuffer[kPpuOverlaySource_Count];
   uint8_t brightnessMult[32 + 31];
   uint8_t brightnessMultHalf[32 * 2];
   uint8_t mosaicModulo[kPpuXPixels];
@@ -262,6 +299,35 @@ uint8_t ppu_read(Ppu* ppu, uint8_t adr);
 void ppu_write(Ppu* ppu, uint8_t adr, uint8_t val);
 void ppu_saveload(Ppu *ppu, SaveLoadInfo *sli);
 void PpuBeginDrawing(Ppu *ppu, uint8_t *pixels, size_t pitch, uint32_t render_flags);
+
+// Renderer-neutral host-overlay extraction (opt-in; see
+// docs/HOST_OVERLAY_EXTRACTION.md). Default behavior is unchanged: with no
+// surface bound and no capture rectangle set, every source is a deterministic
+// no-op and the layer stays composited into renderBuffer exactly as before.
+
+// Clear/bind persistent transparent ARGB host-overlay surfaces. Bindings survive
+// ppu_reset; capture rectangles do not and are configured by game policy each
+// frame. Surfaces are 256-kPpuBufWidth pixels wide and use the same full-frame
+// coordinate system as renderBuffer.
+// Passing NULL disables extraction for that source. Call ClearBindings once
+// after PPU creation so a frontend can explicitly own all optional surfaces.
+void PpuClearOverlayBindings(Ppu *ppu);
+bool PpuBindOverlaySurface(Ppu *ppu, PpuOverlaySource source,
+                           uint8_t *pixels, size_t pitch);
+
+// Clear per-frame capture policy, then configure an arbitrary screen-space
+// rectangle from BG1-BG4 or OBJ. With RemoveFromGame, pixels inside the rect
+// are omitted from both main and subscreen while still exported with palette,
+// transparency, windows, mosaic, and master brightness resolved. Coverage:
+// Mode 1 BG1/BG2 (4bpp) and BG3 (2bpp), and Mode 7 BG1; other modes/layers
+// leave the source inactive.
+void PpuClearOverlayCaptures(Ppu *ppu);
+bool PpuSetOverlayCapture(Ppu *ppu, PpuOverlaySource source,
+                          int x, int y, int width, int height, uint8_t flags);
+
+// Select a contiguous OAM slot range for an already configured OBJ capture.
+// The game remains responsible for validating what those slots represent.
+bool PpuSetOverlayOamRange(Ppu *ppu, uint8_t first, uint8_t count);
 
 // Set the symmetric widescreen border, in pixels per side (clamped to
 // kPpuExtraLeftRight). 0 restores authentic 256-wide rendering. The internal


### PR DESCRIPTION
Ports Derrick Gold's renderer-neutral BG/OBJ **host-overlay extraction** into our
PPU as an additive, opt-in capability. The PPU can export selected already-rendered
SNES graphics (a HUD, portrait, logo, menu panel, …) into transparent ARGB surfaces
for independent host composition — without touching emulated VRAM/OAM/WRAM/registers/
DMA/savestate.

Source: `DerrickGold/snesrecomp` commit
[`c6ad43a`](https://github.com/DerrickGold/snesrecomp/commit/c6ad43a35260c2d872995327ec6e1d11c1f66e39)
("PPU: generalize host overlay extraction").

## Why a re-implementation instead of a cherry-pick
That commit is the tip of an unmerged 22-commit ActRaiser widescreen-HUD chain and
does **not** apply to our engine — two independent reasons:
1. **Line endings** — their tree is LF, ours is (mixed) CRLF, so every line "differs."
2. **Diverged widescreen subsystem** — our main uses `PpuSetWidescreenLayerMask` +
   Mode-2 layer capture; their tree replaced those with clamp/mirror/repeat *bands*.
   The function bodies the commit refactors don't match ours.

So this is a faithful re-implementation against **our** PPU, keeping our existing
widescreen layer-policy API fully intact.

## What changed
- New API in `ppu.h`: `PpuOverlaySource`, `PpuOverlayCapture`, `PpuClearOverlayBindings`,
  `PpuBindOverlaySurface`, `PpuClearOverlayCaptures`, `PpuSetOverlayCapture`,
  `PpuSetOverlayOamRange`.
- Threads an explicit destination buffer through the per-scanline BG draw functions
  (`_2bpp`, `_2bpp_mosaic`, `_mode7`, `_4bpp_policy`, `MergePaddedBackground`) and wraps
  **Mode 1 BG1–BG3** and **Mode 7 BG1** with `PpuBegin/FinishBackgroundOverlay`.
- OBJ capture threaded into `ppu_evaluateSprites`; each source's ARGB line is exported
  at scanout. Bindings survive `ppu_reset`; capture policy is per-frame.
- Docs: `docs/HOST_OVERLAY_EXTRACTION.md` + README pointer.

## Regression risk: opt-in and non-destructive *by construction*
With no surface bound and no capture rectangle set, `PpuBeginBackgroundOverlay` returns
the normal composition buffer and the finish/clear/export/OBJ-capture paths are all
no-ops — default output is byte-identical. No consumer game (SMW, MMX, Zelda, Super
Metroid, DKC, Star Fox, SMK) calls the API; it lands dormant until a frontend wires it up.

## Validation
A standalone render-equivalence harness drives the **old (main)** vs **new (this branch)**
PPU with identical deterministic VRAM/OAM/CGRAM/register state and byte-compares the
rendered framebuffer across 8 scenes exercising every threaded path:

| Scene | Coverage | old == new |
|---|---|---|
| 0–1 | Mode 1 (+bg3prio, +mosaic) | ✓ |
| 2–4 | widescreen, HUD split, layer padding/mirror/repeat | ✓ |
| 5–6 | Mode 7 (+mosaic) | ✓ |
| 7 | subscreen + color math | ✓ |

All 8 framebuffer hashes are **identical**. A bound BG3 copy-capture (`flags=0`) leaves the
base framebuffer **byte-identical** to the no-overlay render while exporting non-empty
overlay pixels — confirming the feature works *and* the isolate→merge-back path
reconstructs the same image.

(Full SMW/MMX game-build attract frame-diffs were not run here: the current `src/gen`
is in a stale duplicate-body state that needs a full regen — orthogonal to this PPU
change. The standalone harness isolates the rendering paths more directly.)

Co-authored with Derrick Gold (original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
