### PR TITLE
codegen: make block moves frame-safe

### DIFF
--- a/recompiler/v2/codegen.py
+++ b/recompiler/v2/codegen.py
@@ -33,6 +33,7 @@ for p in (str(_THIS_DIR), str(_RECOMPILER_DIR)):
         sys.path.insert(0, p)
 
 from typing import Dict, List, Optional, Tuple  # noqa: E402
+from snes_cycles import region_speed  # noqa: E402
 
 # Resolver: 24-bit address (bank << 16 | pc) -> friendly C function name.
 # Populated by emit_bank before each bank emit (a process-wide map of every
@@ -2471,21 +2472,37 @@ def _emit_blockmove(op: BlockMove) -> List[str]:
     delta = "+1" if op.direction == "mvn" else "-1"
     et = "CPU_TR_MVN" if op.direction == "mvn" else "CPU_TR_MVP"
     trace_pc = _trace_pc_arg()
+    slow_speed = region_speed(_CURRENT_SOURCE_PC24, 0)
+    fast_speed = region_speed(_CURRENT_SOURCE_PC24, 1)
+    speed_expr = (str(slow_speed) if slow_speed == fast_speed else
+                  f"(g_memsel ? {fast_speed} : {slow_speed})")
     return [
         "{",
         f"  uint8 _src_b = {op.src_bank:#04x};",
         f"  uint8 _dst_b = {op.dst_bank:#04x};",
         "  uint8 _old_db = cpu->DB;",
         f"  cpu_trace_event(cpu, 0, {et}, _src_b, _dst_b);",
-        "  while (cpu->A != 0xFFFF) {",
+        "  cpu->DB = _dst_b;",
+        f"  cpu_trace_db_change(cpu, {trace_pc}, _old_db, _dst_b, {et});",
+        "  /* MVN/MVP always transfer at least one byte. A is count-minus-one,",
+        "   * and an interrupt resumes at this same opcode with the updated",
+        "   * A/X/Y/DB state. The block's static charge covers the first byte;",
+        "   * each repeated byte costs another seven CPU cycles. */",
+        "  do {",
         "    uint8 _b = cpu_read8(cpu, _src_b, cpu->X);",
         "    cpu_write8(cpu, _dst_b, cpu->Y, _b);",
         f"    cpu->X = (uint16)(cpu->X {delta});",
         f"    cpu->Y = (uint16)(cpu->Y {delta});",
+        "    if (cpu->x_flag) { cpu->X &= 0x00FFu; cpu->Y &= 0x00FFu; }",
         "    cpu->A = (uint16)(cpu->A - 1);",
-        "  }",
-        "  cpu->DB = _dst_b;",
-        f"  cpu_trace_db_change(cpu, {trace_pc}, _old_db, _dst_b, {et});",
+        "    if (cpu->A != 0xFFFF) {",
+        "      if (interp_bridge_lle_master_deadline_reached(cpu)) {",
+        f"        return interp_bridge_lle_yield_unwind(cpu, {trace_pc});",
+        "      }",
+        "      cpu->cycles += 7;",
+        f"      cpu->master_cycles += 7 * {speed_expr};",
+        "    }",
+        "  } while (cpu->A != 0xFFFF);",
         "}",
     ]
 

