### PR TITLE
Detect pop-push inline argument routines

### DIFF
--- a/recompiler-rs/src/bin/analyze.rs
+++ b/recompiler-rs/src/bin/analyze.rs
@@ -722,16 +722,18 @@ fn discover_inline_args(
             continue;
         }
         let mut counts = BTreeSet::new();
-        for (m, x) in [(0, 0), (1, 1)] {
+        let mut probe_count = 0;
+        for (m, x) in [(0, 0), (0, 1), (1, 0), (1, 1)] {
             if let Some(count) =
                 detect_inline_arg_bytes(rom, mapping, (target >> 16) & 0xFF, target & 0xFFFF, m, x)
             {
                 if count != 0 {
                     counts.insert(count);
+                    probe_count += 1;
                 }
             }
         }
-        if counts.len() == 1 {
+        if probe_count == 4 && counts.len() == 1 {
             result.insert(target, i32::from(*counts.first().unwrap()));
         }
     }

--- a/recompiler-rs/src/decoder.rs
+++ b/recompiler-rs/src/decoder.rs
@@ -2790,10 +2790,10 @@ pub fn classify_dispatch_helper(
 /// number of inline argument bytes. Port of Python's
 /// `detect_inline_arg_bytes`.
 ///
-/// This deliberately recognizes only the load-return-address, add-immediate,
-/// store-back-to-the-same-stack-slot idiom. Instructions that may clobber A
-/// reset the match, which keeps ordinary routines that merely inspect their
-/// return address from being classified as inline-argument callees.
+/// This deliberately recognizes narrow return-address adjustment idioms.
+/// Instructions that clobber the tracked carrier register reset that carrier,
+/// which keeps ordinary routines that merely inspect their return address from
+/// being classified as inline-argument callees.
 pub fn detect_inline_arg_bytes(
     rom: &[u8],
     mapping: RomMapping,
@@ -2867,7 +2867,41 @@ pub fn detect_inline_arg_bytes(
     fn mutates_y(opcode: u8) -> bool {
         matches!(
             opcode,
-            0xA0 | 0xA4 | 0xB4 | 0xAC | 0xBC | 0xC8 | 0x88 | 0x7A
+            0xA0 | 0xA4 | 0xB4 | 0xAC | 0xBC | 0xC8 | 0x88 | 0x7A | 0xA8 | 0x9B
+        )
+    }
+
+    fn mutates_x(opcode: u8) -> bool {
+        matches!(
+            opcode,
+            0xA2 | 0xA6 | 0xB6 | 0xAE | 0xBE | 0xE8 | 0xCA | 0xFA | 0xAA | 0xBA | 0xBB
+        )
+    }
+
+    fn breaks_carrier_flow(opcode: u8) -> bool {
+        matches!(
+            opcode,
+            0x00 | 0x02
+                | 0x10
+                | 0x20
+                | 0x22
+                | 0x30
+                | 0x40
+                | 0x4C
+                | 0x50
+                | 0x5C
+                | 0x60
+                | 0x6B
+                | 0x70
+                | 0x80
+                | 0x82
+                | 0x90
+                | 0xB0
+                | 0xD0
+                | 0xDC
+                | 0xF0
+                | 0x6C
+                | 0x7C
         )
     }
 
@@ -2875,9 +2909,13 @@ pub fn detect_inline_arg_bytes(
     let mut m = entry_m & 1;
     let mut x = entry_x & 1;
     let mut a_slot: Option<u8> = None;
+    let mut a_pulled = false;
     let mut a_added = 0u32;
     let mut y_slot: Option<u8> = None;
+    let mut y_pulled = false;
     let mut y_added = 0u32;
+    let mut x_pulled = false;
+    let mut x_added = 0u32;
 
     for _ in 0..96 {
         let offset = rom_offset_opt(mapping, bank, pc)?;
@@ -2896,6 +2934,8 @@ pub fn detect_inline_arg_bytes(
                 }
                 if ins.operand & 0x10 != 0 {
                     x = 0;
+                    x_pulled = false;
+                    x_added = 0;
                 }
             }
             "SEP" => {
@@ -2904,21 +2944,39 @@ pub fn detect_inline_arg_bytes(
                 }
                 if ins.operand & 0x10 != 0 {
                     x = 1;
+                    x_pulled = false;
+                    x_added = 0;
                 }
             }
             "LDA" if ins.mode == Mode::Stk => {
                 a_slot = Some((ins.operand & 0xFF) as u8);
+                a_pulled = false;
+                a_added = 0;
+            }
+            "PLA" => {
+                a_slot = None;
+                a_pulled = true;
                 a_added = 0;
             }
             "TAY" => {
                 y_slot = a_slot;
-                y_added = if a_slot.is_some() { a_added } else { 0 };
+                y_pulled = a_pulled;
+                y_added = if a_slot.is_some() || a_pulled {
+                    a_added
+                } else {
+                    0
+                };
             }
             "TYA" => {
                 a_slot = y_slot;
-                a_added = if y_slot.is_some() { y_added } else { 0 };
+                a_pulled = y_pulled;
+                a_added = if y_slot.is_some() || y_pulled {
+                    y_added
+                } else {
+                    0
+                };
             }
-            "ADC" if ins.opcode == 0x69 && a_slot.is_some() => {
+            "ADC" if ins.opcode == 0x69 && (a_slot.is_some() || a_pulled) => {
                 a_added = (a_added + ins.operand) & 0xFFFF;
             }
             "STA" if ins.opcode == 0x83 && ins.mode == Mode::Stk => {
@@ -2926,15 +2984,61 @@ pub fn detect_inline_arg_bytes(
                     return Some((a_added & 0xFF) as u8);
                 }
             }
+            "PHA" if a_pulled => {
+                if a_added != 0 {
+                    return Some((a_added & 0xFF) as u8);
+                }
+                a_pulled = false;
+                a_added = 0;
+            }
+            "PLX" => {
+                x_pulled = true;
+                x_added = 0;
+            }
+            "INX" if x_pulled => {
+                x_added = x_added.wrapping_add(1);
+            }
+            "PHX" if x_pulled => {
+                if x_added != 0 {
+                    return Some((x_added & 0xFF) as u8);
+                }
+                x_pulled = false;
+                x_added = 0;
+            }
+            _ if breaks_carrier_flow(ins.opcode) => {
+                a_slot = None;
+                a_pulled = false;
+                a_added = 0;
+                y_slot = None;
+                y_pulled = false;
+                y_added = 0;
+                x_pulled = false;
+                x_added = 0;
+            }
             _ if preserves_a(ins.opcode) => {
                 if mutates_y(ins.opcode) {
                     y_slot = None;
+                    y_pulled = false;
                     y_added = 0;
+                }
+                if mutates_x(ins.opcode) {
+                    x_pulled = false;
+                    x_added = 0;
                 }
             }
             _ => {
                 a_slot = None;
+                a_pulled = false;
                 a_added = 0;
+                if mutates_y(ins.opcode) {
+                    y_slot = None;
+                    y_pulled = false;
+                    y_added = 0;
+                }
+                if mutates_x(ins.opcode) {
+                    x_pulled = false;
+                    x_added = 0;
+                }
             }
         }
         pc = (pc + ins.length as u32) & 0xFFFF;
@@ -3288,6 +3392,92 @@ mod tests {
         assert_eq!(
             detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
             Some(8)
+        );
+    }
+
+    #[test]
+    fn detects_accumulator_pop_push_inline_argument_adjustment() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0xA8, // TAY
+            0x18, // CLC
+            0x69, 0x03, 0x00, // ADC #$0003
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn rejects_accumulator_after_unadjusted_restore() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0x48, // PHA
+            0x18, // CLC
+            0x69, 0x03, 0x00, // ADC #$0003
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_x_pop_push_inline_argument_adjustment() {
+        let rom = rom_at_8000(&[
+            0xE2, 0x20, // SEP #$20
+            0xC2, 0x10, // REP #$10
+            0xFA, // PLX
+            0x68, // PLA
+            0x48, // PHA
+            0xE8, // INX
+            0xBD, 0x00, 0x00, // LDA $0000,X
+            0xE8, // INX
+            0xDA, // PHX
+            0x6B, // RTL
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn rejects_x_carrier_after_x_mutation() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x10, // REP #$10
+            0xFA, // PLX
+            0xE8, // INX
+            0xA2, 0x34, 0x12, // LDX #$1234
+            0xDA, // PHX
+            0x6B, // RTL
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_x_carrier_across_subroutine_call() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x10, // REP #$10
+            0xFA, // PLX
+            0xE8, // INX
+            0x22, 0x34, 0x12, 0x00, // JSL $001234
+            0xDA, // PHX
+            0x6B, // RTL
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
         );
     }
 

--- a/recompiler/v2/decoder.py
+++ b/recompiler/v2/decoder.py
@@ -1216,12 +1216,26 @@ def detect_inline_arg_bytes(rom: bytes, bank: int, addr: int,
         0x48, 0xDA, 0x5A, 0x08, 0x8B, 0x4B, 0x0B,     # PHA/PHX/PHY/PHP/PHB/PHK/PHD
         0xEA, 0x42,                                   # NOP / WDM
     }
+    Y_MUTATING = {
+        0xA0, 0xA4, 0xB4, 0xAC, 0xBC, 0xC8, 0x88, 0x7A, 0xA8, 0x9B,
+    }
+    X_MUTATING = {
+        0xA2, 0xA6, 0xB6, 0xAE, 0xBE, 0xE8, 0xCA, 0xFA, 0xAA, 0xBA, 0xBB,
+    }
+    CONTROL_TRANSFER = {
+        0x00, 0x02, 0x10, 0x20, 0x22, 0x30, 0x40, 0x4C, 0x50, 0x5C, 0x60, 0x6B,
+        0x70, 0x80, 0x82, 0x90, 0xB0, 0xD0, 0xDC, 0xF0, 0x6C, 0x7C,
+    }
     pc = addr & 0xFFFF
     m, x = entry_m & 1, entry_x & 1
     a_slot = None     # stack slot the live A value came from (LDA $nn,S)
+    a_pulled = False  # live A value came from PLA of the return address
     a_added = 0       # constant added to that value since the load
     y_slot = None     # stack slot copied through Y via TAY/TYA
+    y_pulled = False
     y_added = 0
+    x_pulled = False
+    x_added = 0
     budget = 0
     while budget < 96:
         budget += 1
@@ -1242,41 +1256,92 @@ def detect_inline_arg_bytes(rom: bytes, bank: int, addr: int,
             return None
         if mn == 'REP':
             if ins.operand & 0x20: m = 0
-            if ins.operand & 0x10: x = 0
+            if ins.operand & 0x10:
+                x = 0
+                x_pulled = False
+                x_added = 0
         elif mn == 'SEP':
             if ins.operand & 0x20: m = 1
-            if ins.operand & 0x10: x = 1
+            if ins.operand & 0x10:
+                x = 1
+                x_pulled = False
+                x_added = 0
         elif mn == 'LDA' and ins.mode == STK:
             a_slot = ins.operand & 0xFF       # (re)start tracking from this slot
+            a_pulled = False
+            a_added = 0
+        elif op == 0x68:                       # PLA
+            a_slot = None
+            a_pulled = True
             a_added = 0
         elif op == 0xA8:                       # TAY
-            if a_slot is not None:
+            if a_slot is not None or a_pulled:
                 y_slot = a_slot
+                y_pulled = a_pulled
                 y_added = a_added
             else:
                 y_slot = None
+                y_pulled = False
                 y_added = 0
         elif op == 0x98:                       # TYA
-            if y_slot is not None:
+            if y_slot is not None or y_pulled:
                 a_slot = y_slot
+                a_pulled = y_pulled
                 a_added = y_added
             else:
                 a_slot = None
+                a_pulled = False
                 a_added = 0
-        elif op == 0x69 and a_slot is not None:   # ADC #imm (m-dependent)
+        elif op == 0x69 and (a_slot is not None or a_pulled):   # ADC #imm
             a_added = (a_added + ins.operand) & 0xFFFF
         elif op == 0x83 and ins.mode == STK:      # STA $nn,S — return-addr write-back
             if a_slot is not None and (ins.operand & 0xFF) == a_slot and a_added:
                 return a_added & 0xFF             # inline byte count
             # store-back without an add (or to a different slot): not it
+        elif op == 0x48 and a_pulled:             # PHA
+            if a_added:
+                return a_added & 0xFF
+            a_pulled = False
+            a_added = 0
+        elif op == 0xFA:                          # PLX
+            x_pulled = True
+            x_added = 0
+        elif op == 0xE8 and x_pulled:             # INX
+            x_added = (x_added + 1) & 0xFFFF
+        elif op == 0xDA and x_pulled:             # PHX
+            if x_added:
+                return x_added & 0xFF
+            x_pulled = False
+            x_added = 0
+        elif op in CONTROL_TRANSFER:
+            a_slot = None
+            a_pulled = False
+            a_added = 0
+            y_slot = None
+            y_pulled = False
+            y_added = 0
+            x_pulled = False
+            x_added = 0
         elif op in A_PRESERVING:
-            if op in (0xA0, 0xA4, 0xB4, 0xAC, 0xBC, 0xC8, 0x88, 0x7A):
+            if op in Y_MUTATING:
                 y_slot = None
+                y_pulled = False
                 y_added = 0
+            if op in X_MUTATING:
+                x_pulled = False
+                x_added = 0
             pass                                  # A unchanged; keep tracking
         else:
             a_slot = None                         # A clobbered — reset
+            a_pulled = False
             a_added = 0
+            if op in Y_MUTATING:
+                y_slot = None
+                y_pulled = False
+                y_added = 0
+            if op in X_MUTATING:
+                x_pulled = False
+                x_added = 0
         pc = (pc + ins.length) & 0xFFFF
     return None
 

--- a/tests/v2/test_inline_arg_detector.py
+++ b/tests/v2/test_inline_arg_detector.py
@@ -48,6 +48,87 @@ def test_detects_y_carried_stack_return_address_adjustment():
     assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 8
 
 
+def test_detects_accumulator_pop_push_return_address_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0xA8,              # TAY
+            0x18,              # CLC
+            0x69, 0x03, 0x00,  # ADC #$0003
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 3
+
+
+def test_rejects_accumulator_after_unadjusted_restore():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0x48,              # PHA
+            0x18,              # CLC
+            0x69, 0x03, 0x00,  # ADC #$0003
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_detects_x_pop_push_return_address_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xE2, 0x20,        # SEP #$20
+            0xC2, 0x10,        # REP #$10
+            0xFA,              # PLX
+            0x68,              # PLA
+            0x48,              # PHA
+            0xE8,              # INX
+            0xBD, 0x00, 0x00,  # LDA $0000,X
+            0xE8,              # INX
+            0xDA,              # PHX
+            0x6B,              # RTL
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 2
+
+
+def test_x_carrier_is_invalidated_by_x_mutation():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x10,        # REP #$10
+            0xFA,              # PLX
+            0xE8,              # INX
+            0xA2, 0x34, 0x12,  # LDX #$1234
+            0xDA,              # PHX
+            0x6B,              # RTL
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_x_carrier_is_invalidated_by_subroutine_call():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x10,              # REP #$10
+            0xFA,                    # PLX
+            0xE8,                    # INX
+            0x22, 0x34, 0x12, 0x00,  # JSL $001234
+            0xDA,                    # PHX
+            0x6B,                    # RTL
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
 def test_y_carrier_is_invalidated_by_y_mutation():
     rom = make_lorom_bank0({
         0x8000: bytes([

--- a/tools/v2_analyze.py
+++ b/tools/v2_analyze.py
@@ -668,7 +668,8 @@ def build_manifest(rom: bytes, parsed, *, max_insns: int, max_nodes: int,
             if target not in inline_arg_map and target not in inline_arg_probes:
                 inline_arg_probes.add(target)
                 byte_counts = set()
-                for probe_m, probe_x in ((0, 0), (1, 1)):
+                byte_count_probes = 0
+                for probe_m, probe_x in ((0, 0), (0, 1), (1, 0), (1, 1)):
                     try:
                         count = detect_inline_arg_bytes(
                             rom, (target >> 16) & 0xFF,
@@ -677,7 +678,8 @@ def build_manifest(rom: bytes, parsed, *, max_insns: int, max_nodes: int,
                         count = None
                     if count:
                         byte_counts.add(count)
-                if len(byte_counts) == 1:
+                        byte_count_probes += 1
+                if byte_count_probes == 4 and len(byte_counts) == 1:
                     inline_additions[target] = byte_counts.pop()
 
         if helper_additions or inline_additions:

--- a/tools/v2_regen.py
+++ b/tools/v2_regen.py
@@ -1394,11 +1394,13 @@ def main() -> int:
         tbank = (tgt >> 16) & 0xFF
         taddr = tgt & 0xFFFF
         seen_n: set = set()
-        for em, ex in ((0, 0), (1, 1)):
+        seen_probe_count = 0
+        for em, ex in ((0, 0), (0, 1), (1, 0), (1, 1)):
             n = detect_inline_arg_bytes(rom, tbank, taddr, em, ex)
             if n:
                 seen_n.add(n)
-        if len(seen_n) == 1:
+                seen_probe_count += 1
+        if seen_probe_count == 4 and len(seen_n) == 1:
             inline_arg_map[tgt] = seen_n.pop()
     if inline_arg_map:
         print(f"  detected {len(inline_arg_map)} inline-argument routine(s):")


### PR DESCRIPTION
## Summary
- extend inline-argument detection beyond stack-relative `LDA/ADC/STA` to cover `PLA/ADC/PHA` and `PLX/INX/PHX` return-address adjustment idioms
- keep carrier tracking conservative across register mutations, width changes, and control transfers
- require all four M/X probes to agree before publishing an auto-detected table-wide inline-argument skip

Fixes #18.

## Validation
- `cargo test` in `recompiler-rs`: pass
- `python tests/run_tests.py`: 81 passed, 0 failed
- `python tests/v2/run_tests.py`: 368/371 passed; remaining three are the existing MSYS native-analyzer exec-format failures for `target/release/snesrecomp-analyze`
- `git diff --check`: clean
- SimCitySNESRecomp regenerated with the Python backend using `Sim City (U) [!].sfc`: `03:A2F5` and `03:A3CF` now publish skip `3`, and the caller at `03:AFD6` resumes at `L_AFDC` instead of decoding inline bytes
- SimCitySNESRecomp `--qualify 600`: pass
- SimCityAOTProbe: links and runs against regenerated banks, reporting 772 dispatch rows and 1009 compiled variants

## Regression Checks
Temporary emissions against the local regression title suite showed no inline-skip changes outside SimCity:
- SMW stock: 0 inline-skip differences
- ALTTP: 0 inline-skip differences
- MMX USA: 0 inline-skip differences

During validation an earlier version falsely classified ALTTP `Ganon_Draw` (`1D:9ADF`) when probed under an impossible width state. The final version prevents that by requiring all four M/X probes to detect the same nonzero count before publishing an auto inline-argument fact.