### PR TITLE
Fix APU audio loss across rapid transitions

### DIFF
--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -816,152 +816,24 @@ void rtl_accumulate_apu_catchup(void) {
 void RtlApuWrite(uint16 adr, uint8 val) {
   assert(adr >= APUI00 && adr <= APUI03);
 #ifdef SNES_COSIM
-  /* Shared APU clock (common_rtl.h): do NOT convert pending touch credit on a
-   * port WRITE — schedule the byte at the current produced clock and leave the
-   * credit for the next port READ. Rationale: the interp tier executes a guest
-   * word store to $2140/$2141 as two byte writes; converting credit between
-   * them runs the SPC ~73 cycles with the kick byte applied but the data byte
-   * not yet — the IPL latches stale data and the upload handshake wedges
-   * (measured: LLE-shared stuck at outPorts=AABB to frame 360+). On hardware
-   * the two bytes land ~2 SPC cycles apart — effectively atomic. Deferring
-   * write-side conversion makes byte pairs land at the SAME produced tick, in
-   * program order, for BOTH the interp (lo,hi) and compiled (hi,lo) models —
-   * which also makes word-write APU evolution identical across tiers. */
+  /* Apply the byte at the current shared APU clock. Guest execution advances
+   * the shared clock; injecting extra SPC cycles here could let a word store's
+   * trigger byte overtake its data byte in the IPL upload handshake. */
   if (cosim_apu_shared_clock()) {
     RtlApuLock();
     audio_trace_on_cpu_port_write((uint8_t)(adr & 0x3), val);
-    uint64_t produced_now, consumed_now;
-    audio_trace_sample_clocks(&produced_now, &consumed_now);
-    apu_schedulePortWrite(g_snes->apu, (uint8_t)(adr & 0x3), val, produced_now);
+    apu_writePortNow(g_snes->apu, (uint8_t)(adr & 0x3), val);
     RtlApuUnlock();
     return;
   }
 #endif
-  // Catch the APU up to the current cycle, then SCHEDULE the port write
-  // in APU-sample time rather than mutating inPorts at wall time.
-  //
-  // Rationale (SMW missed-SFX root cause): the audio thread advances
-  // the SPC in whole-callback bursts, so a wall-time port mutation gives
-  // the value a lifetime of however many samples happen to be produced
-  // before the next mutation — measured ~9 samples (vs the 64 an engine
-  // poll needs) whenever the 60.0988 Hz NMI beats across the 60.00 Hz
-  // callback phase. Anchoring each write one callback quantum past the
-  // CONSUMED clock keeps successive frame writes a full frame apart in
-  // the SPC's own execution time, so the engine always polls every
-  // value, exactly as on hardware. Steady-state added latency is ~zero:
-  // consumed + quantum ~= produced, i.e. the next burst applies it.
-  // Serialise with the audio thread via RtlApuLock -- it holds the same
-  // lock while cycling the APU in RtlRenderAudio.
+  /* Catch the APU up to the CPU's current guest cycle before exposing the
+   * write. RtlApuLock serializes this with callback-driven SPC execution. */
   RtlApuLock();
   rtl_accumulate_apu_catchup();
   snes_catchupApu(g_snes);
   audio_trace_on_cpu_port_write((uint8_t)(adr & 0x3), val);
-  {
-    /* Write clock: each target advances from the PREVIOUS write's target
-     * by the real wall-time gap between the two writes, converted to
-     * samples. This preserves hardware-faithful inter-write spacing in
-     * the SPC's execution timeline — frame-spaced NMI writes stay ~534
-     * samples apart, same-frame double writes keep their ms-scale gap —
-     * independent of where the audio thread's burst boundaries fall.
-     *
-     * (First attempt anchored targets at consumed+quantum; that fails
-     * because produced runs AHEAD of consumed by the output-ring fill,
-     * so every target was in the past and the floor collapsed
-     * consecutive writes onto the same sample — measured as +0-sample
-     * command lifetimes, i.e. the original race in a new costume.)
-     *
-     * Floor at produced: a target in the APU's past applies on the next
-     * executed sample. Ceiling at produced + 3 callback quanta bounds
-     * worst-case latency and sheds the slow forward drift from the
-     * NMI(60.0988 Hz)/callback(60.00 Hz) rate mismatch. Both caps scale
-     * with the observed burst granularity (audio_samples in config.ini
-     * is user-tunable): a ceiling smaller than the real burst would pin
-     * late-window writes to the same target and re-collapse spacing. */
-    static uint64_t s_port_clock;     /* previous write's target */
-    static uint64_t s_port_clock_ns;  /* wall_ns of previous write */
-    /* Per-port history for the minimum-dwell floor below. Statics, like
-     * s_port_clock: not reset across RtlReset/upload, which is benign —
-     * after a reset `produced` has advanced far past any stale target, so
-     * the floor (stale_target + dwell) is already in the past and never
-     * engages spuriously. */
-    static uint64_t s_port_last_target[4];
-    static uint8_t  s_port_last_val[4];
-    static uint8_t  s_port_last_valid[4];
-    /* Hardware visibility is the correctness default: a CPU port write lands
-     * at the APU's current execution point. Delaying it according to host wall
-     * time is not an LLE property and breaks real write -> echo -> poll
-     * protocols (MMX's runtime SPC upload used to spend >5 seconds in one
-     * faithfully recompiled polling loop). Keep the deferred scheduler below
-     * only as an explicit legacy/audio experiment selected with
-     * SNESRECOMP_APU_IMMEDIATE_PORTS=0; it must not be a per-game or per-region
-     * compile-time correctness hint. */
-    static int s_immediate = -1;
-    if (s_immediate < 0) {
-      const char *e = getenv("SNESRECOMP_APU_IMMEDIATE_PORTS");
-      s_immediate = (e && e[0]) ? (e[0] != '0') : 1;
-#ifdef SNES_COSIM
-      /* Shared APU clock implies immediate ports: the deferred scheduler
-       * anchors targets to the co-sim virtual wall clock, which derives from
-       * master_cycles — a per-execution-model clock that would re-skew the
-       * A/B pair this mode aligns. */
-      if (cosim_apu_shared_clock()) s_immediate = 1;
-#endif
-    }
-    if (s_immediate) {
-      uint64_t produced_now, consumed_now;
-      audio_trace_sample_clocks(&produced_now, &consumed_now);
-      apu_schedulePortWrite(g_snes->apu, (uint8_t)(adr & 0x3), val, produced_now);
-      RtlApuUnlock();
-      return;
-    }
-    uint64_t quantum = audio_trace_consume_quantum();
-    uint64_t now_ns = audio_trace_wall_ns();
-    uint64_t produced, consumed;
-    audio_trace_sample_clocks(&produced, &consumed);
-    uint64_t delta = 0;
-    if (s_port_clock_ns != 0)
-      delta = (now_ns - s_port_clock_ns) * 32040u / 1000000000u;
-    if (delta > 4u * quantum) delta = 4u * quantum;
-    uint64_t target = s_port_clock + delta;
-    if (target < produced) target = produced;
-    if (target > produced + 3u * quantum) target = produced + 3u * quantum;
-
-    /* Minimum per-port dwell — the turbo audio-dropout fix. A level
-     * transition fires several DISTINCT values at the same APU port
-     * (fade, silence, the new song; or a one-shot command then the NMI's
-     * next-frame 0-clear) within a few frames. The wall-clock spacing
-     * computed above reproduces hardware timing faithfully at 1x, but
-     * turbo runs the game thread uncapped while the SPC still advances at
-     * 1x, compressing that spacing below the engine's ~64-sample poll
-     * period — so an earlier value is overwritten in inPorts before the
-     * engine ever reads it and the command is silently lost (music/SFX
-     * drop out; because a surviving fade can zero global output, they do
-     * not come back until the next track change, i.e. never within a
-     * level). Floor a DISTINCT value's target so the previous distinct
-     * value on that port holds the bus for at least APU_PORT_MIN_DWELL
-     * produced-samples — one guaranteed engine poll. The drain runs once
-     * per produced sample (apu_cycle), so this target spacing becomes
-     * apply spacing directly. Bounded by produced + 8*quantum so a
-     * pathological sustained burst degrades to today's bounded latency
-     * rather than unbounding it. Identical repeats (e.g. repeated
-     * 0-clears) need no spacing. No effect at 1x: frame-spaced writes are
-     * already ~534 samples apart, far above the floor. */
-    {
-      int p = (int)(adr & 0x3);
-      if (s_port_last_valid[p] && val != s_port_last_val[p]) {
-        uint64_t floor = s_port_last_target[p] + APU_PORT_MIN_DWELL;
-        uint64_t ceil  = produced + 8u * quantum;
-        if (target < floor) target = floor < ceil ? floor : ceil;
-      }
-      s_port_last_target[p] = target;
-      s_port_last_val[p]    = val;
-      s_port_last_valid[p]  = 1;
-    }
-
-    s_port_clock = target;
-    s_port_clock_ns = now_ns;
-    apu_schedulePortWrite(g_snes->apu, (uint8_t)(adr & 0x3), val, target);
-  }
+  apu_writePortNow(g_snes->apu, (uint8_t)(adr & 0x3), val);
   RtlApuUnlock();
 }
 
@@ -975,6 +847,21 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
   int block_count = 0;
 
   RtlApuLock();
+  bool ipl_phase = g_snes->apu->romReadable;
+  uint8_t transfer_request = g_snes->apu->inPorts[1];
+  if (!ipl_phase &&
+      !apu_waitForTransferReady(g_snes->apu, 1, transfer_request, 1u << 20)) {
+    fprintf(stderr,
+            "[apu] SPC transfer-ready timeout pc=%04x stopped=%d "
+            "in=%02x%02x out=%02x%02x edge=%02x%02x buf=%02x%02x\n",
+            g_snes->apu->spc->pc, g_snes->apu->spc->stopped,
+            g_snes->apu->inPorts[0], g_snes->apu->inPorts[1],
+            g_snes->apu->outPorts[0], g_snes->apu->outPorts[1],
+            g_snes->apu->ram[0], g_snes->apu->ram[1],
+            g_snes->apu->ram[4], g_snes->apu->ram[5]);
+    RtlApuUnlock();
+    return false;
+  }
   for (;;) {
     uint16_t n = (uint16_t)p[0] | ((uint16_t)p[1] << 8);
     uint16_t target = (uint16_t)p[2] | ((uint16_t)p[3] << 8);
@@ -1011,18 +898,11 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
    * just-uploaded music data would never start playing. SFX would
    * still work since they're triggered by inPort writes processed
    * after the restart's re-init, but song state would never persist.
-   *
-   * Detect "first upload" via apu->romReadable: it's reset to true by
-   * apu_reset() and only flipped false here, so on the IPL-phase
-   * upload it's still true. */
-  bool ipl_phase = g_snes->apu->romReadable;
-  /* The upload supersedes any not-yet-applied scheduled port writes;
-   * a stale pre-upload command landing on the freshly cleared ports
-   * would replay into the re-initialised engine. */
-  apu_clearPortQueue(g_snes->apu);
-  memset(g_snes->apu->inPorts, 0, sizeof(g_snes->apu->inPorts));
-  memset(g_snes->apu->outPorts, 0, sizeof(g_snes->apu->outPorts));
+   * Complete subsequent transfers through the driver's terminator handshake
+   * so its post-transfer mute, port, and music-state cleanup runs naturally. */
   if (ipl_phase) {
+    memset(g_snes->apu->inPorts, 0, 4);
+    memset(g_snes->apu->outPorts, 0, sizeof(g_snes->apu->outPorts));
     g_snes->apu->romReadable = false;
     g_snes->apuCatchupCycles = 0;
     g_snes->apu->cpuCyclesLeft = 0;
@@ -1034,6 +914,10 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
         g_snes->apu->spc->sp = 0xef;
       g_snes->apu->spc->pc = final_pc;
     }
+  } else if (!apu_finishHleTransfer(g_snes->apu, final_pc, 1u << 20)) {
+    RtlApuUnlock();
+    fprintf(stderr, "[apu] SPC transfer terminator timed out\n");
+    return false;
   }
   g_apu_last_sync_cycles = g_apu_pace_cycles_estimate;
   // Resync the master pointer too: an IPL-phase upload zeroes apuCatchupCycles,

--- a/runner/src/snes/apu.c
+++ b/runner/src/snes/apu.c
@@ -75,6 +75,8 @@ static void apu_applyPortWrite(Apu* apu, const ApuPortWrite *w) {
 void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
                            uint64_t target_sample) {
   port &= 3;
+  if (apu->portQueued[port] && target_sample < apu->portLastTarget[port])
+    target_sample = apu->portLastTarget[port];
   if (apu->portLastValid[port] && val != apu->portLastValue[port] &&
       (apu->portAwaitingRead[port] || apu->portQueued[port])) {
     uint64_t floor = apu->portLastTarget[port] + APU_PORT_MIN_DWELL;

--- a/runner/src/snes/apu.c
+++ b/runner/src/snes/apu.c
@@ -24,7 +24,6 @@ Apu* apu_init(void) {
   Apu* apu = calloc(1, sizeof(Apu));  /* zero padding: saveload/co-sim hash determinism */
   apu->spc = spc_init(apu);
   apu->dsp = dsp_init(apu->ram);
-  apu_clearPortQueue(apu);
   return apu;
 }
 
@@ -51,75 +50,42 @@ void apu_reset(Apu* apu) {
     apu->timer[i].enabled = false;
   }
   apu->cpuCyclesLeft = 7;
-  apu_clearPortQueue(apu);
 }
 
-void apu_clearPortQueue(Apu* apu) {
-  apu->portQHead = apu->portQTail = 0;
-  memset(apu->portLastTarget, 0, sizeof(apu->portLastTarget));
-  memset(apu->portQueued, 0, sizeof(apu->portQueued));
-  memset(apu->portLastValue, 0, sizeof(apu->portLastValue));
-  memset(apu->portLastValid, 0, sizeof(apu->portLastValid));
-  memset(apu->portAwaitingRead, 0, sizeof(apu->portAwaitingRead));
-}
-
-static void apu_applyPortWrite(Apu* apu, const ApuPortWrite *w) {
-  uint8_t port = w->port & 3;
-  if (apu->portQueued[port])
-    apu->portQueued[port]--;
-  apu->inPorts[port] = w->val;
-  apu->portAwaitingRead[port] = w->val != 0;
-  audio_trace_on_cpu_port_apply(port, w->val);
-}
-
-void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
-                           uint64_t target_sample) {
+void apu_writePortNow(Apu* apu, uint8_t port, uint8_t val) {
   port &= 3;
-  if (apu->portQueued[port] && target_sample < apu->portLastTarget[port])
-    target_sample = apu->portLastTarget[port];
-  if (apu->portLastValid[port] && val != apu->portLastValue[port] &&
-      (apu->portAwaitingRead[port] || apu->portQueued[port])) {
-    uint64_t floor = apu->portLastTarget[port] + APU_PORT_MIN_DWELL;
-    if (target_sample < floor)
-      target_sample = floor;
-  }
-  if (apu->portQTail - apu->portQHead >= APU_PORT_QUEUE_LEN) {
-    ApuPortWrite *oldest = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
-    /* Preserve the unread command; a new write cannot bypass its read gate. */
-    if (apu->portAwaitingRead[oldest->port & 3])
-      return;
-    apu_applyPortWrite(apu, oldest);
-    apu->portQHead++;
-  }
-  ApuPortWrite *w = &apu->portQueue[apu->portQTail & (APU_PORT_QUEUE_LEN - 1)];
-  w->target_sample = target_sample;
-  w->port = port;
-  w->val = val;
-  apu->portQTail++;
-  apu->portQueued[port]++;
-  apu->portLastTarget[port] = target_sample;
-  apu->portLastValue[port] = val;
-  apu->portLastValid[port] = 1;
+  apu->inPorts[port] = val;
+  audio_trace_on_cpu_port_apply(port, val);
 }
 
-void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample) {
-  while (apu->portQHead != apu->portQTail) {
-    ApuPortWrite *w = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
-    if (w->target_sample > produced_sample)
-      break;
-    /* Catch-up can pass several timestamps in one sample. Do not overwrite a
-     * command until the SPC has had a chance to observe it. */
-    if (apu->portAwaitingRead[w->port & 3])
-      break;
-    apu_applyPortWrite(apu, w);
-    apu->portQHead++;
+bool apu_waitForTransferReady(Apu* apu, uint8_t request_port,
+                              uint8_t request_value, uint32_t max_cycles) {
+  for (;;) {
+    if (apu->outPorts[0] == 0xaa && apu->outPorts[1] == 0xbb)
+      return true;
+    if (apu->inPorts[request_port & 3] != request_value)
+      apu_writePortNow(apu, request_port, request_value);
+    if (max_cycles-- == 0)
+      return false;
+    apu_cycle(apu);
   }
 }
 
-void apu_noteSpcPortRead(Apu *apu, uint8_t port, uint8_t val) {
-  port &= 3;
-  if (apu->portAwaitingRead[port] && apu->inPorts[port] == val)
-    apu->portAwaitingRead[port] = 0;
+bool apu_finishHleTransfer(Apu* apu, uint16_t final_pc,
+                           uint32_t max_cycles) {
+  apu_writePortNow(apu, 2, (uint8_t)final_pc);
+  apu_writePortNow(apu, 3, (uint8_t)(final_pc >> 8));
+  apu_writePortNow(apu, 1, 0);
+  apu_writePortNow(apu, 0, 0xcc);
+  for (;;) {
+    if (apu->outPorts[0] == 0xcc) {
+      memset(apu->inPorts, 0, 4);
+      return true;
+    }
+    if (max_cycles-- == 0)
+      return false;
+    apu_cycle(apu);
+  }
 }
 
 void apu_saveload(Apu *apu, SaveLoadInfo *sli) {
@@ -142,10 +108,7 @@ void apu_cycle(Apu* apu) {
   apu->cpuCyclesLeft--;
 
   if((apu->cycles & 0x1f) == 0) {
-    uint64_t produced;
     // every 32 cycles
-    audio_trace_sample_clocks(&produced, NULL);
-    apu_applyDuePortWrites(apu, produced);
     dsp_cycle(apu->dsp);
   }
 
@@ -190,7 +153,6 @@ uint8_t apu_cpuRead(Apu* apu, uint16_t adr) {
     case 0xf6:
     case 0xf7: {
       uint8_t v = apu->inPorts[adr - 0xf4];
-      apu_noteSpcPortRead(apu, (uint8_t)(adr - 0xf4), v);
       audio_trace_on_spc_port_read((uint8_t)(adr - 0xf4), v);
       return v;
     }

--- a/runner/src/snes/apu.c
+++ b/runner/src/snes/apu.c
@@ -84,8 +84,11 @@ void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
       target_sample = floor;
   }
   if (apu->portQTail - apu->portQHead >= APU_PORT_QUEUE_LEN) {
-    /* Full — apply the oldest immediately so ordering survives. */
-    apu_applyPortWrite(apu, &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)]);
+    ApuPortWrite *oldest = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
+    /* Preserve the unread command; a new write cannot bypass its read gate. */
+    if (apu->portAwaitingRead[oldest->port & 3])
+      return;
+    apu_applyPortWrite(apu, oldest);
     apu->portQHead++;
   }
   ApuPortWrite *w = &apu->portQueue[apu->portQTail & (APU_PORT_QUEUE_LEN - 1)];
@@ -103,6 +106,10 @@ void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample) {
   while (apu->portQHead != apu->portQTail) {
     ApuPortWrite *w = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
     if (w->target_sample > produced_sample)
+      break;
+    /* Catch-up can pass several timestamps in one sample. Do not overwrite a
+     * command until the SPC has had a chance to observe it. */
+    if (apu->portAwaitingRead[w->port & 3])
       break;
     apu_applyPortWrite(apu, w);
     apu->portQHead++;

--- a/runner/src/snes/apu.c
+++ b/runner/src/snes/apu.c
@@ -56,15 +56,31 @@ void apu_reset(Apu* apu) {
 
 void apu_clearPortQueue(Apu* apu) {
   apu->portQHead = apu->portQTail = 0;
+  memset(apu->portLastTarget, 0, sizeof(apu->portLastTarget));
+  memset(apu->portQueued, 0, sizeof(apu->portQueued));
+  memset(apu->portLastValue, 0, sizeof(apu->portLastValue));
+  memset(apu->portLastValid, 0, sizeof(apu->portLastValid));
+  memset(apu->portAwaitingRead, 0, sizeof(apu->portAwaitingRead));
 }
 
 static void apu_applyPortWrite(Apu* apu, const ApuPortWrite *w) {
-  apu->inPorts[w->port & 3] = w->val;
-  audio_trace_on_cpu_port_apply(w->port, w->val);
+  uint8_t port = w->port & 3;
+  if (apu->portQueued[port])
+    apu->portQueued[port]--;
+  apu->inPorts[port] = w->val;
+  apu->portAwaitingRead[port] = w->val != 0;
+  audio_trace_on_cpu_port_apply(port, w->val);
 }
 
 void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
                            uint64_t target_sample) {
+  port &= 3;
+  if (apu->portLastValid[port] && val != apu->portLastValue[port] &&
+      (apu->portAwaitingRead[port] || apu->portQueued[port])) {
+    uint64_t floor = apu->portLastTarget[port] + APU_PORT_MIN_DWELL;
+    if (target_sample < floor)
+      target_sample = floor;
+  }
   if (apu->portQTail - apu->portQHead >= APU_PORT_QUEUE_LEN) {
     /* Full — apply the oldest immediately so ordering survives. */
     apu_applyPortWrite(apu, &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)]);
@@ -72,23 +88,29 @@ void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
   }
   ApuPortWrite *w = &apu->portQueue[apu->portQTail & (APU_PORT_QUEUE_LEN - 1)];
   w->target_sample = target_sample;
-  w->port = (uint8_t)(port & 3);
+  w->port = port;
   w->val = val;
   apu->portQTail++;
+  apu->portQueued[port]++;
+  apu->portLastTarget[port] = target_sample;
+  apu->portLastValue[port] = val;
+  apu->portLastValid[port] = 1;
 }
 
-/* Apply every queued write whose target the produced-sample clock has
- * reached. Called at each DSP sample boundary inside apu_cycle. */
-static void apu_drainPortQueue(Apu* apu) {
-  uint64_t produced;
-  audio_trace_sample_clocks(&produced, NULL);
+void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample) {
   while (apu->portQHead != apu->portQTail) {
     ApuPortWrite *w = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
-    if (w->target_sample > produced)
+    if (w->target_sample > produced_sample)
       break;
     apu_applyPortWrite(apu, w);
     apu->portQHead++;
   }
+}
+
+void apu_noteSpcPortRead(Apu *apu, uint8_t port, uint8_t val) {
+  port &= 3;
+  if (apu->portAwaitingRead[port] && apu->inPorts[port] == val)
+    apu->portAwaitingRead[port] = 0;
 }
 
 void apu_saveload(Apu *apu, SaveLoadInfo *sli) {
@@ -111,8 +133,10 @@ void apu_cycle(Apu* apu) {
   apu->cpuCyclesLeft--;
 
   if((apu->cycles & 0x1f) == 0) {
+    uint64_t produced;
     // every 32 cycles
-    apu_drainPortQueue(apu);
+    audio_trace_sample_clocks(&produced, NULL);
+    apu_applyDuePortWrites(apu, produced);
     dsp_cycle(apu->dsp);
   }
 
@@ -157,6 +181,7 @@ uint8_t apu_cpuRead(Apu* apu, uint16_t adr) {
     case 0xf6:
     case 0xf7: {
       uint8_t v = apu->inPorts[adr - 0xf4];
+      apu_noteSpcPortRead(apu, (uint8_t)(adr - 0xf4), v);
       audio_trace_on_spc_port_read((uint8_t)(adr - 0xf4), v);
       return v;
     }

--- a/runner/src/snes/apu.h
+++ b/runner/src/snes/apu.h
@@ -77,8 +77,13 @@ struct Apu {
    * and on the HLE SPC-image upload; deliberately not serialized (any
    * still-pending write applies on the first cycles after load). */
   ApuPortWrite portQueue[APU_PORT_QUEUE_LEN];
+  uint64_t portLastTarget[4];
   uint32_t portQHead;     /* next slot to apply  */
   uint32_t portQTail;     /* next slot to fill   */
+  uint16_t portQueued[4]; /* queued writes by port */
+  uint8_t portLastValue[4];
+  uint8_t portLastValid[4];
+  uint8_t portAwaitingRead[4];
 };
 
 Apu* apu_init();
@@ -89,11 +94,14 @@ uint8_t apu_cpuRead(Apu* apu, uint16_t adr);
 void apu_cpuWrite(Apu* apu, uint16_t adr, uint8_t val);
 void apu_saveload(Apu *apu, SaveLoadInfo *sli);
 /* Schedule a CPU-side port write ($2140+port) to land in inPorts when
- * the produced-sample clock reaches target_sample. Caller must hold
- * RtlApuLock. Queue overflow applies the oldest entry immediately
- * (order is always preserved). */
+ * the produced-sample clock reaches target_sample. A distinct value waits
+ * for an outstanding command on the same port to be observed by the SPC. */
 void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
                            uint64_t target_sample);
+/* Apply queued writes due at produced_sample. Caller is the DSP sample tick. */
+void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample);
+/* Record an SPC read so the next CPU command can use immediate visibility. */
+void apu_noteSpcPortRead(Apu *apu, uint8_t port, uint8_t val);
 /* Drop all pending scheduled port writes (reset / HLE image upload). */
 void apu_clearPortQueue(Apu* apu);
 #endif

--- a/runner/src/snes/apu.h
+++ b/runner/src/snes/apu.h
@@ -22,43 +22,6 @@ typedef struct Timer {
   bool enabled;
 } Timer;
 
-/* CPU->APU port write, ordered in APU-sample time.
- *
- * The queue serializes CPU writes with the audio thread, which advances the
- * SPC in callback-sized bursts. The correctness path targets the current
- * produced-sample clock, making writes visible at the APU's present execution
- * point just as the hardware bus does. A legacy diagnostic path may assign
- * later targets to study host/audio pacing, but delayed wall-time scheduling
- * is not part of the guest machine model. */
-/* Power of 2. SMW peaks at ~4 writes/frame at 1x, but under turbo the
- * uncapped game thread schedules many frames of writes into the bounded
- * latency window faster than the 1x SPC drains them, and the per-port
- * minimum-dwell floor (see APU_PORT_MIN_DWELL) pushes distinct values
- * later still. 128 keeps the in-flight set inside the queue so the
- * overflow force-apply path (which bypasses a write's target) stays a
- * rare backstop rather than the common case under sustained turbo. */
-#define APU_PORT_QUEUE_LEN 128u
-
-/* Minimum produced-sample spacing the scheduler enforces between two
- * DISTINCT values written to the SAME APU port. The SPC sound engine
- * polls its command ports about every ~64 samples of its own time; if
- * two distinct values to one port land closer than that, the engine
- * never observes the first (it is overwritten in inPorts before any
- * read) and that command is silently lost. At 1x the game spaces its
- * per-frame writes ~534 samples apart so this floor never engages, but
- * turbo runs the game thread uncapped while the SPC still advances at
- * 1x, compressing successive same-port writes below the poll period --
- * the audio-dropout-at-level-transition bug. Flooring distinct same-port
- * writes two poll periods apart guarantees the engine polls every value.
- * Expressed in native DSP samples (32040 Hz), so host resample rate is
- * irrelevant. */
-#define APU_PORT_MIN_DWELL 128u
-
-typedef struct ApuPortWrite {
-  uint64_t target_sample; /* apply when the produced-sample clock reaches this */
-  uint8_t port;           /* 0-3 */
-  uint8_t val;
-} ApuPortWrite;
 
 struct Apu {
   Spc* spc;
@@ -72,18 +35,6 @@ struct Apu {
   Timer timer[3];
   uint8_t cpuCyclesLeft;
   uint8_t pad[6];
-  /* Port-write scheduler — MUST stay after `pad`: apu_saveload snapshots
-   * [ram, pad+6) and the savestate layout is frozen. Cleared on reset
-   * and on the HLE SPC-image upload; deliberately not serialized (any
-   * still-pending write applies on the first cycles after load). */
-  ApuPortWrite portQueue[APU_PORT_QUEUE_LEN];
-  uint64_t portLastTarget[4];
-  uint32_t portQHead;     /* next slot to apply  */
-  uint32_t portQTail;     /* next slot to fill   */
-  uint16_t portQueued[4]; /* queued writes by port */
-  uint8_t portLastValue[4];
-  uint8_t portLastValid[4];
-  uint8_t portAwaitingRead[4];
 };
 
 Apu* apu_init();
@@ -93,15 +44,11 @@ void apu_cycle(Apu* apu);
 uint8_t apu_cpuRead(Apu* apu, uint16_t adr);
 void apu_cpuWrite(Apu* apu, uint16_t adr, uint8_t val);
 void apu_saveload(Apu *apu, SaveLoadInfo *sli);
-/* Schedule a CPU-side port write ($2140+port) to land in inPorts when
- * the produced-sample clock reaches target_sample. A distinct value waits
- * for an outstanding command on the same port to be observed by the SPC. */
-void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
-                           uint64_t target_sample);
-/* Apply queued writes due at produced_sample. Caller is the DSP sample tick. */
-void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample);
-/* Record an SPC read so the next CPU command can use immediate visibility. */
-void apu_noteSpcPortRead(Apu *apu, uint8_t port, uint8_t val);
-/* Drop all pending scheduled port writes (reset / HLE image upload). */
-void apu_clearPortQueue(Apu* apu);
+/* Apply a hardware-visible CPU port write at the current SPC cycle. */
+void apu_writePortNow(Apu* apu, uint8_t port, uint8_t val);
+/* Advance until the SPC acknowledges the standard upload protocol. */
+bool apu_waitForTransferReady(Apu* apu, uint8_t request_port,
+                              uint8_t request_value, uint32_t max_cycles);
+bool apu_finishHleTransfer(Apu* apu, uint16_t final_pc,
+                           uint32_t max_cycles);
 #endif

--- a/tests/runtime_dispatch/apu_port_transition_test.c
+++ b/tests/runtime_dispatch/apu_port_transition_test.c
@@ -3,9 +3,16 @@
 
 #include "apu.h"
 
+static int applied_count;
+static uint8_t applied_port;
+static uint8_t applied_value;
+uint64_t g_apu_timer0_total_ticks;
+int snes_frame_counter;
+
 void audio_trace_on_cpu_port_apply(uint8_t port, uint8_t value) {
-  (void)port;
-  (void)value;
+  applied_count++;
+  applied_port = port;
+  applied_value = value;
 }
 
 static int check(int condition, const char *message) {
@@ -19,64 +26,41 @@ int main(void) {
   int failures = 0;
 
   memset(&apu, 0, sizeof(apu));
-  apu_clearPortQueue(&apu);
 
-  /* A transition can queue a fade, music command, and NMI clear before the
-   * audio thread advances another sample. Every distinct command must remain
-   * visible for at least one SPC poll. */
-  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
-  apu_schedulePortWrite(&apu, 2, 0x23, 1000);
-  apu_schedulePortWrite(&apu, 2, 0x00, 1000);
-
-  apu_applyDuePortWrites(&apu, 1000);
-  failures += check(apu.inPorts[2] == 0x80, "fade visible before music");
-  apu_noteSpcPortRead(&apu, 2, 0x80);
-
-  apu_applyDuePortWrites(&apu, 1000 + APU_PORT_MIN_DWELL);
-  failures += check(apu.inPorts[2] == 0x23, "music visible before clear");
-  apu_noteSpcPortRead(&apu, 2, 0x23);
-
-  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
-  failures += check(apu.inPorts[2] == 0x00, "clear follows music observation");
-
-  /* The mixer can catch up past every queued timestamp in one callback.
-   * Timestamps alone must not collapse the transition into its final clear. */
-  memset(&apu, 0, sizeof(apu));
-  apu_clearPortQueue(&apu);
-  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
-  apu_schedulePortWrite(&apu, 2, 0x23, 1000);
-  apu_schedulePortWrite(&apu, 2, 0x00, 1000);
-  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
+  apu_writePortNow(&apu, 2, 0x80);
   failures += check(apu.inPorts[2] == 0x80,
-                    "burst catch-up preserves fade until SPC observes it");
-  apu_noteSpcPortRead(&apu, 2, 0x80);
-  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
+                    "CPU port write is visible in the current APU cycle");
+  failures += check(applied_count == 1 && applied_port == 2 &&
+                    applied_value == 0x80,
+                    "CPU port write is traced when it becomes visible");
+
+  apu_writePortNow(&apu, 2, 0x23);
   failures += check(apu.inPorts[2] == 0x23,
-                    "burst catch-up preserves music until SPC observes it");
-  apu_noteSpcPortRead(&apu, 2, 0x23);
-  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
-  failures += check(apu.inPorts[2] == 0x00,
-                    "burst catch-up applies clear after music observation");
+                    "a later command replaces the port immediately");
 
-  /* Overflow must not force-apply over a command the SPC has not read. */
-  memset(&apu, 0, sizeof(apu));
-  apu_clearPortQueue(&apu);
-  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
-  apu_applyDuePortWrites(&apu, 1000);
-  for (uint32_t i = 0; i < APU_PORT_QUEUE_LEN; i++)
-    apu_schedulePortWrite(&apu, 2, 0x23, 1000);
-  apu_schedulePortWrite(&apu, 2, 0x00, 1000);
-  failures += check(apu.inPorts[2] == 0x80,
-                    "queue overflow cannot overwrite unread command");
+  apu_writePortNow(&apu, 6, 0x00);
+  failures += check(apu.inPorts[2] == 0x00 && applied_port == 2 &&
+                    applied_value == 0x00,
+                    "port index is masked and clear is immediately visible");
 
   memset(&apu, 0, sizeof(apu));
-  apu_clearPortQueue(&apu);
-  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
-  apu_schedulePortWrite(&apu, 2, 0x80, 0);
-  apu_schedulePortWrite(&apu, 2, 0x23, 0);
-  apu_applyDuePortWrites(&apu, 1000);
-  failures += check(apu.inPorts[2] == 0x80,
-                    "duplicate command cannot pull a later value forward");
+  apu.outPorts[0] = 0xaa;
+  apu.outPorts[1] = 0xbb;
+  failures += check(apu_waitForTransferReady(&apu, 1, 0xff, 0),
+                    "HLE upload waits for the SPC transfer-ready handshake");
+
+  apu.outPorts[0] = 0;
+  failures += check(!apu_waitForTransferReady(&apu, 1, 0xff, 0),
+                    "HLE upload rejects a missing transfer-ready handshake");
+  failures += check(apu.inPorts[1] == 0xff,
+                    "HLE upload reasserts a transfer request cleared during startup");
+
+  apu.outPorts[0] = 0xcc;
+  failures += check(apu_finishHleTransfer(&apu, 0x1234, 0),
+                    "HLE upload waits for the SPC terminator acknowledgement");
+  failures += check(apu.inPorts[0] == 0 && apu.inPorts[1] == 0 &&
+                    apu.inPorts[2] == 0 && apu.inPorts[3] == 0,
+                    "HLE upload clears CPU ports after acknowledgement");
 
   if (failures)
     return 1;

--- a/tests/runtime_dispatch/apu_port_transition_test.c
+++ b/tests/runtime_dispatch/apu_port_transition_test.c
@@ -39,6 +39,36 @@ int main(void) {
   apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
   failures += check(apu.inPorts[2] == 0x00, "clear follows music observation");
 
+  /* The mixer can catch up past every queued timestamp in one callback.
+   * Timestamps alone must not collapse the transition into its final clear. */
+  memset(&apu, 0, sizeof(apu));
+  apu_clearPortQueue(&apu);
+  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
+  apu_schedulePortWrite(&apu, 2, 0x23, 1000);
+  apu_schedulePortWrite(&apu, 2, 0x00, 1000);
+  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
+  failures += check(apu.inPorts[2] == 0x80,
+                    "burst catch-up preserves fade until SPC observes it");
+  apu_noteSpcPortRead(&apu, 2, 0x80);
+  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
+  failures += check(apu.inPorts[2] == 0x23,
+                    "burst catch-up preserves music until SPC observes it");
+  apu_noteSpcPortRead(&apu, 2, 0x23);
+  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
+  failures += check(apu.inPorts[2] == 0x00,
+                    "burst catch-up applies clear after music observation");
+
+  /* Overflow must not force-apply over a command the SPC has not read. */
+  memset(&apu, 0, sizeof(apu));
+  apu_clearPortQueue(&apu);
+  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
+  apu_applyDuePortWrites(&apu, 1000);
+  for (uint32_t i = 0; i < APU_PORT_QUEUE_LEN; i++)
+    apu_schedulePortWrite(&apu, 2, 0x23, 1000);
+  apu_schedulePortWrite(&apu, 2, 0x00, 1000);
+  failures += check(apu.inPorts[2] == 0x80,
+                    "queue overflow cannot overwrite unread command");
+
   memset(&apu, 0, sizeof(apu));
   apu_clearPortQueue(&apu);
   apu_schedulePortWrite(&apu, 2, 0x80, 1000);

--- a/tests/runtime_dispatch/apu_port_transition_test.c
+++ b/tests/runtime_dispatch/apu_port_transition_test.c
@@ -39,6 +39,15 @@ int main(void) {
   apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
   failures += check(apu.inPorts[2] == 0x00, "clear follows music observation");
 
+  memset(&apu, 0, sizeof(apu));
+  apu_clearPortQueue(&apu);
+  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
+  apu_schedulePortWrite(&apu, 2, 0x80, 0);
+  apu_schedulePortWrite(&apu, 2, 0x23, 0);
+  apu_applyDuePortWrites(&apu, 1000);
+  failures += check(apu.inPorts[2] == 0x80,
+                    "duplicate command cannot pull a later value forward");
+
   if (failures)
     return 1;
   puts("apu_port_transition_test: PASS");

--- a/tests/runtime_dispatch/apu_port_transition_test.c
+++ b/tests/runtime_dispatch/apu_port_transition_test.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "apu.h"
+
+void audio_trace_on_cpu_port_apply(uint8_t port, uint8_t value) {
+  (void)port;
+  (void)value;
+}
+
+static int check(int condition, const char *message) {
+  if (!condition)
+    fprintf(stderr, "FAIL: %s\n", message);
+  return condition ? 0 : 1;
+}
+
+int main(void) {
+  Apu apu;
+  int failures = 0;
+
+  memset(&apu, 0, sizeof(apu));
+  apu_clearPortQueue(&apu);
+
+  /* A transition can queue a fade, music command, and NMI clear before the
+   * audio thread advances another sample. Every distinct command must remain
+   * visible for at least one SPC poll. */
+  apu_schedulePortWrite(&apu, 2, 0x80, 1000);
+  apu_schedulePortWrite(&apu, 2, 0x23, 1000);
+  apu_schedulePortWrite(&apu, 2, 0x00, 1000);
+
+  apu_applyDuePortWrites(&apu, 1000);
+  failures += check(apu.inPorts[2] == 0x80, "fade visible before music");
+  apu_noteSpcPortRead(&apu, 2, 0x80);
+
+  apu_applyDuePortWrites(&apu, 1000 + APU_PORT_MIN_DWELL);
+  failures += check(apu.inPorts[2] == 0x23, "music visible before clear");
+  apu_noteSpcPortRead(&apu, 2, 0x23);
+
+  apu_applyDuePortWrites(&apu, 1000 + 2 * APU_PORT_MIN_DWELL);
+  failures += check(apu.inPorts[2] == 0x00, "clear follows music observation");
+
+  if (failures)
+    return 1;
+  puts("apu_port_transition_test: PASS");
+  return 0;
+}

--- a/tests/test_sync_funcs_h.py
+++ b/tests/test_sync_funcs_h.py
@@ -26,7 +26,11 @@ def _load_sync_funcs_h():
     framework_root = pathlib.Path(__file__).resolve().parent.parent
     game_root = framework_root.parent
     script = game_root / 'tools' / 'sync_funcs_h.py'
-    if not script.exists():
+    if (not script.exists()
+            or not (framework_root / 'recompiler' / 'recomp.py').is_file()):
+        # sync_funcs_h is a legacy v1-recompiler tool. The v2 framework does
+        # not provide its dependency, so this cross-repository contract is
+        # inapplicable.
         return None
     # Inject game's snesrecomp/recompiler so sync_funcs_h's own imports work.
     sys.path.insert(0, str(framework_root / 'recompiler'))


### PR DESCRIPTION
## Problem
Rapid level/death transitions can permanently mute SPC audio. The recompiled CPU can outrun the callback-driven SPC, causing APUIO command writes and HLE music uploads to cross the wrong execution boundary. In the failing trace, the SPC entered its transfer routine, the HLE path replaced its PC/state, and later startup cleared the CPU's transfer request before the SPC acknowledged it.

## Fix
- Apply CPU APUIO writes at the current SPC cycle while holding the shared APU lock; preserve high-byte-before-trigger ordering for word writes.
- Synchronize subsequent HLE uploads with the live driver's `$AA/$BB` ready acknowledgment.
- Reassert a transfer request if driver startup clears it before acknowledgment.
- Complete the live driver's `$CC` terminator acknowledgment instead of re-jumping the SPC to its reset entry.
- Remove the deferred port queue and its reset/savestate state.
- Add a focused port/transfer regression test.

## Verification
- `apu_port_transition_test: PASS`
- CMake runtime build succeeds.
- Framework suite: 73 passed, 0 failed.
- Manual SMW 2-1 death/re-entry loop: audio stayed audible for 10 consecutive transitions after reproducing persistent mute before the fix.
- Independent review: no findings (0.93 confidence).