### PR TITLE
audio: couple APU events to guest frame time

### DIFF
--- a/recompiler-rs/src/cfg.rs
+++ b/recompiler-rs/src/cfg.rs
@@ -214,11 +214,19 @@ pub fn parse_bank_cfg(text: &str, path: &str) -> Result<BankCfg, String> {
             end_at.insert(pc16, end);
             continue;
         }
-        // hle_spc_upload <hex_pc>
+        // hle_spc_upload <hex_pc> [legacy|live]
+        // The Rust analyzer only needs the entry address; the Python emitter
+        // retains the optional protocol mode when selecting the runtime helper.
         if head == "hle_spc_upload" {
-            if tokens.len() != 2 {
+            if tokens.len() < 2 || tokens.len() > 3 {
                 return Err(format!(
-                    "{path}: hle_spc_upload needs exactly one <pc> argument, got: {stripped:?}"
+                    "{path}: hle_spc_upload needs <pc> and optional [legacy|live], got: {stripped:?}"
+                ));
+            }
+            if tokens.len() == 3 && tokens[2] != "legacy" && tokens[2] != "live" {
+                return Err(format!(
+                    "{path}: hle_spc_upload mode must be legacy or live, got: {:?}",
+                    tokens[2]
                 ));
             }
             let pc16 =

--- a/recompiler/v2/cfg_loader.py
+++ b/recompiler/v2/cfg_loader.py
@@ -133,7 +133,10 @@ class BankCfg:
     # Per-game: declare the SPC upload entry PC here. Works for SMW
     # (HandleSPCUploads_Inner / SPC700UploadLoop at $00:8079) and
     # ALttP (LoadSongBank at $00:8888) — both use the same protocol.
-    hle_spc_upload: List[int] = field(default_factory=list)
+    # Map entry PC to protocol ownership mode. `live` preserves the running
+    # driver's AA/BB-ready and CC-terminator handshake; `legacy` retains the
+    # direct state replacement required by older per-game declarations.
+    hle_spc_upload: dict = field(default_factory=dict)
     # `hle_func <pc16> <c_function_name>` — replace the recompiled body
     # of the function at <pc> with a single forwarding call to the named
     # C function. Used for hand-written HLE bodies that need to run
@@ -286,16 +289,21 @@ def load_bank_cfg(path: str) -> BankCfg:
             # block stream pointed to by DP+0..2 and writes directly
             # into apu->ram. See BankCfg.hle_spc_upload comment.
             if head == 'hle_spc_upload':
-                if len(tokens) != 2:
+                if len(tokens) not in (2, 3):
                     raise ValueError(
-                        f"{path}: hle_spc_upload needs exactly one <pc> "
-                        f"argument, got: {stripped!r}")
+                        f"{path}: hle_spc_upload needs <pc> and optional "
+                        f"legacy|live mode, got: {stripped!r}")
                 try:
                     pc16 = _parse_hex(tokens[1]) & 0xFFFF
                 except ValueError as e:
                     raise ValueError(
                         f"{path}: hle_spc_upload bad pc {tokens[1]!r}: {e}")
-                cfg.hle_spc_upload.append(pc16)
+                mode = tokens[2].lower() if len(tokens) == 3 else 'legacy'
+                if mode not in ('legacy', 'live'):
+                    raise ValueError(
+                        f"{path}: hle_spc_upload bad mode {mode!r}; "
+                        "expected legacy or live")
+                cfg.hle_spc_upload[pc16] = mode
                 continue
 
             # hle_func <pc16> <c_function_name> — replace the decoded

--- a/recompiler/v2/emit_function.py
+++ b/recompiler/v2/emit_function.py
@@ -511,10 +511,14 @@ def emit_function(rom: bytes, bank: int, start: int,
     if hle_spc_upload and (start & 0xFFFF) in set(hle_spc_upload):
         variant_name = f"{base_func_name}{_variant_suffix(entry_m, entry_x)}"
         pc24 = ((bank & 0xFF) << 16) | (start & 0xFFFF)
+        live_upload = (isinstance(hle_spc_upload, dict) and
+                       hle_spc_upload.get(start & 0xFFFF) == 'live')
+        upload_helper = ('RtlUploadSpcImageFromDpLive' if live_upload else
+                         'RtlUploadSpcImageFromDp')
         return "\n".join([
             f"RecompReturn {variant_name}(CpuState *cpu) {{",
             "  extern const char *g_last_recomp_func;",
-            "  extern bool RtlUploadSpcImageFromDp(CpuState *cpu);",
+            f"  extern bool {upload_helper}(CpuState *cpu);",
             f"  g_last_recomp_func = \"{variant_name}\";",
             f"  RecompStackPush(\"{variant_name}\");",
             f"  cpu_dbg_funcname(\"{variant_name}\");",
@@ -533,7 +537,7 @@ def emit_function(rom: bytes, bank: int, start: int,
             "  }",
             f"  cpu_trace_block(cpu, 0x{pc24:06X});",
             "  WatchdogCheck();",
-            "  if (!RtlUploadSpcImageFromDp(cpu)) {",
+            f"  if (!{upload_helper}(cpu)) {{",
             f"    fprintf(stderr, \"[apu] {base_func_name} HLE upload failed\\n\");",
             "  }",
             "  { uint16 _ret_s = cpu->S;  /* HLE SPC upload RTS pop hardware return frame */",

--- a/runner/src/audio_trace.c
+++ b/runner/src/audio_trace.c
@@ -92,6 +92,17 @@ void audio_trace_set_producer(int producer) {
   s_producer = producer;
 }
 
+void audio_trace_on_fast_forward_discard(uint32_t samples,
+                                         uint32_t occupancy_after) {
+  s_stats.fast_forward_discarded += samples;
+  s_stats.occupancy_current = occupancy_after;
+}
+
+void audio_trace_on_output_underflow(uint32_t occupancy) {
+  s_stats.output_underflows++;
+  s_stats.occupancy_current = occupancy;
+}
+
 void audio_trace_on_sample(int16_t l, int16_t r, int dropped, uint32_t ring_fill) {
   uint32_t w = (uint32_t)(s_stats.produced & (AUDIO_TRACE_PCM_RING - 1));
   s_pcm[w * 2] = l;
@@ -119,6 +130,7 @@ void audio_trace_on_sample(int16_t l, int16_t r, int dropped, uint32_t ring_fill
   if (s_producer == AUDIO_TRACE_PRODUCER_CPU) s_stats.produced_cpu++;
   else if (s_producer == AUDIO_TRACE_PRODUCER_AUDIO) s_stats.produced_audio++;
   if (ring_fill > s_stats.occupancy_highwater) s_stats.occupancy_highwater = ring_fill;
+  s_stats.occupancy_current = ring_fill;
   maybe_snap(ring_fill);
 }
 
@@ -177,6 +189,13 @@ void audio_trace_on_pace(int consumer_active, uint32_t baseline_cycles) {
   s_stats.pace_consumer_active = (uint32_t)(consumer_active != 0);
   s_stats.pace_baseline_cycles += baseline_cycles;
   s_stats.pace_accumulate_calls++;
+}
+
+void audio_trace_on_guest_sync(int frame_boundary, uint64_t cycles) {
+  if (frame_boundary)
+    s_stats.guest_frame_sync_cycles += cycles;
+  else
+    s_stats.guest_read_sync_cycles += cycles;
 }
 
 /* ---- CPU<->SPC port traffic ----
@@ -269,6 +288,7 @@ void audio_trace_on_consume(uint64_t read_idx, uint32_t count, uint32_t avail_af
   (void)read_idx;
   s_stats.consumed += count;
   s_stats.consume_calls++;
+  s_stats.occupancy_current = avail_after;
   if (count > s_max_consume_chunk) s_max_consume_chunk = count;
   s_open_drop_event = UINT64_MAX;
 }

--- a/runner/src/audio_trace.h
+++ b/runner/src/audio_trace.h
@@ -98,10 +98,14 @@ typedef struct AudioTraceStats {
                                * `dropped`; THIS counter going nonzero
                                * means audible music was discarded.      */
   uint64_t consumed;          /* total native samples read for output   */
+  uint64_t fast_forward_discarded; /* stale queued samples removed only
+                                    * on the fast-forward -> normal edge */
+  uint64_t output_underflows; /* callbacks with <1 guest-produced block */
   uint64_t consume_calls;     /* dsp_getSamples calls (audio callbacks) */
   uint64_t reg_writes;        /* DSP register writes                    */
   uint64_t kon_writes;        /* writes to $4C (KON)                    */
   uint32_t occupancy_highwater;
+  uint32_t occupancy_current;
   uint64_t event_count;       /* events recorded (monotonic)            */
   uint64_t snap_count;        /* snapshots recorded (monotonic)         */
   /* APU catch-up pacing (rtl_accumulate_apu_catchup):                  */
@@ -109,6 +113,8 @@ typedef struct AudioTraceStats {
                                   /* no consumer was draining the ring  */
   uint64_t pace_accumulate_calls; /* catch-up accumulations (APU touches)*/
   uint32_t pace_consumer_active;  /* consumer draining at last catch-up */
+  uint64_t guest_frame_sync_cycles;
+  uint64_t guest_read_sync_cycles;
   /* Port-traffic totals (appended; events themselves are in the ring). */
   uint64_t cpu_port_writes;       /* every CPU write to $2140-43        */
   uint64_t spc_port_reads_seen;   /* every SPC read of $F4-F7 (raw)     */
@@ -193,6 +199,10 @@ void audio_trace_on_echo_div(double d);
 /* Per catch-up accumulation: consumer state + wall-clock baseline cycles
  * injected (0 when a consumer is draining or no wall time elapsed). */
 void audio_trace_on_pace(int consumer_active, uint32_t baseline_cycles);
+void audio_trace_on_guest_sync(int frame_boundary, uint64_t cycles);
+void audio_trace_on_fast_forward_discard(uint32_t samples,
+                                         uint32_t occupancy_after);
+void audio_trace_on_output_underflow(uint32_t occupancy);
 /* CPU<->SPC port traffic. port = 0-3. All call sites hold RtlApuLock.
  * The SPC-read / CPU-read hooks gate internally (value change or fresh
  * counterpart write); callers pass every access unconditionally. */
@@ -232,7 +242,7 @@ uint32_t audio_trace_copy_snaps(uint64_t first_idx, uint32_t max,
 /* Write a 32 kHz stereo 16-bit WAV of PCM-ring samples
  * [start_idx, start_idx+count). start_idx<0 / count==0 mean "everything
  * still in the ring". Returns 0 on success, writes the actually-dumped
- * range to *out_start/*out_count. */
+ * range through out_start and out_count. */
 int audio_trace_dump_wav(const char *path, int64_t start_idx, uint64_t count,
                          uint64_t *out_start, uint64_t *out_count);
 

--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -77,6 +77,37 @@ int cosim_apu_shared_clock(void) {
 // synthetic estimate. g_apu_last_sync_master is the master-clock count at the
 // last APU sync; rtl_accumulate_apu_catchup() converts the delta to SPC cycles.
 uint64_t g_apu_last_sync_master = 0;
+/* Production's frame loop is the stable guest-time ruler: one frame is
+ * 357368 SNES master cycles and 17088 SPC cycles in this runtime's 60 Hz
+ * model. g_cpu.master_cycles supplies only the within-frame position because
+ * its total per frame varies with recompilation coverage. */
+#define RTL_MASTER_CYCLES_PER_FRAME 357368ull
+#define RTL_APU_CYCLES_PER_FRAME     17088ull
+static uint64_t g_apu_frame_start_master;
+static bool g_apu_frame_time_valid;
+
+/* Fast-forward advances the real SPC/DSP state faster than the host device can
+ * play it. On the transition back to realtime, buffered PCM represents stale
+ * guest time and must not become permanent A/V latency. The short ramp joins
+ * the last delivered sample to the first current sample without a hard edge. */
+#define RTL_AUDIO_RECOVERY_RAMP 128u
+static bool g_audio_fast_forward;
+static uint32_t g_audio_recovery_frames;
+static uint32_t g_audio_recovery_remaining;
+static int16 g_audio_recovery_anchor_l;
+static int16 g_audio_recovery_anchor_r;
+static int16 g_audio_last_output_l;
+static int16 g_audio_last_output_r;
+static void rtl_sync_apu_frame_boundary(void);
+
+static uint64_t rtl_apu_guest_cycle(void) {
+  uint64_t within = g_cpu.master_cycles - g_apu_frame_start_master;
+  if (within >= RTL_MASTER_CYCLES_PER_FRAME)
+    within = RTL_MASTER_CYCLES_PER_FRAME - 1;
+  return (uint64_t)snes_frame_counter * RTL_APU_CYCLES_PER_FRAME +
+         within * RTL_APU_CYCLES_PER_FRAME /
+             RTL_MASTER_CYCLES_PER_FRAME;
+}
 // $420D bit 0 (FastROM / MEMSEL): 1 => $80-$FF:$8000-$FFFF code runs fast (6
 // master clocks/access) instead of slow (8). Tracked here so emitted blocks in
 // the WS2 mirror banks weight their master-cycle charge correctly at runtime.
@@ -158,6 +189,8 @@ static void memory_sli_func(SaveLoadInfo *sli, void *data, size_t n) {
 
 void RtlReset(int mode) {
   snes_frame_counter = 0;
+  g_apu_frame_time_valid = false;
+  g_apu_frame_start_master = g_cpu.master_cycles;
   g_main_cpu_cycles_estimate = 0;
   g_apu_pace_cycles_estimate = 0;
   g_apu_last_sync_cycles = 0;
@@ -173,6 +206,13 @@ void RtlReset(int mode) {
     memset(g_sram, 0, g_sram_size);
 
   RtlApuLock();
+  g_audio_fast_forward = false;
+  g_audio_recovery_frames = 0;
+  g_audio_recovery_remaining = 0;
+  g_audio_recovery_anchor_l = 0;
+  g_audio_recovery_anchor_r = 0;
+  g_audio_last_output_l = 0;
+  g_audio_last_output_r = 0;
   g_spc_player->initialize(g_spc_player);
   RtlApuUnlock();
 }
@@ -358,6 +398,11 @@ bool RtlRunFrame(uint32 inputs) {
   g_snes->input1_currentState = inputs & 0xfff;
   g_snes->input2_currentState = (inputs >> 12) & 0xfff;
 
+  /* Establish the guest timestamp origin before any frame code can touch an
+   * APU port. Host turbo changes how quickly frames arrive, not their guest
+   * duration. */
+  g_apu_frame_start_master = g_cpu.master_cycles;
+  g_apu_frame_time_valid = true;
   WatchdogFrameStart();
   // Watchdog guard: WatchdogCheck() (called per-block in v2 gen) longjmps
   // here when a frame exceeds 5s, so an infinite loop in recompiled code
@@ -432,6 +477,10 @@ bool RtlRunFrame(uint32 inputs) {
   g_fp_max_frame = (uint64_t)snes_frame_counter;
 
   snes_frame_counter++;
+  /* Every runner client gets the same guest-frame/APU coupling. Presentation
+   * code may opt into fast-forward PCM recovery separately, but cannot omit
+   * the emulation clock. */
+  rtl_sync_apu_frame_boundary();
 
 #ifdef SNES_COSIM
   /* Frame-keyed checkpoint: snapshot full state + park for the coordinator. */
@@ -708,15 +757,12 @@ uint16 ReadRegWord(uint16 reg) {
   // snapshot. Two separate ReadReg calls would each catch the APU
   // up — between them the SPC could write only the LO byte (port 0)
   // before host has read HI (port 1), so host sees a torn value. Read
-  // both ports atomically (single catchup) for the APU-port range.
+  // both ports atomically (single guest-time sync) for the APU-port range.
   if (reg >= 0x2140 && reg <= 0x217F) {
-    extern void rtl_accumulate_apu_catchup(void);
     void RtlApuLock(void); void RtlApuUnlock(void);
-    void snes_catchupApu(Snes* snes);
     extern Snes *g_snes;
     RtlApuLock();
-    rtl_accumulate_apu_catchup();
-    snes_catchupApu(g_snes);
+    rtl_sync_apu_to_cpu_locked();
     uint8_t lo = g_snes->apu->outPorts[(reg & 0x3)];
     uint8_t hi = g_snes->apu->outPorts[((reg + 1) & 0x3)];
     RtlApuUnlock();
@@ -894,157 +940,60 @@ void rtl_accumulate_apu_catchup(void) {
 
 void RtlApuWrite(uint16 adr, uint8 val) {
   assert(adr >= APUI00 && adr <= APUI03);
+  uint8_t port = (uint8_t)(adr & 3);
+
 #ifdef SNES_COSIM
-  /* Shared APU clock (common_rtl.h): do NOT convert pending touch credit on a
-   * port WRITE — schedule the byte at the current produced clock and leave the
-   * credit for the next port READ. Rationale: the interp tier executes a guest
-   * word store to $2140/$2141 as two byte writes; converting credit between
-   * them runs the SPC ~73 cycles with the kick byte applied but the data byte
-   * not yet — the IPL latches stale data and the upload handshake wedges
-   * (measured: LLE-shared stuck at outPorts=AABB to frame 360+). On hardware
-   * the two bytes land ~2 SPC cycles apart — effectively atomic. Deferring
-   * write-side conversion makes byte pairs land at the SAME produced tick, in
-   * program order, for BOTH the interp (lo,hi) and compiled (hi,lo) models —
-   * which also makes word-write APU evolution identical across tiers. */
+  /* The shared-clock co-sim advances the SPC synchronously and compares two
+   * execution models instruction-for-instruction. Keep its bus mutation at
+   * the already-aligned current clock. */
   if (cosim_apu_shared_clock()) {
     RtlApuLock();
-    audio_trace_on_cpu_port_write((uint8_t)(adr & 0x3), val);
-    uint64_t produced_now, consumed_now;
-    audio_trace_sample_clocks(&produced_now, &consumed_now);
-    apu_schedulePortWrite(g_snes->apu, (uint8_t)(adr & 0x3), val, produced_now);
+    audio_trace_on_cpu_port_write(port, val);
+    apu_writePortNow(g_snes->apu, port, val);
     RtlApuUnlock();
     return;
   }
 #endif
-  // Catch the APU up to the current cycle, then SCHEDULE the port write
-  // in APU-sample time rather than mutating inPorts at wall time.
-  //
-  // Rationale (SMW missed-SFX root cause): the audio thread advances
-  // the SPC in whole-callback bursts, so a wall-time port mutation gives
-  // the value a lifetime of however many samples happen to be produced
-  // before the next mutation — measured ~9 samples (vs the 64 an engine
-  // poll needs) whenever the 60.0988 Hz NMI beats across the 60.00 Hz
-  // callback phase. Anchoring each write one callback quantum past the
-  // CONSUMED clock keeps successive frame writes a full frame apart in
-  // the SPC's own execution time, so the engine always polls every
-  // value, exactly as on hardware. Steady-state added latency is ~zero:
-  // consumed + quantum ~= produced, i.e. the next burst applies it.
-  // Serialise with the audio thread via RtlApuLock -- it holds the same
-  // lock while cycling the APU in RtlRenderAudio.
+
   RtlApuLock();
-  rtl_accumulate_apu_catchup();
-  snes_catchupApu(g_snes);
-  audio_trace_on_cpu_port_write((uint8_t)(adr & 0x3), val);
-  {
-    /* Write clock: each target advances from the PREVIOUS write's target
-     * by the real wall-time gap between the two writes, converted to
-     * samples. This preserves hardware-faithful inter-write spacing in
-     * the SPC's execution timeline — frame-spaced NMI writes stay ~534
-     * samples apart, same-frame double writes keep their ms-scale gap —
-     * independent of where the audio thread's burst boundaries fall.
-     *
-     * (First attempt anchored targets at consumed+quantum; that fails
-     * because produced runs AHEAD of consumed by the output-ring fill,
-     * so every target was in the past and the floor collapsed
-     * consecutive writes onto the same sample — measured as +0-sample
-     * command lifetimes, i.e. the original race in a new costume.)
-     *
-     * Floor at produced: a target in the APU's past applies on the next
-     * executed sample. Ceiling at produced + 3 callback quanta bounds
-     * worst-case latency and sheds the slow forward drift from the
-     * NMI(60.0988 Hz)/callback(60.00 Hz) rate mismatch. Both caps scale
-     * with the observed burst granularity (audio_samples in config.ini
-     * is user-tunable): a ceiling smaller than the real burst would pin
-     * late-window writes to the same target and re-collapse spacing. */
-    static uint64_t s_port_clock;     /* previous write's target */
-    static uint64_t s_port_clock_ns;  /* wall_ns of previous write */
-    /* Per-port history for the minimum-dwell floor below. Statics, like
-     * s_port_clock: not reset across RtlReset/upload, which is benign —
-     * after a reset `produced` has advanced far past any stale target, so
-     * the floor (stale_target + dwell) is already in the past and never
-     * engages spuriously. */
-    static uint64_t s_port_last_target[4];
-    static uint8_t  s_port_last_val[4];
-    static uint8_t  s_port_last_valid[4];
-    /* Hardware visibility is the correctness default: a CPU port write lands
-     * at the APU's current execution point. Delaying it according to host wall
-     * time is not an LLE property and breaks real write -> echo -> poll
-     * protocols (MMX's runtime SPC upload used to spend >5 seconds in one
-     * faithfully recompiled polling loop). Keep the deferred scheduler below
-     * only as an explicit legacy/audio experiment selected with
-     * SNESRECOMP_APU_IMMEDIATE_PORTS=0; it must not be a per-game or per-region
-     * compile-time correctness hint. */
-    static int s_immediate = -1;
-    if (s_immediate < 0) {
-      const char *e = getenv("SNESRECOMP_APU_IMMEDIATE_PORTS");
-      s_immediate = (e && e[0]) ? (e[0] != '0') : 1;
-#ifdef SNES_COSIM
-      /* Shared APU clock implies immediate ports: the deferred scheduler
-       * anchors targets to the co-sim virtual wall clock, which derives from
-       * master_cycles — a per-execution-model clock that would re-skew the
-       * A/B pair this mode aligns. */
-      if (cosim_apu_shared_clock()) s_immediate = 1;
-#endif
-    }
-    if (s_immediate) {
-      uint64_t produced_now, consumed_now;
-      audio_trace_sample_clocks(&produced_now, &consumed_now);
-      apu_schedulePortWrite(g_snes->apu, (uint8_t)(adr & 0x3), val, produced_now);
-      RtlApuUnlock();
-      return;
-    }
-    uint64_t quantum = audio_trace_consume_quantum();
-    uint64_t now_ns = audio_trace_wall_ns();
-    uint64_t produced, consumed;
-    audio_trace_sample_clocks(&produced, &consumed);
-    uint64_t delta = 0;
-    if (s_port_clock_ns != 0)
-      delta = (now_ns - s_port_clock_ns) * 32040u / 1000000000u;
-    if (delta > 4u * quantum) delta = 4u * quantum;
-    uint64_t target = s_port_clock + delta;
-    if (target < produced) target = produced;
-    if (target > produced + 3u * quantum) target = produced + 3u * quantum;
+  if (!g_apu_frame_time_valid) {
+    rtl_accumulate_apu_catchup();
+    snes_catchupApu(g_snes);
+  }
+  audio_trace_on_cpu_port_write(port, val);
 
-    /* Minimum per-port dwell — the turbo audio-dropout fix. A level
-     * transition fires several DISTINCT values at the same APU port
-     * (fade, silence, the new song; or a one-shot command then the NMI's
-     * next-frame 0-clear) within a few frames. The wall-clock spacing
-     * computed above reproduces hardware timing faithfully at 1x, but
-     * turbo runs the game thread uncapped while the SPC still advances at
-     * 1x, compressing that spacing below the engine's ~64-sample poll
-     * period — so an earlier value is overwritten in inPorts before the
-     * engine ever reads it and the command is silently lost (music/SFX
-     * drop out; because a surviving fade can zero global output, they do
-     * not come back until the next track change, i.e. never within a
-     * level). Floor a DISTINCT value's target so the previous distinct
-     * value on that port holds the bus for at least APU_PORT_MIN_DWELL
-     * produced-samples — one guaranteed engine poll. The drain runs once
-     * per produced sample (apu_cycle), so this target spacing becomes
-     * apply spacing directly. Bounded by produced + 8*quantum so a
-     * pathological sustained burst degrades to today's bounded latency
-     * rather than unbounding it. Identical repeats (e.g. repeated
-     * 0-clears) need no spacing. No effect at 1x: frame-spaced writes are
-     * already ~534 samples apart, far above the floor. */
-    {
-      int p = (int)(adr & 0x3);
-      if (s_port_last_valid[p] && val != s_port_last_val[p]) {
-        uint64_t floor = s_port_last_target[p] + APU_PORT_MIN_DWELL;
-        uint64_t ceil  = produced + 8u * quantum;
-        if (target < floor) target = floor < ceil ? floor : ceil;
-      }
-      s_port_last_target[p] = target;
-      s_port_last_val[p]    = val;
-      s_port_last_valid[p]  = 1;
-    }
-
-    s_port_clock = target;
-    s_port_clock_ns = now_ns;
-    apu_schedulePortWrite(g_snes->apu, (uint8_t)(adr & 0x3), val, target);
+  if (!g_apu_frame_time_valid) {
+    /* Reset/IPL handshakes actively advance the SPC through their poll loops;
+     * there is no host frame timeline yet, so current-cycle visibility is the
+     * faithful model. */
+    apu_writePortNow(g_snes->apu, port, val);
+  } else {
+    uint64_t guest_cycle = rtl_apu_guest_cycle();
+    while (!apu_schedulePortWrite(g_snes->apu, port, val, guest_cycle))
+      apu_cycle(g_snes->apu);
   }
   RtlApuUnlock();
 }
 
-static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_result) {
+void rtl_sync_apu_to_cpu_locked(void) {
+  if (!g_apu_frame_time_valid) {
+    rtl_accumulate_apu_catchup();
+    snes_catchupApu(g_snes);
+    return;
+  }
+  audio_trace_set_producer(AUDIO_TRACE_PRODUCER_CPU);
+  uint64_t before = g_snes->apu->portClock;
+  bool synced = apu_runToGuestCycle(g_snes->apu, rtl_apu_guest_cycle(),
+                                    1u << 20);
+  audio_trace_on_guest_sync(0, g_snes->apu->portClock - before);
+  audio_trace_set_producer(AUDIO_TRACE_PRODUCER_UNKNOWN);
+  if (!synced)
+    fprintf(stderr, "[apu] CPU-port guest-clock sync timed out\n");
+}
+
+static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu,
+                                            bool update_cpu_result,
+                                            bool live_transfer) {
   uint16_t dp = cpu->D;
   uint16_t data_lo = (uint16_t)g_ram[(dp + 0) & 0xffff]
                    | ((uint16_t)g_ram[(dp + 1) & 0xffff] << 8);
@@ -1054,6 +1003,30 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
   int block_count = 0;
 
   RtlApuLock();
+  bool ipl_phase = g_snes->apu->romReadable;
+  /* The HLE routine takes ownership only after all earlier CPU bus events
+   * have reached the live SPC. For a running driver, honor its ready
+   * handshake before replacing the byte-by-byte payload copy. */
+  if (!apu_runUntilPortQueueEmpty(g_snes->apu, 1u << 22)) {
+    RtlApuUnlock();
+    fprintf(stderr, "[apu] queued port events did not reach upload boundary\n");
+    return false;
+  }
+  uint8_t transfer_request = g_snes->apu->inPorts[1];
+  if (live_transfer && !ipl_phase &&
+      !apu_waitForTransferReady(g_snes->apu, 1, transfer_request, 1u << 20)) {
+    fprintf(stderr,
+            "[apu] SPC transfer-ready timeout pc=%04x stopped=%d "
+            "in=%02x%02x out=%02x%02x edge=%02x%02x buf=%02x%02x\n",
+            g_snes->apu->spc->pc, g_snes->apu->spc->stopped,
+            g_snes->apu->inPorts[0], g_snes->apu->inPorts[1],
+            g_snes->apu->outPorts[0], g_snes->apu->outPorts[1],
+            g_snes->apu->ram[0], g_snes->apu->ram[1],
+            g_snes->apu->ram[4], g_snes->apu->ram[5]);
+    RtlApuUnlock();
+    return false;
+  }
+  apu_clearPortQueue(g_snes->apu);
   for (;;) {
     uint16_t n = (uint16_t)p[0] | ((uint16_t)p[1] << 8);
     uint16_t target = (uint16_t)p[2] | ((uint16_t)p[3] << 8);
@@ -1094,14 +1067,12 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
    * Detect "first upload" via apu->romReadable: it's reset to true by
    * apu_reset() and only flipped false here, so on the IPL-phase
    * upload it's still true. */
-  bool ipl_phase = g_snes->apu->romReadable;
-  /* The upload supersedes any not-yet-applied scheduled port writes;
-   * a stale pre-upload command landing on the freshly cleared ports
-   * would replay into the re-initialised engine. */
-  apu_clearPortQueue(g_snes->apu);
-  memset(g_snes->apu->inPorts, 0, sizeof(g_snes->apu->inPorts));
-  memset(g_snes->apu->outPorts, 0, sizeof(g_snes->apu->outPorts));
   if (ipl_phase) {
+    /* The boot upload body was replaced wholesale, so this is the logical
+     * consumption of the request that selected it. */
+    audio_trace_on_spc_port_read(1, transfer_request);
+    memset(g_snes->apu->inPorts, 0, 4);
+    memset(g_snes->apu->outPorts, 0, sizeof(g_snes->apu->outPorts));
     g_snes->apu->romReadable = false;
     g_snes->apuCatchupCycles = 0;
     g_snes->apu->cpuCyclesLeft = 0;
@@ -1113,6 +1084,18 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
         g_snes->apu->spc->sp = 0xef;
       g_snes->apu->spc->pc = final_pc;
     }
+  } else if (live_transfer) {
+    if (!apu_finishHleTransfer(g_snes->apu, final_pc, 1u << 20)) {
+      RtlApuUnlock();
+      fprintf(stderr, "[apu] SPC transfer terminator timed out\n");
+      return false;
+    }
+  } else {
+    /* Legacy HLE users have not declared a live driver protocol. Preserve
+     * their prior behavior instead of guessing that they speak SMW's
+     * AA/BB/CC transfer handshake. */
+    memset(g_snes->apu->inPorts, 0, 4);
+    memset(g_snes->apu->outPorts, 0, sizeof(g_snes->apu->outPorts));
   }
   g_apu_last_sync_cycles = g_apu_pace_cycles_estimate;
   // Resync the master pointer too: an IPL-phase upload zeroes apuCatchupCycles,
@@ -1133,52 +1116,121 @@ static bool RtlUploadSpcImageFromDpInternal(CpuState *cpu, bool update_cpu_resul
 }
 
 bool RtlUploadSpcImageFromDp(CpuState *cpu) {
-  return RtlUploadSpcImageFromDpInternal(cpu, false);
+  return RtlUploadSpcImageFromDpInternal(cpu, false, false);
+}
+
+bool RtlUploadSpcImageFromDpLive(CpuState *cpu) {
+  return RtlUploadSpcImageFromDpInternal(cpu, false, true);
 }
 
 bool RtlHandleSpcUpload(CpuState *cpu) {
-  return RtlUploadSpcImageFromDpInternal(cpu, true);
+  return RtlUploadSpcImageFromDpInternal(cpu, true, false);
+}
+
+static void rtl_sync_apu_frame_boundary(void) {
+  /* The game frame is the authoritative guest-time clock. The audio callback
+   * may fill a host scheduling shortfall, but CPU->APU events must never wait
+   * behind it: advance the real SPC through every event due by this completed
+   * frame at normal speed and turbo alike. */
+  RtlApuLock();
+  audio_trace_set_producer(AUDIO_TRACE_PRODUCER_CPU);
+  uint64_t before = g_snes->apu->portClock;
+  /* RtlRunFrame has already incremented snes_frame_counter. This is the exact
+   * boundary after the completed frame; adding its stale within-frame master
+   * offset here would count the frame body twice. */
+  uint64_t boundary = (uint64_t)snes_frame_counter *
+                      RTL_APU_CYCLES_PER_FRAME;
+  bool synced = apu_runToGuestCycle(g_snes->apu, boundary,
+                                    1u << 20);
+  audio_trace_on_guest_sync(1, g_snes->apu->portClock - before);
+  audio_trace_set_producer(AUDIO_TRACE_PRODUCER_UNKNOWN);
+  if (!synced)
+    fprintf(stderr, "[apu] frame-boundary guest-clock sync timed out\n");
+  RtlApuUnlock();
+}
+
+void RtlAudioSetFastForward(bool active) {
+  if (!active && !g_audio_fast_forward && g_audio_recovery_frames == 0)
+    return;
+  RtlApuLock();
+  if (active && !g_audio_fast_forward) {
+    /* A new fast-forward interval supersedes the prior continuity ramp. */
+    g_audio_recovery_frames = 0;
+    g_audio_recovery_remaining = 0;
+  } else if (!active && g_audio_fast_forward) {
+    g_audio_recovery_frames = 30;
+    g_audio_recovery_anchor_l = g_audio_last_output_l;
+    g_audio_recovery_anchor_r = g_audio_last_output_r;
+    g_audio_recovery_remaining = RTL_AUDIO_RECOVERY_RAMP;
+  }
+  if (!active && g_audio_recovery_frames != 0) {
+    uint32_t available = g_snes->apu->dsp->sampleWrite -
+                         g_snes->apu->dsp->sampleRead;
+    /* Keep two current blocks: one for the next callback and one scheduling
+     * cushion. Repeat at frame boundaries only while post-turbo CPU work is
+     * settling, then restore the ordinary FIFO unchanged. */
+    uint32_t discarded = dsp_trimSamples(g_snes->apu->dsp, 1068);
+    if (discarded != 0) {
+      audio_trace_on_fast_forward_discard(discarded,
+                                           available - discarded);
+      g_audio_recovery_anchor_l = g_audio_last_output_l;
+      g_audio_recovery_anchor_r = g_audio_last_output_r;
+      g_audio_recovery_remaining = RTL_AUDIO_RECOVERY_RAMP;
+      /* The host frame-delay clock may still be catching up after a long
+       * turbo interval. Require a full stable window after the most recent
+       * trim instead of expiring recovery after a fixed number of fast game
+       * frames. This makes release behavior independent of turbo duration. */
+      g_audio_recovery_frames = 30;
+    } else {
+      g_audio_recovery_frames--;
+    }
+  }
+  g_audio_fast_forward = active;
+  RtlApuUnlock();
 }
 
 void RtlRenderAudio(int16 *audio_buffer, int samples, int channels) {
   assert(channels == 2);
-  /* Cycle the APU in small batches under the lock, releasing between
-   * each so the CPU thread (RtlApuWrite / snes_readBBus) can make
-   * progress. Earlier code held RtlApuLock for the entire 17 000-cycle
-   * loop, which took ~4 ms host time per audio callback. With audio
-   * callbacks at ~60 Hz that pinned the CPU thread out of the lock for
-   * ~27 % of wall time, and the SMW IPL upload (which touches APU
-   * ports thousands of times) ran an order of magnitude slower than
-   * the watchdog allowed.
-   *
-   * 256 SPC cycles per batch is about 64 us host work per acquire, short
-   * enough that the CPU thread's RtlApuLock call almost never has to
-   * wait through a full audio batch. apu_cycle is single-threaded
-   * regardless -- the lock just serialises access to inPorts/outPorts
-   * shared with the CPU thread. */
-  // Ensure at least one block (534 native samples) is available in the
-  // ring, then consume it. The audio thread only produces the shortfall
-  // the CPU-thread catch-up (snes_catchupApu) hasn't already supplied, so
-  // it self-balances: total SPC advance stays at the consumption rate and
-  // bursty catch-up production is buffered, not dropped.
-  #define DSP_AVAIL(d) ((uint32_t)((d)->sampleWrite - (d)->sampleRead))
-  while (DSP_AVAIL(g_snes->apu->dsp) < 534) {
-    RtlApuLock();
-    audio_trace_set_producer(AUDIO_TRACE_PRODUCER_AUDIO);
-    int batch = 256;
-    while (batch-- > 0 && DSP_AVAIL(g_snes->apu->dsp) < 534)
-      apu_cycle(g_snes->apu);
-    audio_trace_set_producer(AUDIO_TRACE_PRODUCER_UNKNOWN);
-    RtlApuUnlock();
-  }
-  #undef DSP_AVAIL
+  /* SPC state is guest-frame driven by RtlAudioSyncFrame. The host callback is
+   * a consumer only: allowing it to invent SPC cycles makes its wall-clock
+   * schedule a second, competing emulation clock and is what let audio drift
+   * behind visuals after turbo. */
   RtlApuLock();
-  dsp_getSamples(g_snes->apu->dsp, audio_buffer, samples);
+  uint32_t available = g_snes->apu->dsp->sampleWrite -
+                       g_snes->apu->dsp->sampleRead;
+  if (available >= 534) {
+    dsp_getSamples(g_snes->apu->dsp, audio_buffer, samples);
+  } else {
+    /* Do not advance guest state to hide host scheduling jitter. Preserve a
+     * partial block for the next callback and emit one block of silence. */
+    memset(audio_buffer, 0, (size_t)samples * 2 * sizeof(*audio_buffer));
+    audio_trace_on_output_underflow(available);
+  }
   /* Mix MSU-1 streaming audio on top of the S-DSP block. Inert (no-op)
    * unless a pack is armed and a track is playing. Runs under the APU
    * lock we already hold, which serialises it against MSU register
    * writes on the CPU thread (msu1_read/msu1_write take the same lock). */
   msu1_mix(audio_buffer, samples);
+  for (int i = 0; i < samples && g_audio_recovery_remaining != 0; i++) {
+    uint32_t progressed = RTL_AUDIO_RECOVERY_RAMP -
+                          g_audio_recovery_remaining + 1;
+    uint32_t old_weight = RTL_AUDIO_RECOVERY_RAMP - progressed;
+    audio_buffer[i * 2] = (int16)(((int32_t)g_audio_recovery_anchor_l *
+                                   (int32_t)old_weight +
+                                   (int32_t)audio_buffer[i * 2] *
+                                   (int32_t)progressed) /
+                                  (int32_t)RTL_AUDIO_RECOVERY_RAMP);
+    audio_buffer[i * 2 + 1] = (int16)(((int32_t)g_audio_recovery_anchor_r *
+                                       (int32_t)old_weight +
+                                       (int32_t)audio_buffer[i * 2 + 1] *
+                                       (int32_t)progressed) /
+                                      (int32_t)RTL_AUDIO_RECOVERY_RAMP);
+    g_audio_recovery_remaining--;
+  }
+  if (samples > 0) {
+    g_audio_last_output_l = audio_buffer[(samples - 1) * 2];
+    g_audio_last_output_r = audio_buffer[(samples - 1) * 2 + 1];
+  }
   RtlApuUnlock();
 }
 

--- a/runner/src/common_rtl.h
+++ b/runner/src/common_rtl.h
@@ -44,6 +44,9 @@ extern uint64_t g_apu_last_sync_cycles;
 // it; it's defined alongside the pacing state in common_rtl.c.
 extern uint64_t g_apu_last_sync_master;
 void rtl_accumulate_apu_catchup(void);
+/* Caller holds RtlApuLock. Before the first frame, retain bootstrap synthetic
+ * pacing; afterward synchronize reads to the authoritative guest timestamp. */
+void rtl_sync_apu_to_cpu_locked(void);
 
 #ifdef SNES_COSIM
 // Co-sim shared APU clock (SNES_COSIM_APU_SHARED=1, dev-only): pace the SPC
@@ -258,7 +261,12 @@ void RtlSaveLoad(int cmd, int slot);
 void RtlApuLock();
 void RtlApuUnlock();
 void RtlRenderAudio(int16 *audio_buffer, int samples, int channels);
-bool RtlUploadSpcImageFromDp(CpuState *cpu);
+/* Notify the shared audio runner of host fast-forward state. Guest-frame SPC
+ * synchronization is automatic inside RtlRunFrame; clients only supply the
+ * presentation policy needed to discard stale PCM after fast-forward. */
+void RtlAudioSetFastForward(bool active);
+  bool RtlUploadSpcImageFromDp(CpuState *cpu);
+  bool RtlUploadSpcImageFromDpLive(CpuState *cpu);
 bool RtlRunFrame(uint32 inputs);
 void RtlReadSram();
 void RtlWriteSram();

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -6611,26 +6611,47 @@ static void cmd_audio_stats(const char *args) {
     if (want > 256) want = 256;
     AudioTraceStats st;
     audio_trace_get_stats(&st);
+    uint32_t apu_port_queue_depth = 0;
+    uint64_t apu_port_queue_lag = 0;
+    RtlApuLock();
+    if (g_snes && g_snes->apu) {
+        apu_port_queue_depth = apu_portQueueDepth(g_snes->apu);
+        if (apu_port_queue_depth != 0 &&
+            g_snes->apu->portLastTarget > g_snes->apu->portClock)
+            apu_port_queue_lag = g_snes->apu->portLastTarget -
+                                 g_snes->apu->portClock;
+    }
+    RtlApuUnlock();
     static char buf[65536];
     int pos = snprintf(buf, sizeof(buf),
         "{\"ok\":true,\"produced\":%llu,\"produced_cpu\":%llu,\"produced_audio\":%llu,"
-        "\"dropped\":%llu,\"dropped_audible\":%llu,\"drop_runs\":%llu,\"consumed\":%llu,\"consume_calls\":%llu,"
+        "\"dropped\":%llu,\"dropped_audible\":%llu,\"drop_runs\":%llu,\"consumed\":%llu,"
+        "\"fast_forward_discarded\":%llu,\"output_underflows\":%llu,"
+        "\"consume_calls\":%llu,"
         "\"reg_writes\":%llu,\"kon_writes\":%llu,\"occupancy_highwater\":%u,"
+        "\"occupancy_current\":%u,"
         "\"pace_baseline_cycles\":%llu,\"pace_accumulate_calls\":%llu,"
         "\"pace_consumer_active\":%u,"
+        "\"guest_frame_sync_cycles\":%llu,\"guest_read_sync_cycles\":%llu,"
         "\"cpu_port_writes\":%llu,\"spc_port_reads_seen\":%llu,"
         "\"spc_port_reads_logged\":%llu,\"spc_port_writes\":%llu,"
         "\"cpu_port_reads_logged\":%llu,"
         "\"cpu_port_overwrites\":[%llu,%llu,%llu,%llu],"
+        "\"apu_port_queue_depth\":%u,\"apu_port_queue_lag\":%llu,"
         "\"event_count\":%llu,\"snap_count\":%llu,\"snaps\":[",
         (unsigned long long)st.produced, (unsigned long long)st.produced_cpu,
         (unsigned long long)st.produced_audio, (unsigned long long)st.dropped,
         (unsigned long long)st.dropped_audible,
         (unsigned long long)st.drop_runs, (unsigned long long)st.consumed,
+        (unsigned long long)st.fast_forward_discarded,
+        (unsigned long long)st.output_underflows,
         (unsigned long long)st.consume_calls, (unsigned long long)st.reg_writes,
         (unsigned long long)st.kon_writes, st.occupancy_highwater,
+        st.occupancy_current,
         (unsigned long long)st.pace_baseline_cycles,
         (unsigned long long)st.pace_accumulate_calls, st.pace_consumer_active,
+        (unsigned long long)st.guest_frame_sync_cycles,
+        (unsigned long long)st.guest_read_sync_cycles,
         (unsigned long long)st.cpu_port_writes,
         (unsigned long long)st.spc_port_reads_seen,
         (unsigned long long)st.spc_port_reads_logged,
@@ -6640,6 +6661,7 @@ static void cmd_audio_stats(const char *args) {
         (unsigned long long)st.cpu_port_overwrites[1],
         (unsigned long long)st.cpu_port_overwrites[2],
         (unsigned long long)st.cpu_port_overwrites[3],
+        apu_port_queue_depth, (unsigned long long)apu_port_queue_lag,
         (unsigned long long)st.event_count, (unsigned long long)st.snap_count);
     uint64_t first = st.snap_count > (uint64_t)want ? st.snap_count - want : 0;
     static AudioTraceSnap snaps[256];

--- a/runner/src/snes/apu.c
+++ b/runner/src/snes/apu.c
@@ -51,43 +51,139 @@ void apu_reset(Apu* apu) {
     apu->timer[i].enabled = false;
   }
   apu->cpuCyclesLeft = 7;
+  apu->portClock = 0;
   apu_clearPortQueue(apu);
 }
 
 void apu_clearPortQueue(Apu* apu) {
   apu->portQHead = apu->portQTail = 0;
+  apu->portGuestAnchor = 0;
+  apu->portTargetAnchor = 0;
+  apu->portLastGuest = 0;
+  apu->portLastTarget = 0;
+  apu->portTimeValid = false;
+}
+
+void apu_writePortNow(Apu* apu, uint8_t port, uint8_t val) {
+  port &= 3;
+  apu->inPorts[port] = val;
+  audio_trace_on_cpu_port_apply(port, val);
 }
 
 static void apu_applyPortWrite(Apu* apu, const ApuPortWrite *w) {
-  apu->inPorts[w->port & 3] = w->val;
-  audio_trace_on_cpu_port_apply(w->port, w->val);
+  apu_writePortNow(apu, w->port, w->val);
 }
 
-void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
-                           uint64_t target_sample) {
-  if (apu->portQTail - apu->portQHead >= APU_PORT_QUEUE_LEN) {
-    /* Full — apply the oldest immediately so ordering survives. */
-    apu_applyPortWrite(apu, &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)]);
-    apu->portQHead++;
+uint32_t apu_portQueueDepth(const Apu* apu) {
+  return apu->portQTail - apu->portQHead;
+}
+
+bool apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
+                           uint64_t guest_cycle) {
+  if (apu_portQueueDepth(apu) >= APU_PORT_QUEUE_LEN)
+    return false;
+
+  /* Establish a correspondence between guest time and wherever the
+   * callback-driven SPC is now. If the callback later runs ahead, rebase at
+   * the new current point; future guest deltas are still preserved. */
+  if (!apu->portTimeValid || guest_cycle < apu->portLastGuest) {
+    apu->portGuestAnchor = guest_cycle;
+    apu->portTargetAnchor = apu->portClock;
+    apu->portTimeValid = true;
   }
+
+  uint64_t target = apu->portTargetAnchor +
+                    (guest_cycle - apu->portGuestAnchor);
+  if (target < apu->portClock) {
+    apu->portGuestAnchor = guest_cycle;
+    apu->portTargetAnchor = apu->portClock;
+    target = apu->portClock;
+  }
+  if (target < apu->portLastTarget)
+    target = apu->portLastTarget;
+
   ApuPortWrite *w = &apu->portQueue[apu->portQTail & (APU_PORT_QUEUE_LEN - 1)];
-  w->target_sample = target_sample;
+  w->target_cycle = target;
   w->port = (uint8_t)(port & 3);
   w->val = val;
   apu->portQTail++;
+  apu->portLastGuest = guest_cycle;
+  apu->portLastTarget = target;
+  return true;
 }
 
-/* Apply every queued write whose target the produced-sample clock has
- * reached. Called at each DSP sample boundary inside apu_cycle. */
+/* Apply all CPU bus events due before this SPC cycle executes. */
 static void apu_drainPortQueue(Apu* apu) {
-  uint64_t produced;
-  audio_trace_sample_clocks(&produced, NULL);
   while (apu->portQHead != apu->portQTail) {
     ApuPortWrite *w = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
-    if (w->target_sample > produced)
+    if (w->target_cycle > apu->portClock)
       break;
     apu_applyPortWrite(apu, w);
     apu->portQHead++;
+  }
+}
+
+bool apu_runUntilPortQueueEmpty(Apu* apu, uint32_t max_cycles) {
+  while (apu->portQHead != apu->portQTail) {
+    if (max_cycles-- == 0)
+      return false;
+    apu_cycle(apu);
+  }
+  return true;
+}
+
+bool apu_runToGuestCycle(Apu* apu, uint64_t guest_cycle,
+                         uint32_t max_cycles) {
+  if (!apu->portTimeValid || guest_cycle < apu->portGuestAnchor)
+    return true;
+
+  uint64_t target = apu->portTargetAnchor +
+                    (guest_cycle - apu->portGuestAnchor);
+  if (target < apu->portLastTarget)
+    target = apu->portLastTarget;
+
+  for (;;) {
+    bool due_event = false;
+    if (apu->portQHead != apu->portQTail) {
+      const ApuPortWrite *w =
+          &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
+      due_event = w->target_cycle <= target;
+    }
+    if (apu->portClock >= target && !due_event)
+      return true;
+    if (max_cycles-- == 0)
+      return false;
+    apu_cycle(apu);
+  }
+}
+
+bool apu_waitForTransferReady(Apu* apu, uint8_t request_port,
+                              uint8_t request_value, uint32_t max_cycles) {
+  for (;;) {
+    if (apu->outPorts[0] == 0xaa && apu->outPorts[1] == 0xbb)
+      return true;
+    if (apu->inPorts[request_port & 3] != request_value)
+      apu_writePortNow(apu, request_port, request_value);
+    if (max_cycles-- == 0)
+      return false;
+    apu_cycle(apu);
+  }
+}
+
+bool apu_finishHleTransfer(Apu* apu, uint16_t final_pc,
+                           uint32_t max_cycles) {
+  apu_writePortNow(apu, 2, (uint8_t)final_pc);
+  apu_writePortNow(apu, 3, (uint8_t)(final_pc >> 8));
+  apu_writePortNow(apu, 1, 0);
+  apu_writePortNow(apu, 0, 0xcc);
+  for (;;) {
+    if (apu->outPorts[0] == 0xcc) {
+      memset(apu->inPorts, 0, 4);
+      return true;
+    }
+    if (max_cycles-- == 0)
+      return false;
+    apu_cycle(apu);
   }
 }
 
@@ -101,6 +197,7 @@ extern uint64_t g_spc_pc_histogram[0x10000];
 extern int g_spc_pc_max_seen;
 
 void apu_cycle(Apu* apu) {
+  apu_drainPortQueue(apu);
   if(apu->cpuCyclesLeft == 0) {
     /* Sample PC right BEFORE running the opcode — so PC reflects the
      * instruction we're about to execute, not the post-opcode PC. */
@@ -112,7 +209,6 @@ void apu_cycle(Apu* apu) {
 
   if((apu->cycles & 0x1f) == 0) {
     // every 32 cycles
-    apu_drainPortQueue(apu);
     dsp_cycle(apu->dsp);
   }
 
@@ -135,6 +231,7 @@ void apu_cycle(Apu* apu) {
   }
 
   apu->cycles++;
+  apu->portClock++;
 }
 
 uint8_t apu_cpuRead(Apu* apu, uint16_t adr) {

--- a/runner/src/snes/apu.h
+++ b/runner/src/snes/apu.h
@@ -1,4 +1,3 @@
-
 #ifndef APU_H
 #define APU_H
 
@@ -22,41 +21,17 @@ typedef struct Timer {
   bool enabled;
 } Timer;
 
-/* CPU->APU port write, ordered in APU-sample time.
- *
- * The queue serializes CPU writes with the audio thread, which advances the
- * SPC in callback-sized bursts. The correctness path targets the current
- * produced-sample clock, making writes visible at the APU's present execution
- * point just as the hardware bus does. A legacy diagnostic path may assign
- * later targets to study host/audio pacing, but delayed wall-time scheduling
- * is not part of the guest machine model. */
-/* Power of 2. SMW peaks at ~4 writes/frame at 1x, but under turbo the
- * uncapped game thread schedules many frames of writes into the bounded
- * latency window faster than the 1x SPC drains them, and the per-port
- * minimum-dwell floor (see APU_PORT_MIN_DWELL) pushes distinct values
- * later still. 128 keeps the in-flight set inside the queue so the
- * overflow force-apply path (which bypasses a write's target) stays a
- * rare backstop rather than the common case under sustained turbo. */
-#define APU_PORT_QUEUE_LEN 128u
-
-/* Minimum produced-sample spacing the scheduler enforces between two
- * DISTINCT values written to the SAME APU port. The SPC sound engine
- * polls its command ports about every ~64 samples of its own time; if
- * two distinct values to one port land closer than that, the engine
- * never observes the first (it is overwritten in inPorts before any
- * read) and that command is silently lost. At 1x the game spaces its
- * per-frame writes ~534 samples apart so this floor never engages, but
- * turbo runs the game thread uncapped while the SPC still advances at
- * 1x, compressing successive same-port writes below the poll period --
- * the audio-dropout-at-level-transition bug. Flooring distinct same-port
- * writes two poll periods apart guarantees the engine polls every value.
- * Expressed in native DSP samples (32040 Hz), so host resample rate is
- * irrelevant. */
-#define APU_PORT_MIN_DWELL 128u
+/* CPU->APU bus events are timestamped in guest APU cycles. The audio callback
+ * may execute the SPC ahead of or behind the CPU thread, but it must not turn
+ * two writes from different emulated frames into back-to-back host mutations.
+ * A power-of-two queue preserves global CPU bus order. If it ever fills, the
+ * caller advances the SPC until space exists; no event is overwritten or
+ * force-applied before its guest timestamp. */
+#define APU_PORT_QUEUE_LEN 1024u
 
 typedef struct ApuPortWrite {
-  uint64_t target_sample; /* apply when the produced-sample clock reaches this */
-  uint8_t port;           /* 0-3 */
+  uint64_t target_cycle; /* apply when portClock reaches this APU cycle */
+  uint8_t port;          /* 0-3 */
   uint8_t val;
 } ApuPortWrite;
 
@@ -72,13 +47,18 @@ struct Apu {
   Timer timer[3];
   uint8_t cpuCyclesLeft;
   uint8_t pad[6];
-  /* Port-write scheduler — MUST stay after `pad`: apu_saveload snapshots
-   * [ram, pad+6) and the savestate layout is frozen. Cleared on reset
-   * and on the HLE SPC-image upload; deliberately not serialized (any
-   * still-pending write applies on the first cycles after load). */
+  /* Port event state must stay after pad: apu_saveload snapshots [ram,pad+6),
+   * and that savestate layout is frozen. Callback lead is host state, so the
+   * queue and its mapping are deliberately reset rather than serialized. */
   ApuPortWrite portQueue[APU_PORT_QUEUE_LEN];
-  uint32_t portQHead;     /* next slot to apply  */
-  uint32_t portQTail;     /* next slot to fill   */
+  uint32_t portQHead;
+  uint32_t portQTail;
+  uint64_t portClock;        /* APU cycles executed since reset */
+  uint64_t portGuestAnchor;  /* guest-cycle origin for current mapping */
+  uint64_t portTargetAnchor; /* matching portClock origin */
+  uint64_t portLastGuest;
+  uint64_t portLastTarget;
+  bool portTimeValid;
 };
 
 Apu* apu_init();
@@ -88,12 +68,29 @@ void apu_cycle(Apu* apu);
 uint8_t apu_cpuRead(Apu* apu, uint16_t adr);
 void apu_cpuWrite(Apu* apu, uint16_t adr, uint8_t val);
 void apu_saveload(Apu *apu, SaveLoadInfo *sli);
-/* Schedule a CPU-side port write ($2140+port) to land in inPorts when
- * the produced-sample clock reaches target_sample. Caller must hold
- * RtlApuLock. Queue overflow applies the oldest entry immediately
- * (order is always preserved). */
-void apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
-                           uint64_t target_sample);
-/* Drop all pending scheduled port writes (reset / HLE image upload). */
+
+/* Immediate visibility is reserved for boot and synchronous protocol code
+ * which advances the SPC itself. Caller holds RtlApuLock. */
+void apu_writePortNow(Apu* apu, uint8_t port, uint8_t val);
+/* Map a monotonic guest APU-cycle timestamp onto the live SPC timeline and
+ * enqueue the write. False means the caller must advance the APU and retry. */
+bool apu_schedulePortWrite(Apu* apu, uint8_t port, uint8_t val,
+                           uint64_t guest_cycle);
+uint32_t apu_portQueueDepth(const Apu* apu);
+/* Advance real SPC execution until every queued bus event has landed. */
+bool apu_runUntilPortQueueEmpty(Apu* apu, uint32_t max_cycles);
+/* Advance the live SPC to a guest timestamp using the same mapping as queued
+ * CPU writes. This is the fast-forward coupling point: game frames and SPC
+ * state advance together even when the host audio device cannot play them. */
+bool apu_runToGuestCycle(Apu* apu, uint64_t guest_cycle,
+                         uint32_t max_cycles);
+/* HLE for a declared live transfer protocol: wait for the driver-ready AA/BB
+ * pair, then deliver the standard CC terminator and wait for its echo. */
+bool apu_waitForTransferReady(Apu* apu, uint8_t request_port,
+                              uint8_t request_value, uint32_t max_cycles);
+bool apu_finishHleTransfer(Apu* apu, uint16_t final_pc,
+                           uint32_t max_cycles);
+/* Drop pending events and reset the guest-to-SPC mapping. */
 void apu_clearPortQueue(Apu* apu);
+
 #endif

--- a/runner/src/snes/dsp.c
+++ b/runner/src/snes/dsp.c
@@ -655,3 +655,12 @@ void dsp_getSamples(Dsp* dsp, int16_t* sampleData, int samplesPerFrame) {
   dsp->sampleRead += 534;
   audio_trace_on_consume(base, 534, dsp->sampleWrite - dsp->sampleRead);
 }
+
+uint32_t dsp_trimSamples(Dsp* dsp, uint32_t samples_to_keep) {
+  uint32_t available = dsp->sampleWrite - dsp->sampleRead;
+  if (samples_to_keep > available)
+    samples_to_keep = available;
+  uint32_t discarded = available - samples_to_keep;
+  dsp->sampleRead += discarded;
+  return discarded;
+}

--- a/runner/src/snes/dsp.h
+++ b/runner/src/snes/dsp.h
@@ -110,6 +110,10 @@ void dsp_cycle(Dsp* dsp);
 uint8_t dsp_read(Dsp* dsp, uint8_t adr);
 void dsp_write(Dsp* dsp, uint8_t adr, uint8_t val);
 void dsp_getSamples(Dsp* dsp, int16_t* sampleData, int samplesPerFrame);
+/* Drop queued host-output samples without rewinding SPC/DSP state. Used only
+ * when leaving fast-forward, where buffered samples describe obsolete guest
+ * time and retaining them would create persistent A/V latency. */
+uint32_t dsp_trimSamples(Dsp* dsp, uint32_t samples_to_keep);
 /* Per-voice Gaussian-interpolated sample (canon hardware math). Exposed for the
  * dev-only in-process faithful reference (dsp_shadow) to diff against blargg's
  * reference Gaussian. Pure: reads channel[ch].decodeBuffer[sampleNum..+3], no

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -149,14 +149,10 @@ uint8_t snes_readBBus(Snes* snes, uint8_t adr) {
     return ppu_read(g_ppu, adr);
   }
   if(adr < 0x80) {
-    // APU port read ($2140-$217F). Catch the APU up based on the
-    // main-CPU cycles elapsed since the last APU sync, and return
-    // the live outPort value. RtlApuLock serialises us against the
-    // audio thread's render loop, which advances the APU under the
-    // same lock.
+    // APU port read ($2140-$217F). Synchronize the SPC to this exact guest
+    // timestamp before observing its output-port state.
     RtlApuLock();
-    rtl_accumulate_apu_catchup();
-    snes_catchupApu(snes);
+    rtl_sync_apu_to_cpu_locked();
     uint8_t v = snes->apu->outPorts[adr & 0x3];
     audio_trace_on_cpu_port_read((uint8_t)(adr & 0x3), v);
     RtlApuUnlock();

--- a/tests/runtime_dispatch/apu_port_guest_time_test.c
+++ b/tests/runtime_dispatch/apu_port_guest_time_test.c
@@ -1,0 +1,168 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "apu.h"
+#include "dsp_shadow.h"
+
+uint64_t g_apu_timer0_total_ticks;
+int snes_frame_counter;
+
+static unsigned applied_count;
+
+void audio_trace_on_cpu_port_apply(uint8_t port, uint8_t value) {
+  (void)port;
+  (void)value;
+  applied_count++;
+}
+void audio_trace_on_spc_port_read(uint8_t port, uint8_t value) {
+  (void)port;
+  (void)value;
+}
+void audio_trace_on_spc_port_write(uint8_t port, uint8_t value) {
+  (void)port;
+  (void)value;
+}
+void audio_trace_on_sample(int16_t left, int16_t right, int dropped,
+                           uint32_t ring_fill) {
+  (void)left;
+  (void)right;
+  (void)dropped;
+  (void)ring_fill;
+}
+void audio_trace_on_reg_write(uint8_t address, uint8_t value) {
+  (void)address;
+  (void)value;
+}
+void audio_trace_on_consume(uint64_t read_index, uint32_t count,
+                            uint32_t available_after) {
+  (void)read_index;
+  (void)count;
+  (void)available_after;
+}
+void audio_trace_on_faithful_div(double divergence) { (void)divergence; }
+void audio_trace_on_brr_compare(uint16_t block, uint8_t header, uint8_t sample,
+                                int canon, int reference, int old, int older) {
+  (void)block; (void)header; (void)sample; (void)canon;
+  (void)reference; (void)old; (void)older;
+}
+void audio_trace_on_echo_div(double divergence) { (void)divergence; }
+DspShadow *dsp_shadow_create(void) { return NULL; }
+void dsp_shadow_free(DspShadow *shadow) { (void)shadow; }
+void dsp_shadow_process(DspShadow *shadow, Dsp *dsp, int canonical_left,
+                        int canonical_right, int *out_left, int *out_right) {
+  (void)shadow;
+  (void)dsp;
+  *out_left = canonical_left;
+  *out_right = canonical_right;
+}
+
+static int check(int condition, const char *message) {
+  if (!condition)
+    fprintf(stderr, "FAIL: %s\n", message);
+  return condition ? 0 : 1;
+}
+
+int main(void) {
+  int failures = 0;
+  Apu *apu = apu_init();
+
+  /* SMW writes a nonzero command in one NMI and clears it in the next.
+   * Host callback phase must not shorten that emulated frame. */
+  failures += check(apu_schedulePortWrite(apu, 0, 0x1f, 1000),
+                    "queue first frame command");
+  failures += check(apu_schedulePortWrite(apu, 0, 0x00, 1000 + 17088),
+                    "queue next frame clear");
+  apu_cycle(apu);
+  failures += check(apu->inPorts[0] == 0x1f && applied_count == 1,
+                    "command lands at its first due cycle");
+  for (int i = 1; i < 17088; i++)
+    apu_cycle(apu);
+  failures += check(apu->inPorts[0] == 0x1f && applied_count == 1,
+                    "command remains visible for one emulated frame");
+  apu_cycle(apu);
+  failures += check(apu->inPorts[0] == 0x00 && applied_count == 2,
+                    "clear lands exactly one guest frame later");
+
+  /* A word write shares one guest timestamp. Preserve high-byte then low-byte
+   * insertion order without inventing time between them. */
+  apu_clearPortQueue(apu);
+  failures += check(apu_schedulePortWrite(apu, 1, 0x44, 20000),
+                    "queue word high byte");
+  failures += check(apu_schedulePortWrite(apu, 0, 0x55, 20000),
+                    "queue word low byte");
+  failures += check(apu->portQueue[apu->portQHead].target_cycle ==
+                        apu->portQueue[apu->portQHead + 1].target_cycle &&
+                    apu->portQueue[apu->portQHead].port == 1 &&
+                    apu->portQueue[apu->portQHead + 1].port == 0,
+                    "same-cycle word bytes retain bus order");
+
+  /* If the callback has moved the SPC beyond the old mapping, rebase once and
+   * preserve later guest deltas from the new live point. */
+  apu_clearPortQueue(apu);
+  apu->portClock = 50000;
+  failures += check(apu_schedulePortWrite(apu, 2, 0x80, 30000),
+                    "queue callback-ahead anchor");
+  apu->portQHead = apu->portQTail;
+  apu->portClock = 51000;
+  failures += check(apu_schedulePortWrite(apu, 2, 0x23, 30100),
+                    "rebase callback-ahead event");
+  failures += check(apu_schedulePortWrite(apu, 2, 0x00, 30200),
+                    "queue event after rebase");
+  ApuPortWrite *rebased = &apu->portQueue[(apu->portQTail - 2) &
+                                          (APU_PORT_QUEUE_LEN - 1)];
+  ApuPortWrite *following = &apu->portQueue[(apu->portQTail - 1) &
+                                            (APU_PORT_QUEUE_LEN - 1)];
+  failures += check(rebased->target_cycle == 51000 &&
+                    following->target_cycle == 51100,
+                    "callback-ahead rebase preserves the next guest delta");
+
+  failures += check(apu_runToGuestCycle(apu, 30200, 200) &&
+                    apu->portClock >= 51100 &&
+                    apu->inPorts[2] == 0x00,
+                    "guest-clock sync advances SPC through all due bus events");
+
+  /* Saturation must backpressure the producer rather than prematurely expose
+   * an old command or discard a new one. */
+  apu_clearPortQueue(apu);
+  for (unsigned i = 0; i < APU_PORT_QUEUE_LEN; i++)
+    failures += check(apu_schedulePortWrite(apu, i & 3, (uint8_t)i, 40000 + i),
+                      "fill bounded queue");
+  uint32_t head_before = apu->portQHead;
+  failures += check(!apu_schedulePortWrite(apu, 0, 0xaa, 50000) &&
+                    apu->portQHead == head_before &&
+                    apu_portQueueDepth(apu) == APU_PORT_QUEUE_LEN,
+                    "full queue applies backpressure without mutation");
+
+  /* Declared live HLE uploads synchronize with the running driver instead of
+   * erasing its port state at the transfer boundary. */
+  apu_clearPortQueue(apu);
+  memset(apu->inPorts, 0, sizeof(apu->inPorts));
+  memset(apu->outPorts, 0, sizeof(apu->outPorts));
+  apu->outPorts[0] = 0xaa;
+  apu->outPorts[1] = 0xbb;
+  failures += check(apu_waitForTransferReady(apu, 1, 0xff, 0),
+                    "live upload accepts the driver-ready handshake");
+  apu->outPorts[0] = 0;
+  failures += check(!apu_waitForTransferReady(apu, 1, 0xff, 0) &&
+                    apu->inPorts[1] == 0xff,
+                    "live upload reasserts a request while awaiting ready");
+  apu->outPorts[0] = 0xcc;
+  failures += check(apu_finishHleTransfer(apu, 0x1234, 0) &&
+                    apu->inPorts[0] == 0 && apu->inPorts[1] == 0 &&
+                    apu->inPorts[2] == 0 && apu->inPorts[3] == 0,
+                    "live upload completes CC acknowledgement and clears ports");
+
+  apu->dsp->sampleRead = 100;
+  apu->dsp->sampleWrite = 419;
+  failures += check(dsp_trimSamples(apu->dsp, 64) == 255 &&
+                    apu->dsp->sampleRead == 355 &&
+                    apu->dsp->sampleWrite == 419,
+                    "fast-forward recovery retains only the requested newest PCM");
+
+  apu_free(apu);
+  if (failures)
+    return 1;
+  puts("apu_port_guest_time_test: PASS");
+  return 0;
+}

--- a/tests/runtime_dispatch/run_apu_port_guest_time_test.ps1
+++ b/tests/runtime_dispatch/run_apu_port_guest_time_test.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$out = Join-Path $root "build\apu_port_guest_time_test.exe"
+$gcc = (Get-Command gcc).Source
+$args = @(
+    "-std=c11", "-Wall", "-Wextra", "-Werror",
+    "-Wno-error=unknown-pragmas", "-Wno-error=comment",
+    "-ffunction-sections", "-fdata-sections",
+    "-I$root\runner\src", "-I$root\runner\src\snes",
+    "$root\tests\runtime_dispatch\apu_port_guest_time_test.c",
+    "$root\runner\src\snes\apu.c",
+    "$root\runner\src\snes\spc.c",
+    "$root\runner\src\snes\dsp.c",
+    "-Wl,--gc-sections", "-o", $out
+)
+
+New-Item -ItemType Directory -Force (Split-Path $out) | Out-Null
+Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue
+& $gcc @args
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $out)) {
+    throw "gcc did not produce the APU guest-time test executable"
+}
+& $out
+if ($LASTEXITCODE -ne 0) { throw "APU guest-time test failed" }

--- a/tests/v2/test_cfg_loader.py
+++ b/tests/v2/test_cfg_loader.py
@@ -45,6 +45,19 @@ func SpriteMain 9dac end:9db0 entry_mx:0,0
         os.unlink(path)
 
 
+def test_hle_spc_upload_protocol_mode_parses():
+    path = _write("""\
+bank = 00
+hle_spc_upload 8079 live
+func Upload 8079
+""")
+    try:
+        cfg = load_bank_cfg(path)
+        assert cfg.hle_spc_upload == {0x8079: 'live'}
+    finally:
+        os.unlink(path)
+
+
 def test_func_with_end_directive_parses_end():
     path = _write("""\
 bank = 00

--- a/tests/v2/test_hle_spc_upload_return_abi.py
+++ b/tests/v2/test_hle_spc_upload_return_abi.py
@@ -29,3 +29,14 @@ def test_hle_spc_upload_emits_rts_frame_pop_before_normal_return():
 
     assert src.index('HLE SPC upload RTS pop hardware return frame') < src.index(
         'return RECOMP_RETURN_NORMAL;  /* HLE RTS host return */')
+
+
+def test_hle_spc_upload_live_mode_selects_protocol_preserving_helper():
+    rom = make_lorom_bank0({0x8059: bytes([0x60])})
+    src = emit_function(rom, bank=0, start=0x8059,
+                        entry_m=1, entry_x=1,
+                        func_name='SpcUpload',
+                        hle_spc_upload={0x8059: 'live'})
+
+    assert 'RtlUploadSpcImageFromDpLive(cpu)' in src, src
+    assert 'RtlUploadSpcImageFromDp(cpu)' not in src, src


### PR DESCRIPTION
## Summary

- timestamp CPU-to-APU port writes in guest APU cycles and apply them in-order
- synchronize the live SPC at CPU port reads and exact completed-frame boundaries
- make the host audio callback consume-only so wall time cannot become a competing emulation clock
- preserve live SPC upload handshakes through an explicit `hle_spc_upload ... live` mode
- discard stale PCM after turbo and keep recovery active until 30 consecutive stable frames
- add queue/lag, frame/read sync, underflow, and fast-forward recovery observability

This is the clean current-`main` replacement for #7. It avoids the wall-time/minimum-dwell workaround and fixes both missed commands and post-turbo A/V latency at their shared clocking source.

## Validation

- `cargo test --locked`: 42/42 passed
- `py -3.12 tests/v2/run_tests.py`: 355/355 passed
- `tests/runtime_dispatch/run_apu_port_guest_time_test.ps1`: passed
- trace and trace-free builds: Super Mario World, Mega Man X, Zelda ALttP
- 600-frame process-local turbo bursts on MMX and Zelda:
  - APU queue depth/lag: 0/0
  - audio callback guest-cycle production: 0
  - post-release drops stop
  - post-release PCM occupancy: 534-1069 samples (~17-33 ms)
- ear validation: SMW, MMX, and Zelda all passed normal play, turbo transitions, and post-turbo recovery