### PR TITLE
joypad: cover auto-read register byte order

### DIFF
--- a/runner/src/keybinds.c
+++ b/runner/src/keybinds.c
@@ -257,7 +257,8 @@ void keybinds_save(void) {
     write_defaults(s_ini_path);   /* writes the CURRENT s_binds, header included */
 }
 
-/* SNES joypad bitmask layout — matches $4218/$4219 (low/high byte) packing.
+/* Keyboard-local joypad bitmask layout; converted to the runner's serial
+ * controller mask by the desktop host before RtlRunFrame().
  * Returns 0 if either `keys` is NULL or player is out of range. */
 uint16_t keybinds_read_player(const uint8_t *keys, int player) {
     if (!keys) return 0;

--- a/runner/src/keybinds.h
+++ b/runner/src/keybinds.h
@@ -13,21 +13,23 @@ extern "C" {
  * Layout matches the SNES gamepad: A, B, X, Y, L, R, Start, Select, and
  * the d-pad. Two players. Each button maps to one SDL_Scancode.
  *
- * The button bitmask returned by keybinds_read_player() uses the same
- * 12-bit layout as SMW's $4218/$4219 joypad register pair, low byte first:
+ * The button bitmask returned by keybinds_read_player() is a keyboard-local
+ * layout consumed by the desktop host's remap table. It is not the
+ * RtlRunFrame/controller mask and it is not the SNES automatic-joypad word
+ * returned from $4218/$4219.
  *
- *   bit  0: R              (high byte, $4219 bit 4)
- *   bit  1: L              (high byte, $4219 bit 5)
- *   bit  2: X              (high byte, $4219 bit 6)
- *   bit  3: A              (high byte, $4219 bit 7)
- *   bit  4: Right          (low byte,  $4218 bit 0)
- *   bit  5: Left           (low byte,  $4218 bit 1)
- *   bit  6: Down           (low byte,  $4218 bit 2)
- *   bit  7: Up             (low byte,  $4218 bit 3)
- *   bit  8: Start          (low byte,  $4218 bit 4)
- *   bit  9: Select         (low byte,  $4218 bit 5)
- *   bit 10: Y              (low byte,  $4218 bit 6)
- *   bit 11: B              (low byte,  $4218 bit 7)
+ *   bit  0: R
+ *   bit  1: L
+ *   bit  2: X
+ *   bit  3: A
+ *   bit  4: Right
+ *   bit  5: Left
+ *   bit  6: Down
+ *   bit  7: Up
+ *   bit  8: Start
+ *   bit  9: Select
+ *   bit 10: Y
+ *   bit 11: B
  *
  * Per-game runners that prefer a different layout can ignore the
  * bitmask and read individual buttons from PlayerBinds directly.

--- a/runner/src/snes/joypad.c
+++ b/runner/src/snes/joypad.c
@@ -30,3 +30,15 @@ uint8_t joypad_read_serial(Snes *snes, unsigned port) {
   if (*index < 16) (*index)++;
   return value;
 }
+
+uint16_t joypad_auto_read_word(uint16_t state) {
+  uint16_t word = 0;
+  for (int i = 0; i < 16; i++, state >>= 1)
+    word = (uint16_t)(word * 2u + (state & 1u));
+  return word;
+}
+
+uint8_t joypad_auto_read_reg(uint16_t state, unsigned reg) {
+  uint16_t word = joypad_auto_read_word(state);
+  return (uint8_t)((reg & 1u) ? (word >> 8) : (word & 0xffu));
+}

--- a/runner/src/snes/joypad.h
+++ b/runner/src/snes/joypad.h
@@ -7,5 +7,7 @@ struct Snes;
 
 void joypad_write_strobe(struct Snes *snes, uint8_t value);
 uint8_t joypad_read_serial(struct Snes *snes, unsigned port);
+uint16_t joypad_auto_read_word(uint16_t state);
+uint8_t joypad_auto_read_reg(uint16_t state, unsigned reg);
 
 #endif /* SNES_JOYPAD_H */

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -254,10 +254,7 @@ void snes_writeBBus(Snes* snes, uint8_t adr, uint8_t val) {
 }
 
 uint16_t SwapInputBits(uint16_t x) {
-  uint16_t r = 0;
-  for (int i = 0; i < 16; i++, x >>= 1)
-    r = r * 2 + (x & 1);
-  return r;
+  return joypad_auto_read_word(x);
 }
 
 static void snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
@@ -385,13 +382,13 @@ uint8_t snes_readReg(Snes* snes, uint16_t adr) {
       /* $4016 bit 0 latches both pads; reads shift B through R, then 1s. */
       return joypad_read_serial(snes, adr - 0x4016);
     case 0x4218:
-      return SwapInputBits(snes->input1_currentState) & 0xff;
+      return joypad_auto_read_reg(snes->input1_currentState, adr);
     case 0x4219:
-      return SwapInputBits(snes->input1_currentState) >> 8;
+      return joypad_auto_read_reg(snes->input1_currentState, adr);
     case 0x421a:
-      return SwapInputBits(snes->input2_currentState) & 0xff;
+      return joypad_auto_read_reg(snes->input2_currentState, adr);
     case 0x421b:
-      return SwapInputBits(snes->input2_currentState) >> 8;
+      return joypad_auto_read_reg(snes->input2_currentState, adr);
     case 0x421c:
     case 0x421e:
     case 0x421d:

--- a/tests/joypad/auto_joypad_test.c
+++ b/tests/joypad/auto_joypad_test.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "joypad.h"
+
+static int check(int condition, const char *message) {
+  if (!condition) {
+    fprintf(stderr, "FAIL: %s\n", message);
+    return 1;
+  }
+  return 0;
+}
+
+static int expect_auto_word(uint16_t state, unsigned base, uint16_t expected,
+                            const char *label) {
+  uint8_t lo = joypad_auto_read_reg(state, base);
+  uint8_t hi = joypad_auto_read_reg(state, base + 1);
+  char msg[128];
+  int fails = 0;
+
+  snprintf(msg, sizeof(msg), "%s low byte", label);
+  fails += check(lo == (uint8_t)(expected & 0xffu), msg);
+  snprintf(msg, sizeof(msg), "%s high byte", label);
+  fails += check(hi == (uint8_t)(expected >> 8), msg);
+  snprintf(msg, sizeof(msg), "%s 16-bit little-endian word", label);
+  fails += check(((uint16_t)lo | ((uint16_t)hi << 8)) == expected, msg);
+  return fails;
+}
+
+int main(void) {
+  int fails = 0;
+
+  /* Runner input state is the serial joypad order:
+   * B,Y,Select,Start,Up,Down,Left,Right,A,X,L,R.
+   *
+   * SNES automatic joypad registers store the first serial bit in bit 15 of
+   * the 16-bit word at $4218/$4219:
+   *   high byte $4219: B,Y,Select,Start,Up,Down,Left,Right
+   *   low byte  $4218: A,X,L,R,0,0,0,0
+   */
+  fails += expect_auto_word(1u << 6, 0x4218, 0x0200, "p1 left");
+
+  fails += expect_auto_word(1u << 8, 0x4218, 0x0080, "p1 A");
+
+  fails += expect_auto_word((1u << 0) | (1u << 7) | (1u << 11),
+                            0x4218, 0x8110, "p1 B+Right+R");
+
+  fails += expect_auto_word((1u << 5) | (1u << 9),
+                            0x421a, 0x0440, "p2 Down+X");
+
+  if (fails) return 1;
+  puts("auto_joypad_test: PASS");
+  return 0;
+}

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -129,6 +129,14 @@ echo "=== manual joypad serial protocol ==="
     -o "$OUT/manual_joypad_test"
 "$OUT/manual_joypad_test"
 
+echo "=== automatic joypad register byte order ==="
+"$CC" -std=c11 -Wall -Wextra -Werror -O1 \
+    -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes" \
+    "$ROOT/tests/joypad/auto_joypad_test.c" \
+    "$ROOT/runner/src/snes/joypad.c" \
+    -o "$OUT/auto_joypad_test"
+"$OUT/auto_joypad_test"
+
 echo "=== runtime dispatch ==="
 "$CC" -std=c11 -Wall -Wextra -ffunction-sections -fdata-sections \
     -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes" \


### PR DESCRIPTION
## Summary
- factor automatic joypad word/byte packing into joypad.c
- add a ROM-free regression test for $4218/ and $421a/ byte order
- correct stale keybind comments that described the keyboard-local mask as the SNES auto-joypad word

Refs #14.

## Finding
Issue #14's hardware layout is correct, but the proposed byte swap is not correct for this runner. input*_currentState is already in serial order (B,Y,Select,Start,Up,Down,Left,Right,A,X,L,R), so reversing it places Left at $4219 bit 1 and A at $4218 bit 7 with the existing low/high extraction. The new test locks that down.

## Validation
- uto_joypad_test: PASS
- manual_joypad_test: PASS
- python tests/run_tests.py -> 81 passed, 0 failed
- SMK isolated build against this branch: SuperMarioKartSNESRecompHeadless.exe .\\smk.sfc 2801 --input-file .\\tools\\smk-one-player-race.txt with SNESRECOMP_EXECUTION_MODE=lle -> PASS, ideo_hash=56cef3767d436448, strict=1

## Notes
- 	ests/run_c_tests.sh still cannot run end-to-end from this Windows/MSYS setup: it builds PE binaries without .exe, then Bash reports cannot execute binary file: Exec format error on the first launcher test. Focused C tests were compiled and run directly with MinGW GCC.