--- a/recompiler/v2/translation_units.py
+++ b/recompiler/v2/translation_units.py
@@ -20,6 +20,31 @@ _SYNTHETIC_BANK_FN_RE = re.compile(
 _FORWARD_DECL_MARKER = "/* Forward declarations for in-bank entries. */"
 
 
+def _with_referenced_variant_declarations(source: str) -> str:
+    """Give a monolithic bank file prototypes for every generated callee.
+
+    ``emit_bank`` knows only about entries owned by the current bank, while
+    indirect dispatch tables and cross-bank tail transfers can call generated
+    variants owned by another bank.  A block-local ``extern`` at one tail-call
+    site does not declare that target for later dispatch calls in the same
+    translation unit.  Shards already rebuild their declaration list from all
+    call references; apply the same rule to monolithic banks.
+    """
+    marker = source.find(_FORWARD_DECL_MARKER)
+    if marker < 0:
+        raise ValueError("emitted source lacks forward declarations")
+    references = sorted(set(_VARIANT_CALL_NAME_RE.findall(source)))
+    if not references:
+        return source
+    line_end = source.find("\n", marker)
+    if line_end < 0:
+        line_end = len(source)
+    declarations = "".join(
+        f"RecompReturn {name}(CpuState *cpu);\n"
+        for name in references)
+    return source[:line_end + 1] + declarations + source[line_end + 1:]
+
+
 def split_bank_translation_units(
         source: str, bank: int, symbol_pcs: Mapping[str, int], *,
         threshold_bytes: int, pc_span: int) -> dict[str, str]:
@@ -34,7 +59,9 @@ def split_bank_translation_units(
     monolithic_name = f"bank{bank:02x}_v2.c"
     if (pc_span <= 0 or threshold_bytes < 0
             or len(source.encode("utf-8")) < threshold_bytes):
-        return {monolithic_name: source}
+        return {
+            monolithic_name: _with_referenced_variant_declarations(source)
+        }
 
     matches = list(_TOP_LEVEL_CPU_FN_RE.finditer(source))
     if not matches:

--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -458,24 +458,26 @@ bool RtlRunFrame(uint32 inputs) {
   return false;
 }
 
-void RtlSaveSnapshot(const char *filename) {
+bool RtlSaveSnapshot(const char *filename) {
   FILE *f = fopen(filename, "wb");
   if (!f) {
     printf("Failed fopen for save: %s\n", filename);
-    return;
+    return false;
   }
   uint32 hdr[2] = { RTL_SAV_MAGIC, RTL_SAV_VERSION };
-  fwrite(hdr, sizeof(hdr), 1, f);
+  bool header_ok = fwrite(hdr, sizeof(hdr), 1, f) == 1;
   RtlApuLock();
-  FileSli fs = { { &file_sli_func }, f, true, false };
-  snes_saveload(g_snes, &fs.base);
+  FileSli fs = { { &file_sli_func }, f, true, !header_ok };
+  if (header_ok)
+    snes_saveload(g_snes, &fs.base);
   /* v5: game-specific chunk (task-slot resume contexts etc.). Streamed
    * through the same FileSli so the format stays one linear blob. */
   if (g_rtl_game_info && g_rtl_game_info->state_save_extra)
     g_rtl_game_info->state_save_extra(&fs.base);
   RtlApuUnlock();
   if (fs.error) printf("Save write error: %s\n", filename);
-  fclose(f);
+  bool close_ok = fclose(f) == 0;
+  return !fs.error && close_ok;
 }
 
 bool RtlLoadSnapshot(const char *filename) {

--- a/runner/src/common_rtl.h
+++ b/runner/src/common_rtl.h
@@ -266,7 +266,7 @@ void RtlWriteSram();
 // (idempotent). Call before the launcher so its SAVES panel reflects the carried-
 // forward save; RtlReadSram also calls it on boot as a fallback.
 void RtlMigrateLegacySram(const char *legacy_title);
-void RtlSaveSnapshot(const char *filename);
+bool RtlSaveSnapshot(const char *filename);
 bool RtlLoadSnapshot(const char *filename);
 size_t RtlSaveSnapshotToMemory(void *data, size_t capacity);
 bool RtlLoadSnapshotFromMemory(const void *data, size_t size);

--- a/runner/src/cpu_state.h
+++ b/runner/src/cpu_state.h
@@ -620,6 +620,7 @@ RecompReturn interp_tier_dispatch_bank_miss(CpuState *cpu, uint32 addr_pc24,
  * host stack unwinds. */
 #define RECOMP_RETURN_LLE_UNWIND_BASE 0x40000000
 int interp_bridge_in_lle_scheduler(void);
+int interp_bridge_lle_master_deadline_reached(const CpuState *cpu);
 RecompReturn interp_bridge_lle_yield_unwind(CpuState *cpu, uint32 resume_pc24);
 uint32 interp_bridge_lle_resume_pc(void);
 void interp_bridge_set_lle_bounce_exclusions(const uint32 *targets,

--- a/runner/src/snes/interp_bridge.c
+++ b/runner/src/snes/interp_bridge.c
@@ -363,6 +363,12 @@ void interp_bridge_set_master_deadline(uint64_t master_clock) {
     s_lle_master_deadline = master_clock;
 }
 
+int interp_bridge_lle_master_deadline_reached(const CpuState *cpu) {
+    return cpu && s_lle_sched_depth > 0 && s_interp_bounce_owner_depth > 0 &&
+           s_lle_master_deadline != 0 &&
+           cpu->master_cycles >= s_lle_master_deadline;
+}
+
 RecompReturn interp_bridge_lle_yield_unwind(CpuState *cpu, uint32 resume_pc24) {
     (void)cpu;
     /* A JMP-reached primitive (task-die / scheduler-dispatch) arrives via a

--- a/runner/src/snes/interp_bridge.h
+++ b/runner/src/snes/interp_bridge.h
@@ -78,6 +78,12 @@ uint32_t interp_bridge_lle_resume_pc(void);
  * a productive CPU/MMIO loop from running across multiple vblanks atomically. */
 void interp_bridge_set_master_deadline(uint64_t master_clock);
 
+/* True only while a paired AOT bounce is executing inside an auto-quiescent
+ * scheduler whose current frame deadline has been reached. Long,
+ * architecturally interruptible instructions use this at their legal byte
+ * boundaries before unwinding to the owning interpreter. */
+int interp_bridge_lle_master_deadline_reached(const CpuState *cpu);
+
 /* Execute an architectural interrupt handler through its terminal RTI. The
  * caller has already materialized the hardware interrupt frame. */
 int interp_bridge_run_interrupt(CpuState *cpu, uint32_t entry_pc24);

--- a/tests/v2/test_codegen_per_op_smoke.py
+++ b/tests/v2/test_codegen_per_op_smoke.py
@@ -351,9 +351,26 @@ def test_return_short_emits_return_stmt():
 
 def test_blockmove_mvn_increments():
     op = BlockMove(direction='mvn', src_bank=0x7E, dst_bank=0x7F)
-    s = _joined(emit_op(op))
+    s = _joined(emit_op(op, source_pc24=0x808E7A))
     assert "cpu->X = (uint16)(cpu->X +1)" in s
     assert "cpu->Y = (uint16)(cpu->Y +1)" in s
+    assert "do {" in s
+    assert "while (cpu->A != 0xFFFF)" in s
+    assert "cpu->cycles += 7" in s
+    assert "cpu->master_cycles += 7 * (g_memsel ? 6 : 8)" in s
+    assert "interp_bridge_lle_master_deadline_reached(cpu)" in s
+    assert "interp_bridge_lle_yield_unwind(cpu, 0x808e7au)" in s
+    assert "cpu->X &= 0x00FFu" in s
+
+
+def test_blockmove_mvp_decrements_and_can_move_65536_bytes():
+    op = BlockMove(direction='mvp', src_bank=0x7F, dst_bank=0x7E)
+    s = _joined(emit_op(op, source_pc24=0x008000))
+    assert "cpu->X = (uint16)(cpu->X -1)" in s
+    assert "cpu->Y = (uint16)(cpu->Y -1)" in s
+    # A=$FFFF means 65,536 bytes, not zero bytes, so the first transfer must
+    # occur before the continuation test.
+    assert s.index("do {") < s.index("while (cpu->A != 0xFFFF)")
 
 
 def test_pea_pushes_immediate_onto_stack():

--- a/tests/v2/test_translation_units.py
+++ b/tests/v2/test_translation_units.py
@@ -60,11 +60,27 @@ def test_shard_embeds_only_referenced_variant_declarations():
     assert "bank_00_8000_M1X1(CpuState *cpu);" not in part1_preamble
 
 
-def test_small_bank_keeps_monolithic_filename_and_bytes():
+def test_small_bank_keeps_monolithic_filename_and_adds_call_declarations():
     parts = split_bank_translation_units(
         SOURCE, 0, SYMBOL_PCS, threshold_bytes=len(SOURCE) + 1,
         pc_span=0x800)
-    assert parts == {"bank00_v2.c": SOURCE}
+    assert set(parts) == {"bank00_v2.c"}
+    generated = parts["bank00_v2.c"]
+    body = generated.split(
+        "RecompReturn bank_00_8000_M1X1(CpuState *cpu) {", 1)[0]
+    assert "RecompReturn bank_00_8800_M1X1(CpuState *cpu);" in body
+
+
+def test_monolithic_bank_declares_cross_bank_dispatch_target():
+    source = SOURCE.replace(
+        "return bank_00_8800_M1X1(cpu);",
+        "return bank_82_80B4_M1X1(cpu);")
+    parts = split_bank_translation_units(
+        source, 0, SYMBOL_PCS, threshold_bytes=len(source) + 1,
+        pc_span=0x800)
+    body = parts["bank00_v2.c"].split(
+        "RecompReturn bank_00_8000_M1X1(CpuState *cpu) {", 1)[0]
+    assert "RecompReturn bank_82_80B4_M1X1(CpuState *cpu);" in body
 
 
 def test_writer_removes_stale_bank_shape():


### PR DESCRIPTION
## Summary
- make static MVN/MVP byte-accurate and interruptible at legal byte boundaries
- return snapshot write success to hosts
- declare all referenced exact variants in monolithic generated translation units

## Validation
- `python tests/v2/run_tests.py`: 353/353 passed
- DKC2: 12,000 frames, two attract cycles, death/restart manually passed
- SMW, ALttP, MMX, Super Metroid: regenerated with native Rust analyzer, built, 12,000-frame attract soak and manual gameplay passed