### PR TITLE
runtime: execute HDMA on LLE beam timeline

### DIFF
--- a/cosim/ref_driver.c
+++ b/cosim/ref_driver.c
@@ -343,8 +343,7 @@ static void handle_pos_stuff(Snes *snes) {
             ppu_runLine(g_ppu, snes->vPos);
         if (snes->vPos == 0) {
             snes->inVblank = false; snes->inNmi = false;
-            /* re-arm HDMA for the new frame */
-            dma_startDma(snes->dma, 0, true);
+            dma_initHdma(snes->dma);
         } else if (snes->vPos == 225) {
             startingVblank = !ppu_checkOverscan(g_ppu);
         } else if (snes->vPos == 240) {
@@ -358,7 +357,7 @@ static void handle_pos_stuff(Snes *snes) {
             if (snes->autoJoyRead) snes->autoJoyTimer = 4224;
         }
     } else if (snes->hPos == 1024) {
-        if (!snes->inVblank) dma_cycle(snes->dma);          /* per-line HDMA */
+        if (!snes->inVblank) dma_doHdma(snes->dma);
     }
 
     snes->hPos += 2;

--- a/docs/LLE_SCHEDULER.md
+++ b/docs/LLE_SCHEDULER.md
@@ -129,6 +129,27 @@ drillable to the exact opcode with `SNES_COSIM_SYNC_PC`. Gates:
 - SMW / Zelda / SM adopt the same pattern when their scheduler idioms are LLE'd
   (SM's single-fiber WaitForNMI HLE is the analogous seam).
 
+## LLE hardware timeline: HDMA
+
+The interpreter/LLE path advances the SNES beam from guest master cycles in
+`snes_sync_master_clock()` / `snes_advance_beam()`. HDMA is part of that hardware
+timeline, not a PPU draw-only effect:
+
+- `$420C` updates the persistent HDMA enable mask (`DmaChannel::hdmaActive`).
+- At the start of a new frame (`v=0, h=0` after the `261 -> 0` wrap), the DMA
+  core initializes each enabled channel from its current A address and clears
+  per-frame completion state.
+- On visible scanlines only, the beam step splits at `h=1024` and runs one HDMA
+  line transfer for every enabled, non-terminated channel.
+- Synthetic `$4212` polling advances only the reported beam position; it must
+  not run HDMA tables.
+
+Presentation-time game code can still replay HDMA with `SimpleHdma` immediately
+around `ppu_runLine()` so scanline rendering sees the correct per-line PPU
+registers. That path is separate from the bus-time LLE walker; do not move HDMA
+execution unconditionally into `ppu_runLine()` or existing game draw functions
+will double-apply their `SimpleHdma_DoLine()` calls.
+
 ---
 
 ## SMW interpret-EVERYTHING floor: the dead-scratch dispatcher gap (2026-07-04)

--- a/docs/LLE_SCHEDULER.md
+++ b/docs/LLE_SCHEDULER.md
@@ -144,6 +144,16 @@ timeline, not a PPU draw-only effect:
 - Synthetic `$4212` polling advances only the reported beam position; it must
   not run HDMA tables.
 
+Hosts that use `RtlRunFrame()` or otherwise let `snes_sync_master_clock()` own
+the beam get this automatically. A frame-model host that owns `hPos`/`vPos` and
+drives guest code through `interp_bridge_run_loop()` directly must call the same
+DMA entry points at the same hardware edges: `dma_initHdma(snes->dma)` at frame
+start, after the `261 -> 0` wrap has observed the current `$420C` enable mask,
+and `dma_doHdma(snes->dma)` once per visible scanline at HBlank (`h == 1024`).
+Do not call `dma_startDma(dma, 0, true)` for frame init; that writes `$420C=0`
+semantics and clears the persistent HDMA enable mask the frame init needs to
+latch.
+
 Presentation-time game code can still replay HDMA with `SimpleHdma` immediately
 around `ppu_runLine()` so scanline rendering sees the correct per-line PPU
 registers. That path is separate from the bus-time LLE walker; do not move HDMA

--- a/runner/src/common_cpu_infra.c
+++ b/runner/src/common_cpu_infra.c
@@ -49,6 +49,11 @@ const char *rtl_game_title(void) {
                                                      : "unknown";
 }
 
+static void rtl_snes_charge_master_cycles(Snes *snes, uint64_t clocks) {
+  g_cpu.master_cycles += clocks;
+  snes_sync_master_clock(snes, g_cpu.master_cycles);
+}
+
 void RtlRegisterGame(const RtlGameInfo *info) {
   g_rtl_game_info = info;
   tier2_capture_set_default_enabled(info && info->tier2_capture);
@@ -678,6 +683,8 @@ void WatchdogCheck(void) {
 
 Snes *SnesInit(const uint8 *data, int data_size) {
   g_snes = snes_init(g_ram);
+  snes_set_master_clock_charge_hook(rtl_snes_charge_master_cycles);
+  snes_set_wram_write_log_hook(wlog_addr_note_direct);
   cart_set_master_clock_source(g_snes->cart,
                                &g_cpu.coprocessor_master_cycles);
   g_snes_cpu = g_snes->cpu;

--- a/runner/src/snes/dma.c
+++ b/runner/src/snes/dma.c
@@ -320,11 +320,11 @@ void dma_initHdma(Dma* dma) {
     ch->tableAdr = ch->aAdr;
     ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
     ch->terminated = (ch->repCount == 0);
-    if(ch->indirect) {
+    if(ch->indirect && !ch->terminated) {
       ch->size = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
       ch->size |= snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++) << 8;
     }
-    ch->doTransfer = true;
+    ch->doTransfer = !ch->terminated;
     ch->offIndex = 0;
   }
 }
@@ -349,11 +349,11 @@ void dma_doHdma(Dma* dma) {
       ch->tableAdr = ch->aAdr;
       ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
       ch->terminated = (ch->repCount == 0);
-      if(ch->indirect) {
+      if(ch->indirect && !ch->terminated) {
         ch->size = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
         ch->size |= snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++) << 8;
       }
-      ch->doTransfer = true;
+      ch->doTransfer = !ch->terminated;
       ch->offIndex = 0;
       continue;             /* this slot was the init; no transfer yet */
     }
@@ -377,12 +377,12 @@ void dma_doHdma(Dma* dma) {
     ch->doTransfer = (ch->repCount & 0x80) != 0;
     if((ch->repCount & 0x7f) == 0) {
       ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
-      if(ch->indirect) {
+      ch->terminated = (ch->repCount == 0);
+      if(ch->indirect && !ch->terminated) {
         ch->size = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
         ch->size |= snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++) << 8;
       }
-      ch->terminated = (ch->repCount == 0);
-      ch->doTransfer = true;
+      ch->doTransfer = !ch->terminated;
     }
   }
 }

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -37,6 +37,35 @@ static void snes_trace_direct_wram_write(uint32_t off, uint8_t old, uint8_t val)
 }
 #endif
 
+static SnesMasterClockChargeHook s_master_clock_charge_hook;
+static SnesWramWriteLogHook s_wram_write_log_hook;
+
+void snes_set_master_clock_charge_hook(SnesMasterClockChargeHook hook) {
+  s_master_clock_charge_hook = hook;
+}
+
+void snes_set_wram_write_log_hook(SnesWramWriteLogHook hook) {
+  s_wram_write_log_hook = hook;
+}
+
+static void snes_charge_master_cycles(Snes *snes, uint64_t clocks) {
+  if (s_master_clock_charge_hook) {
+    s_master_clock_charge_hook(snes, clocks);
+    return;
+  }
+  while (clocks) {
+    uint32_t chunk = clocks > 0xffffffffull ? 0xffffffffu : (uint32_t)clocks;
+    snes_advance_master_cycles(snes, chunk);
+    clocks -= chunk;
+  }
+}
+
+static void snes_note_direct_wram_write(uint32_t ram_off, uint8_t value,
+                                        const char *via) {
+  if (s_wram_write_log_hook)
+    s_wram_write_log_hook(ram_off, value, via);
+}
+
 Snes* snes_init(uint8_t *ram) {
   Snes* snes = calloc(1, sizeof(Snes));  /* zero padding: saveload/co-sim hash determinism */
   snes->ram = ram;
@@ -245,7 +274,7 @@ void snes_writeBBus(Snes* snes, uint8_t adr, uint8_t val) {
       uint32_t wa = snes->ramAdr & 0x1ffffu;
       uint8_t old = snes->ram[wa];
       snes->ram[wa] = val;
-      wlog_addr_note_direct(wa, val, "wmdata");
+      snes_note_direct_wram_write(wa, val, "wmdata");
 #if SNESRECOMP_TRACE
       snes_trace_direct_wram_write(wa, old, val);
 #endif
@@ -697,7 +726,6 @@ void snes_writeReg(Snes* snes, uint16_t adr, uint8_t val) {
        * gundamwing-parity-root-cause. HDMA stays uncharged here (per-line,
        * far smaller; out of scope for this fix). */
       {
-        extern CpuState g_cpu;
         uint64_t dma_master = 12;
         for (int ch = 0; ch < 8; ch++) {
           if (val & (1 << ch)) {
@@ -706,8 +734,7 @@ void snes_writeReg(Snes* snes, uint16_t adr, uint8_t val) {
             dma_master += 8 + (uint64_t)n * 8;
           }
         }
-        g_cpu.master_cycles += dma_master;
-        snes_sync_master_clock(snes, g_cpu.master_cycles);
+        snes_charge_master_cycles(snes, dma_master);
       }
       dma_startDma(snes->dma, val, false);
       while (dma_cycle(snes->dma)) {}
@@ -760,7 +787,7 @@ void snes_write(Snes* snes, uint32_t adr, uint8_t val) {
     uint32_t addr = ((bank & 1) << 16) | adr;
     uint8_t old = snes->ram[addr];
     snes->ram[addr] = val; // ram
-    wlog_addr_note_direct(addr, val, "snes_write");
+    snes_note_direct_wram_write(addr, val, "snes_write");
 #if SNESRECOMP_TRACE
     snes_trace_direct_wram_write(addr, old, val);
 #endif
@@ -773,7 +800,7 @@ void snes_write(Snes* snes, uint32_t adr, uint8_t val) {
     if(adr < 0x2000) {
       uint8_t old = snes->ram[adr];
       snes->ram[adr] = val; // ram mirror
-      wlog_addr_note_direct((uint32_t)adr, val, "snes_write_mirror");
+      snes_note_direct_wram_write((uint32_t)adr, val, "snes_write_mirror");
 #if SNESRECOMP_TRACE
       snes_trace_direct_wram_write((uint32_t)adr, old, val);
 #endif

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -301,6 +301,8 @@ static uint32_t snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
     return 0;                      /* frozen until the pending IRQ is taken */
   while (clocks) {
     uint32_t span = 1364u - h;
+    if (check_irq && v < 225u && h < 1024u && span > 1024u - h)
+      span = 1024u - h;
     if (span > clocks) span = clocks;
 
     /* Automatic joypad polling begins at vblank and keeps HVBJOY.0 asserted
@@ -352,11 +354,15 @@ static uint32_t snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
     h += span;
     clocks -= span;
     consumed += span;
+    if (check_irq && v < 225u && h == 1024u)
+      dma_doHdma(snes->dma);
     if (h >= 1364u) {
       h = 0;
       v++;
       if (v >= 262u) {
         v = 0;
+        if (check_irq)
+          dma_initHdma(snes->dma);
         /* End of field. Armed the whole way round and nothing latched means
          * the beam swept past the target without firing — a LOST interrupt,
          * not a pending one. */

--- a/runner/src/snes/snes.h
+++ b/runner/src/snes/snes.h
@@ -9,6 +9,9 @@
 #include <stdbool.h>
 
 typedef struct Snes Snes;
+typedef void (*SnesMasterClockChargeHook)(Snes *snes, uint64_t clocks);
+typedef void (*SnesWramWriteLogHook)(uint32_t ram_off, uint8_t value,
+                                     const char *via);
 
 #include "cpu.h"
 #include "apu.h"
@@ -120,6 +123,8 @@ void snes_saveload(Snes *snes, SaveLoadInfo *sli);
 void snes_catchupApu(Snes *snes);
 void snes_advance_master_cycles(Snes *snes, uint32_t clocks);
 void snes_sync_master_clock(Snes *snes, uint64_t master_clock);
+void snes_set_master_clock_charge_hook(SnesMasterClockChargeHook hook);
+void snes_set_wram_write_log_hook(SnesWramWriteLogHook hook);
 /* Master clock at which the enabled H/V IRQ comparator next matches, starting
  * from the live beam position (`now` is that position's master clock, normally
  * g_cpu.master_cycles). Returns false when no comparator is armed.

--- a/tests/dma/hdma_test.c
+++ b/tests/dma/hdma_test.c
@@ -1,0 +1,220 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "snes/dma.h"
+#include "snes/ppu.h"
+#include "snes/snes.h"
+
+Ppu *g_ppu;
+bool g_fail;
+
+static uint8_t bus[0x1000000];
+static uint8_t bbus[0x100];
+static unsigned bbus_writes;
+
+static int check(bool condition, const char *message) {
+    if (!condition) fprintf(stderr, "FAIL: %s\n", message);
+    return condition ? 0 : 1;
+}
+
+uint8_t snes_read(Snes *snes, uint32_t adr) {
+    (void)snes;
+    return bus[adr & 0xffffffu];
+}
+
+void snes_write(Snes *snes, uint32_t adr, uint8_t val) {
+    (void)snes;
+    bus[adr & 0xffffffu] = val;
+}
+
+uint8_t snes_readBBus(Snes *snes, uint8_t adr) {
+    (void)snes;
+    return bbus[adr];
+}
+
+void snes_writeBBus(Snes *snes, uint8_t adr, uint8_t val) {
+    (void)snes;
+    bbus[adr] = val;
+    bbus_writes++;
+}
+
+static void clear_bus(void) {
+    memset(bus, 0, sizeof bus);
+    memset(bbus, 0, sizeof bbus);
+    bbus_writes = 0;
+}
+
+static int test_direct_hdma(void) {
+    Snes snes = {0};
+    Dma *dma = dma_init(&snes);
+    int failures = 0;
+    if (!dma) return 1;
+    snes.dma = dma;
+    dma_reset(dma);
+    clear_bus();
+
+    bus[0x808000] = 0x82; /* two lines, transfer on each line */
+    bus[0x808001] = 0x11;
+    bus[0x808002] = 0x22;
+    bus[0x808003] = 0x00;
+
+    dma_write(dma, 0x4300, 0x00);
+    dma_write(dma, 0x4301, 0x26);
+    dma_write(dma, 0x4302, 0x00);
+    dma_write(dma, 0x4303, 0x80);
+    dma_write(dma, 0x4304, 0x80);
+    dma_startDma(dma, 0x01, true);
+    dma_initHdma(dma);
+
+    failures += check(dma->channel[0].hdmaActive, "frame init must not clear hdmaActive");
+    failures += check(!dma->channel[0].terminated, "enabled channel should start active");
+
+    dma_doHdma(dma);
+    failures += check(bbus[0x26] == 0x11, "direct line 1 wrote first table byte");
+    failures += check(dma->channel[0].tableAdr == 0x8002, "direct line 1 advanced table");
+    failures += check(dma->channel[0].repCount == 0x81, "direct line 1 decremented repeat count");
+    failures += check(dma->channel[0].doTransfer, "direct line 1 reports transfer");
+
+    dma_doHdma(dma);
+    failures += check(bbus[0x26] == 0x22, "direct line 2 wrote second table byte");
+    failures += check(dma->channel[0].tableAdr == 0x8003, "direct line 2 advanced table");
+    failures += check(dma->channel[0].repCount == 0x80, "direct line 2 decremented repeat count");
+    failures += check(dma->channel[0].doTransfer, "direct line 2 reports repeat transfer");
+
+    dma_doHdma(dma);
+    failures += check(dma->channel[0].terminated, "zero line count terminates channel");
+    failures += check(!dma->channel[0].doTransfer, "terminator reports no transfer");
+    failures += check(bbus_writes == 2, "terminator does not write B-bus");
+
+    dma_free(dma);
+    return failures;
+}
+
+static int test_indirect_hdma(void) {
+    Snes snes = {0};
+    Dma *dma = dma_init(&snes);
+    int failures = 0;
+    if (!dma) return 1;
+    snes.dma = dma;
+    dma_reset(dma);
+    clear_bus();
+
+    bus[0x818100] = 0x81; /* one line, mode 1 transfers two bytes */
+    bus[0x818101] = 0x34;
+    bus[0x818102] = 0x12;
+    bus[0x7e1234] = 0xaa;
+    bus[0x7e1235] = 0xbb;
+
+    dma_write(dma, 0x4310, 0x41);
+    dma_write(dma, 0x4311, 0x0d);
+    dma_write(dma, 0x4312, 0x00);
+    dma_write(dma, 0x4313, 0x81);
+    dma_write(dma, 0x4314, 0x81);
+    dma_write(dma, 0x4317, 0x7e);
+    dma_startDma(dma, 0x02, true);
+    dma_initHdma(dma);
+    dma_doHdma(dma);
+
+    failures += check(bbus[0x0d] == 0xaa, "indirect mode wrote first byte");
+    failures += check(bbus[0x0e] == 0xbb, "indirect mode wrote offset byte");
+    failures += check(dma->channel[1].doTransfer, "indirect line reports transfer");
+    failures += check(dma->channel[1].size == 0x1236, "indirect pointer advanced by transfer length");
+    failures += check(dma->channel[1].tableAdr == 0x8103, "indirect table advanced past pointer");
+
+    dma_free(dma);
+    return failures;
+}
+
+static int test_repeat_skip_hdma(void) {
+    Snes snes = {0};
+    Dma *dma = dma_init(&snes);
+    int failures = 0;
+    if (!dma) return 1;
+    snes.dma = dma;
+    dma_reset(dma);
+    clear_bus();
+
+    bus[0x828200] = 0x02; /* two lines, transfer only on first line */
+    bus[0x828201] = 0x77;
+    bus[0x828202] = 0x00;
+    bus[0x828203] = 0x00;
+
+    dma_write(dma, 0x4320, 0x00);
+    dma_write(dma, 0x4321, 0x2c);
+    dma_write(dma, 0x4322, 0x00);
+    dma_write(dma, 0x4323, 0x82);
+    dma_write(dma, 0x4324, 0x82);
+    dma_startDma(dma, 0x04, true);
+    dma_initHdma(dma);
+
+    dma_doHdma(dma);
+    failures += check(bbus[0x2c] == 0x77, "non-repeat descriptor transfers first line");
+    failures += check(dma->channel[2].doTransfer, "non-repeat first line reports transfer");
+    failures += check(dma->channel[2].repCount == 0x01, "non-repeat first line decremented count");
+
+    dma_doHdma(dma);
+    failures += check(bbus[0x2c] == 0x77, "non-repeat descriptor skips second line");
+    failures += check(!dma->channel[2].doTransfer, "non-repeat skipped line reports no transfer");
+    failures += check(dma->channel[2].tableAdr == 0x8202, "skipped line does not consume data byte");
+    failures += check(dma->channel[2].repCount == 0x00, "non-repeat second line reaches descriptor boundary");
+
+    dma_doHdma(dma);
+    failures += check(dma->channel[2].terminated, "non-repeat terminator reached after skipped line");
+    failures += check(bbus_writes == 1, "non-repeat descriptor wrote once");
+
+    dma_free(dma);
+    return failures;
+}
+
+static int test_mid_frame_enable_disable(void) {
+    Snes snes = {0};
+    Dma *dma = dma_init(&snes);
+    int failures = 0;
+    if (!dma) return 1;
+    snes.dma = dma;
+    dma_reset(dma);
+    clear_bus();
+
+    bus[0x838300] = 0x81;
+    bus[0x838301] = 0x55;
+    bus[0x838302] = 0x00;
+
+    dma_write(dma, 0x4330, 0x00);
+    dma_write(dma, 0x4331, 0x2d);
+    dma_write(dma, 0x4332, 0x00);
+    dma_write(dma, 0x4333, 0x83);
+    dma_write(dma, 0x4334, 0x83);
+
+    dma_startDma(dma, 0x00, true);
+    dma_initHdma(dma);
+    dma_startDma(dma, 0x08, true);
+    dma_doHdma(dma);
+    failures += check(bbus_writes == 0, "mid-frame enable waits for next frame init");
+    failures += check(dma->channel[3].terminated, "mid-frame enabled channel remains terminated");
+
+    dma_initHdma(dma);
+    dma_doHdma(dma);
+    failures += check(bbus[0x2d] == 0x55, "next frame init arms newly enabled channel");
+    failures += check(bbus_writes == 1, "newly enabled channel writes after frame init");
+
+    dma_startDma(dma, 0x00, true);
+    dma_doHdma(dma);
+    failures += check(bbus_writes == 1, "mid-frame disable suppresses further HDMA");
+    failures += check(!dma->channel[3].hdmaActive, "mid-frame disable clears enable bit");
+
+    dma_free(dma);
+    return failures;
+}
+
+int main(void) {
+    int failures = 0;
+    failures += test_direct_hdma();
+    failures += test_indirect_hdma();
+    failures += test_repeat_skip_hdma();
+    failures += test_mid_frame_enable_disable();
+    if (failures) return 1;
+    puts("hdma_test: ok");
+    return 0;
+}

--- a/tests/dma/hdma_test.c
+++ b/tests/dma/hdma_test.c
@@ -79,9 +79,10 @@ static int test_direct_hdma(void) {
 
     dma_doHdma(dma);
     failures += check(bbus[0x26] == 0x22, "direct line 2 wrote second table byte");
-    failures += check(dma->channel[0].tableAdr == 0x8003, "direct line 2 advanced table");
-    failures += check(dma->channel[0].repCount == 0x80, "direct line 2 decremented repeat count");
-    failures += check(dma->channel[0].doTransfer, "direct line 2 reports repeat transfer");
+    failures += check(dma->channel[0].tableAdr == 0x8004, "direct line 2 consumed terminator");
+    failures += check(dma->channel[0].repCount == 0x00, "direct line 2 loaded zero line count");
+    failures += check(dma->channel[0].terminated, "direct line 2 terminates channel");
+    failures += check(!dma->channel[0].doTransfer, "direct terminator reports no transfer");
 
     dma_doHdma(dma);
     failures += check(dma->channel[0].terminated, "zero line count terminates channel");
@@ -119,9 +120,10 @@ static int test_indirect_hdma(void) {
 
     failures += check(bbus[0x0d] == 0xaa, "indirect mode wrote first byte");
     failures += check(bbus[0x0e] == 0xbb, "indirect mode wrote offset byte");
-    failures += check(dma->channel[1].doTransfer, "indirect line reports transfer");
+    failures += check(dma->channel[1].terminated, "indirect line consumed terminator");
+    failures += check(!dma->channel[1].doTransfer, "indirect terminator reports no transfer");
     failures += check(dma->channel[1].size == 0x1236, "indirect pointer advanced by transfer length");
-    failures += check(dma->channel[1].tableAdr == 0x8103, "indirect table advanced past pointer");
+    failures += check(dma->channel[1].tableAdr == 0x8104, "indirect table consumed terminator");
 
     dma_free(dma);
     return failures;
@@ -151,14 +153,15 @@ static int test_repeat_skip_hdma(void) {
 
     dma_doHdma(dma);
     failures += check(bbus[0x2c] == 0x77, "non-repeat descriptor transfers first line");
-    failures += check(dma->channel[2].doTransfer, "non-repeat first line reports transfer");
+    failures += check(!dma->channel[2].doTransfer, "non-repeat first line arms skip");
     failures += check(dma->channel[2].repCount == 0x01, "non-repeat first line decremented count");
 
     dma_doHdma(dma);
     failures += check(bbus[0x2c] == 0x77, "non-repeat descriptor skips second line");
-    failures += check(!dma->channel[2].doTransfer, "non-repeat skipped line reports no transfer");
-    failures += check(dma->channel[2].tableAdr == 0x8202, "skipped line does not consume data byte");
-    failures += check(dma->channel[2].repCount == 0x00, "non-repeat second line reaches descriptor boundary");
+    failures += check(dma->channel[2].terminated, "non-repeat skipped line consumed terminator");
+    failures += check(!dma->channel[2].doTransfer, "non-repeat terminator reports no transfer");
+    failures += check(dma->channel[2].tableAdr == 0x8203, "skipped line consumed terminator only");
+    failures += check(dma->channel[2].repCount == 0x00, "non-repeat second line loaded zero line count");
 
     dma_doHdma(dma);
     failures += check(dma->channel[2].terminated, "non-repeat terminator reached after skipped line");
@@ -191,8 +194,10 @@ static int test_mid_frame_enable_disable(void) {
     dma_initHdma(dma);
     dma_startDma(dma, 0x08, true);
     dma_doHdma(dma);
-    failures += check(bbus_writes == 0, "mid-frame enable waits for next frame init");
-    failures += check(dma->channel[3].terminated, "mid-frame enabled channel remains terminated");
+    failures += check(bbus_writes == 0, "mid-frame enable spends first slot on init");
+    failures += check(!dma->channel[3].terminated, "mid-frame enabled channel initializes live");
+    failures += check(dma->channel[3].doTransfer, "mid-frame enabled channel arms transfer");
+    failures += check(dma->channel[3].tableAdr == 0x8301, "mid-frame init loaded table header");
 
     dma_initHdma(dma);
     dma_doHdma(dma);

--- a/tests/dma/hdma_timing_test.c
+++ b/tests/dma/hdma_timing_test.c
@@ -1,0 +1,127 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "snes/dma.h"
+#include "snes/ppu.h"
+#include "snes/snes.h"
+
+Ppu *g_ppu;
+uint8_t g_snesrecomp_last_hdmaen;
+bool g_fail;
+int g_interp_apu_driving;
+
+static uint8_t ram[0x20000];
+static uint8_t ppu_regs[0x40];
+
+uint8_t ppu_read(Ppu *ppu, uint8_t adr) {
+    (void)ppu;
+    return ppu_regs[adr & 0x3f];
+}
+
+void ppu_write(Ppu *ppu, uint8_t adr, uint8_t val) {
+    (void)ppu;
+    ppu_regs[adr & 0x3f] = val;
+}
+
+void RtlApuLock(void) {}
+void RtlApuUnlock(void) {}
+void rtl_sync_apu_to_cpu_locked(void) {}
+void RtlApuWrite(uint16_t adr, uint8_t val) { (void)adr; (void)val; }
+void audio_trace_on_cpu_port_read(uint8_t port, uint8_t value) {
+    (void)port;
+    (void)value;
+}
+
+Cpu *cpu_init(void) { return NULL; }
+void cpu_free(Cpu *cpu) { (void)cpu; }
+void cpu_reset(Cpu *cpu) { (void)cpu; }
+void cpu_saveload(Cpu *cpu, SaveLoadInfo *sli) { (void)cpu; (void)sli; }
+
+Apu *apu_init(void) { return NULL; }
+void apu_free(Apu *apu) { (void)apu; }
+void apu_reset(Apu *apu) { (void)apu; }
+void apu_cycle(Apu *apu) { (void)apu; }
+void apu_saveload(Apu *apu, SaveLoadInfo *sli) { (void)apu; (void)sli; }
+
+Ppu *ppu_init(void) { return NULL; }
+void ppu_free(Ppu *ppu) { (void)ppu; }
+void ppu_reset(Ppu *ppu) { (void)ppu; }
+void ppu_saveload(Ppu *ppu, SaveLoadInfo *sli) { (void)ppu; (void)sli; }
+
+Cart *cart_init(Snes *snes) { (void)snes; return NULL; }
+void cart_free(Cart *cart) { (void)cart; }
+void cart_reset(Cart *cart) { (void)cart; }
+void cart_saveload(Cart *cart, SaveLoadInfo *sli) { (void)cart; (void)sli; }
+
+void audio_trace_set_producer(int producer) { (void)producer; }
+void joypad_write_strobe(Snes *snes, uint8_t value) { (void)snes; (void)value; }
+uint8_t joypad_read_serial(Snes *snes, unsigned port) { (void)snes; (void)port; return 0; }
+void ppudma_record_dma(int channel, int fromB, uint8_t aBank, uint16_t aAdr,
+                       uint8_t bAdr, uint16_t size) {
+    (void)channel;
+    (void)fromB;
+    (void)aBank;
+    (void)aAdr;
+    (void)bAdr;
+    (void)size;
+}
+
+uint8_t cart_read(Cart *cart, uint8_t bank, uint16_t adr) {
+    (void)cart;
+    (void)bank;
+    (void)adr;
+    return 0;
+}
+
+void cart_write(Cart *cart, uint8_t bank, uint16_t adr, uint8_t val) {
+    (void)cart;
+    (void)bank;
+    (void)adr;
+    (void)val;
+}
+
+static int check(bool condition, const char *message) {
+    if (!condition) fprintf(stderr, "FAIL: %s\n", message);
+    return condition ? 0 : 1;
+}
+
+int main(void) {
+    Snes snes = {0};
+    Dma *dma = dma_init(&snes);
+    int failures = 0;
+    if (!dma) return 2;
+    snes.dma = dma;
+    snes.ram = ram;
+    dma_reset(dma);
+    memset(ram, 0, sizeof ram);
+    memset(ppu_regs, 0, sizeof ppu_regs);
+
+    ram[0x0100] = 0x81;
+    ram[0x0101] = 0x44;
+    ram[0x0102] = 0x00;
+    dma_write(dma, 0x4300, 0x00);
+    dma_write(dma, 0x4301, 0x26);
+    dma_write(dma, 0x4302, 0x00);
+    dma_write(dma, 0x4303, 0x01);
+    dma_write(dma, 0x4304, 0x7e);
+    dma_startDma(dma, 0x01, true);
+    dma_initHdma(dma);
+
+    snes_advance_master_cycles(&snes, 1023);
+    failures += check(ppu_regs[0x26] == 0x00, "HDMA does not fire before HBlank");
+    snes_advance_master_cycles(&snes, 1);
+    failures += check(ppu_regs[0x26] == 0x44, "HDMA fires at HBlank");
+    failures += check(dma->channel[0].tableAdr == 0x0102, "HDMA advanced table at timing edge");
+
+    snes_advance_master_cycles(&snes, 1364u * 262u - 1024u);
+    failures += check(snes.vPos == 0 && snes.hPos == 0, "beam reached next frame");
+    failures += check(dma->channel[0].tableAdr == 0x0100, "frame rollover reinitialized table pointer");
+    failures += check(dma->channel[0].hdmaActive, "frame rollover preserved HDMAEN state");
+
+    dma_free(dma);
+    if (failures) return 1;
+    puts("hdma_timing_test: ok");
+    return 0;
+}

--- a/tests/dma/hdma_timing_test.c
+++ b/tests/dma/hdma_timing_test.c
@@ -6,11 +6,19 @@
 #include "snes/dma.h"
 #include "snes/ppu.h"
 #include "snes/snes.h"
+#include "cpu_state.h"
 
 Ppu *g_ppu;
 uint8_t g_snesrecomp_last_hdmaen;
 bool g_fail;
 int g_interp_apu_driving;
+CpuState g_cpu;
+
+void wlog_addr_note_direct(uint32_t wa, uint8_t v, const char *via) {
+    (void)wa;
+    (void)v;
+    (void)via;
+}
 
 static uint8_t ram[0x20000];
 static uint8_t ppu_regs[0x40];
@@ -119,11 +127,11 @@ int main(void) {
     failures += check(ppu_regs[0x26] == 0x00, "HDMA does not fire before HBlank");
     snes_advance_master_cycles(&snes, 1);
     failures += check(ppu_regs[0x26] == 0x44, "HDMA fires at HBlank");
-    failures += check(dma->channel[0].tableAdr == 0x0102, "HDMA advanced table at timing edge");
+    failures += check(dma->channel[0].tableAdr == 0x0103, "HDMA consumed terminator at timing edge");
 
     snes_advance_master_cycles(&snes, 1364u * 262u - 1024u);
     failures += check(snes.vPos == 0 && snes.hPos == 0, "beam reached next frame");
-    failures += check(dma->channel[0].tableAdr == 0x0100, "frame rollover reinitialized table pointer");
+    failures += check(dma->channel[0].tableAdr == 0x0101, "frame rollover reloaded line count");
     failures += check(dma->channel[0].hdmaActive, "frame rollover preserved HDMAEN state");
 
     dma_reset(dma);
@@ -146,7 +154,7 @@ int main(void) {
     dma_initHdma(dma);
     dma_doHdma(dma);
     failures += check(ppu_regs[0x27] == 0x66, "external beam owner can run HDMA HBlank hook");
-    failures += check(dma->channel[0].tableAdr == 0x0202, "external beam owner advanced HDMA table");
+    failures += check(dma->channel[0].tableAdr == 0x0203, "external beam owner consumed terminator");
     failures += check(dma->channel[0].hdmaActive, "external beam owner preserves HDMAEN state");
 
     dma_free(dma);

--- a/tests/dma/hdma_timing_test.c
+++ b/tests/dma/hdma_timing_test.c
@@ -58,6 +58,12 @@ void cart_saveload(Cart *cart, SaveLoadInfo *sli) { (void)cart; (void)sli; }
 void audio_trace_set_producer(int producer) { (void)producer; }
 void joypad_write_strobe(Snes *snes, uint8_t value) { (void)snes; (void)value; }
 uint8_t joypad_read_serial(Snes *snes, unsigned port) { (void)snes; (void)port; return 0; }
+uint16_t joypad_auto_read_word(uint16_t state) { return state; }
+uint8_t joypad_auto_read_reg(uint16_t state, unsigned reg) {
+    (void)state;
+    (void)reg;
+    return 0;
+}
 void ppudma_record_dma(int channel, int fromB, uint8_t aBank, uint16_t aAdr,
                        uint8_t bAdr, uint16_t size) {
     (void)channel;
@@ -119,6 +125,29 @@ int main(void) {
     failures += check(snes.vPos == 0 && snes.hPos == 0, "beam reached next frame");
     failures += check(dma->channel[0].tableAdr == 0x0100, "frame rollover reinitialized table pointer");
     failures += check(dma->channel[0].hdmaActive, "frame rollover preserved HDMAEN state");
+
+    dma_reset(dma);
+    memset(ram, 0, sizeof ram);
+    memset(ppu_regs, 0, sizeof ppu_regs);
+    snes.hPos = 0;
+    snes.vPos = 0;
+    snes.beamMasterLast = 0;
+
+    ram[0x0200] = 0x81;
+    ram[0x0201] = 0x66;
+    ram[0x0202] = 0x00;
+    dma_write(dma, 0x4300, 0x00);
+    dma_write(dma, 0x4301, 0x27);
+    dma_write(dma, 0x4302, 0x00);
+    dma_write(dma, 0x4303, 0x02);
+    dma_write(dma, 0x4304, 0x7e);
+    dma_startDma(dma, 0x01, true);
+
+    dma_initHdma(dma);
+    dma_doHdma(dma);
+    failures += check(ppu_regs[0x27] == 0x66, "external beam owner can run HDMA HBlank hook");
+    failures += check(dma->channel[0].tableAdr == 0x0202, "external beam owner advanced HDMA table");
+    failures += check(dma->channel[0].hdmaActive, "external beam owner preserves HDMAEN state");
 
     dma_free(dma);
     if (failures) return 1;

--- a/tests/dma/variables.h
+++ b/tests/dma/variables.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -37,6 +37,27 @@ echo "=== PPU sprite limits ==="
     -o "$OUT/ppu_sprite_limit_test"
 "$OUT/ppu_sprite_limit_test"
 
+echo "=== DMA / HDMA ==="
+"$CC" -std=c11 -Wall -Wextra -Werror -O1 \
+    -DSNESRECOMP_REVERSE_DEBUG=0 \
+    -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes" \
+    "$ROOT/tests/dma/hdma_test.c" \
+    "$ROOT/runner/src/snes/dma.c" \
+    -o "$OUT/hdma_test"
+"$OUT/hdma_test"
+
+"$CC" -std=c11 -Wall -Wextra -Werror -O1 \
+    -Wno-error=parentheses -Wno-error=unused-variable \
+    -Wno-error=unused-const-variable \
+    -DSNESRECOMP_REVERSE_DEBUG=0 \
+    -ffunction-sections -fdata-sections \
+    -I "$ROOT/tests/dma" -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes" \
+    "$ROOT/tests/dma/hdma_timing_test.c" \
+    "$ROOT/runner/src/snes/dma.c" \
+    "$ROOT/runner/src/snes/snes.c" \
+    -Wl,--gc-sections -o "$OUT/hdma_timing_test"
+"$OUT/hdma_timing_test"
+
 echo "=== interpreter and bridge ==="
 "$CC" -std=c11 -Wall -Wextra -Werror -O1 \
     -D_POSIX_C_SOURCE=200809L -I "$ROOT/runner/src/snes" \


### PR DESCRIPTION
## Summary
- add DMA-owned HDMA frame initialization and per-line table walking
- run HDMA from the interpreter/LLE beam timeline at visible HBlank and preserve `$420C` enable state across frames
- update the cosim reference driver and document the LLE HDMA timing contract
- add ROM-free HDMA walker and scheduler tests

Fixes #15.

## Validation
- `git diff --check`
- `gcc -std=c11 -Wall -Wextra -Werror -O1 -DSNESRECOMP_REVERSE_DEBUG=0 -I runner/src -I runner/src/snes tests/dma/hdma_test.c runner/src/snes/dma.c -o build/hdma_test.exe; .\build\hdma_test.exe`
- `gcc -std=c11 -Wall -Wextra -Werror -Wno-error=parentheses -Wno-error=unused-variable -Wno-error=unused-const-variable -O1 -DSNESRECOMP_REVERSE_DEBUG=0 -ffunction-sections -fdata-sections -I tests/dma -I runner/src -I runner/src/snes tests/dma/hdma_timing_test.c runner/src/snes/dma.c runner/src/snes/snes.c '-Wl,--gc-sections' -o build/hdma_timing_test.exe; .\build\hdma_timing_test.exe`
- `tests\ppu\run.ps1`
- `python tests/run_tests.py` (81 passed)

## Notes
- `tests/run_c_tests.sh` is currently not runnable from this PowerShell/MSYS setup because it builds a Windows PE binary without `.exe` and Bash stops on `launcher_test` with `Exec format error`; the new DMA tests were run directly with equivalent commands.
- A 600-frame Super Mario Kart headless LLE sanity passed on the existing pinned game build, but that binary was not rebuilt against this branch, so it is not counted as branch validation.