### PR TITLE
docs: clarify frame-model host contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ default.
 
 Useful technical references:
 
+- [`docs/FRAME_MODEL_HOSTS.md`](docs/FRAME_MODEL_HOSTS.md) - integration notes
+  for hosts that drive their own frame or beam loop.
+
 - [`docs/MULTI_TIER.md`](docs/MULTI_TIER.md) — static and interpreted execution
   tiers.
 - [`docs/LLE_FIRST_ANALYSIS.md`](docs/LLE_FIRST_ANALYSIS.md) — analysis policy

--- a/docs/FRAME_MODEL_HOSTS.md
+++ b/docs/FRAME_MODEL_HOSTS.md
@@ -1,0 +1,52 @@
+# Frame-Model Hosts
+
+This note is for hosts that drive game time with their own frame or scanline
+loop and call `interp_bridge_run_loop()` or related bridge entry points
+directly. Hosts that use `RtlRunFrame()` normally inherit the framework's timing
+contracts and do not need this integration layer.
+
+## Beam Ownership
+
+Use one beam owner. The framework updates `snes->hPos` and `snes->vPos` from
+`snes_sync_master_clock()` while interpreted code runs, so a host that also
+advances an independent beam can split a frame between two clocks. Device work
+derived from only the host-side clock can then miss edges that the bridge-side
+clock crossed.
+
+Prefer scheduling host device work from the shared `Snes` beam state, or keep a
+single explicit host-owned beam and audit every framework edge that must be
+called manually.
+
+Frame-model hosts that own HBlank/VBlank edges are responsible for hardware
+work normally driven by the framework timeline, including:
+
+- `ppu_checkOverscan()` and `ppu_handleVblank()` at VBlank entry.
+- NMI and automatic joypad-poll handling at the documented hardware edge.
+- `dma_initHdma(snes->dma)` on frame wrap and `dma_doHdma(snes->dma)` once per
+  visible HBlank when using LLE HDMA.
+- APU catch-up at a cadence that does not depend on one frame-sized catch-up
+  call.
+
+## APU Pacing
+
+`snes_catchupApu()` has a per-call runaway clamp. That guard assumes callers
+catch up regularly; a host that batches an entire frame into one call can discard
+part of the requested SPC time. Frame-model hosts should catch up the APU at
+smaller timing slices or use the framework frame runner that owns the audio
+timeline.
+
+When the bridge is running with the absolute SA-1 frame timeline, interpreted
+APU deltas are consumed by that absolute clock. Hosts outside that model should
+not assume bridge exits alone have advanced all deferred SPC time; flush or
+catch up at explicit integration points.
+
+## Bridge Hooks
+
+`interp_bridge_set_pre_opcode_hook()` is the supported pre-opcode extension
+point. The older `interp816_opcode_hook` symbol is a legacy no-op and is not
+called by the bridge.
+
+`interp_bridge_run_interrupt()` expects the caller to have already pushed the
+hardware interrupt frame, for example with `cpu_push_interrupt_frame_at()`. If
+the host has not materialized that frame, use the normal resume path after
+pushing it rather than entering the interrupt body directly.

--- a/docs/HOST_OVERLAY_EXTRACTION.md
+++ b/docs/HOST_OVERLAY_EXTRACTION.md
@@ -96,7 +96,9 @@ renderer in `ppu_legacy.c` does not implement host-overlay extraction.
 This port leaves the engine's existing widescreen layer-policy controls
 (`PpuSetWidescreenLayerClamp`/`Mirror`/`Repeat`, the clamp/repeat bands, the
 margin gap, the BG3 widen/HUD-split, and the Mode-2 layer capture) fully intact;
-overlay extraction is an orthogonal, independently opt-in capability.
+overlay extraction is an orthogonal, independently opt-in capability. The
+clamp/mirror/repeat layer policies are applied by the new renderer; the legacy
+renderer stores those policy fields but does not consult them while drawing.
 
 ## Attribution
 

--- a/runner/src/snes/interp816.h
+++ b/runner/src/snes/interp816.h
@@ -86,8 +86,10 @@ uint8_t  interp816_getFlags(Interp816 *cpu);
 void     interp816_setFlags(Interp816 *cpu, uint8_t val);
 void     interp816_saveload(Interp816 *cpu, SaveLoadInfo *sli);
 
-/* Historical bridge callback retained for source compatibility. Current
- * bridge dispatch uses explicit JSR/JSL interception rather than BRK traps. */
+/* Historical bridge callback retained for source compatibility. Current bridge
+ * dispatch uses explicit JSR/JSL interception rather than BRK traps, and this
+ * is not a per-opcode host extension point. Use
+ * interp_bridge_set_pre_opcode_hook() for that. */
 extern int interp816_opcode_hook(uint32_t addr);
 
 #endif /* INTERP816_H */

--- a/runner/src/snes/interp_bridge.c
+++ b/runner/src/snes/interp_bridge.c
@@ -27,6 +27,7 @@
  * poll, so the SPC stayed frozen (co-sim: A outPorts=0000 vs B outPorts=AABB).
  * Scoped to the interp tier — the compiled path never enters here. */
 extern Snes *g_snes;
+extern int snes_frame_counter;
 extern uint64_t g_apu_last_sync_master;   /* common_rtl.c — keep synced so a bounce's accurate-mode delta excludes interp opcodes */
 extern int g_interp_apu_driving;          /* common_rtl.c — suppresses the per-touch synthetic catch-up while set */
 #ifdef SNES_COSIM
@@ -61,6 +62,20 @@ static uint64_t bridge_bounce_flush_thresh(void) {
         if (s_t < 0) s_t = 0;
     }
     return (uint64_t)s_t;
+}
+/* SNESRECOMP_YIELD_STACK_DIAG enables immediately. Set
+ * SNESRECOMP_YIELD_STACK_DIAG_FROM=<frame> to delay noisy captures. */
+static int bridge_yield_stack_diag_enabled(void) {
+    const char *diag = getenv("SNESRECOMP_YIELD_STACK_DIAG");
+    if (!diag || !diag[0]) return 0;
+
+    const char *from = getenv("SNESRECOMP_YIELD_STACK_DIAG_FROM");
+    if (!from || !from[0]) return 1;
+
+    char *end = NULL;
+    long first_frame = strtol(from, &end, 0);
+    if (end == from) return 1;
+    return snes_frame_counter >= first_frame;
 }
 static void bridge_apu_flush(CpuState *cpu) {
     if (!s_apu_pending_master) return;
@@ -1285,8 +1300,7 @@ static int _interp_run_core(CpuState *cpu, uint32_t entry_pc24,
                 if (_air != RECOMP_RETURN_NORMAL) {
                     if (s_lle_unwind_active) {
                         if (s_lle_unwind_owner_depth == s_interp_bridge_depth) {
-                            if (getenv("SNESRECOMP_YIELD_STACK_DIAG") &&
-                                snes_frame_counter >= 5390) {
+                            if (bridge_yield_stack_diag_enabled()) {
                                 fprintf(stderr,
                                         "[yield_stack] frame=%d bounce=$%06X "
                                         "sp_pre=$%04X sp_unwind=$%04X "

--- a/runner/src/snes/interp_bridge.h
+++ b/runner/src/snes/interp_bridge.h
@@ -102,7 +102,10 @@ void interp_bridge_set_master_deadline(uint64_t master_clock);
 int interp_bridge_lle_master_deadline_reached(const CpuState *cpu);
 
 /* Execute an architectural interrupt handler through its terminal RTI. The
- * caller has already materialized the hardware interrupt frame. */
+ * caller has already materialized the hardware interrupt frame, usually with
+ * cpu_push_interrupt_frame_at(). Do not enter an interrupt body directly from a
+ * host scheduler unless that frame is on the guest stack for the terminal RTI
+ * to consume. */
 int interp_bridge_run_interrupt(CpuState *cpu, uint32_t entry_pc24);
 
 /* Save-state task resume: interpret a suspended cooperative task from its

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -531,6 +531,8 @@ const uint8_t *PpuGetMode2Bg1Palette(const Ppu *ppu);
 
 // Per-layer widescreen clamp: bit L keeps BG(L+1) in the authentic 256
 // columns while other layers extend into the margins. Re-apply per frame.
+// Requires PpuBeginDrawing(..., kPpuRenderFlags_NewRenderer); the legacy
+// renderer stores this policy but does not apply it.
 void PpuSetWidescreenLayerClamp(Ppu *ppu, uint8_t mask);
 
 // Extend selected game-authored PPU windows by the current widescreen margins
@@ -542,12 +544,14 @@ void PpuSetWidescreenWindowExpansion(Ppu *ppu, uint8_t layer_mask,
 // Fill Mode-1 background margins by reflecting or cyclically repeating the
 // authentic rendered scanline. Rendering remains layer-, priority-, window-,
 // and color-math-correct. Repeat wins if both bits are set. Re-apply per frame.
+// Requires kPpuRenderFlags_NewRenderer; the legacy renderer ignores these
+// policies.
 void PpuSetWidescreenLayerMirror(Ppu *ppu, uint8_t mask);
 void PpuSetWidescreenLayerRepeat(Ppu *ppu, uint8_t mask);
 
 // Apply clamp, cyclic-repeat, or stretch only on scanlines [y0,y1).
 // y1<=y0 disables. Repeat/stretch bands apply to Mode-1 4bpp and 2bpp
-// background paths.
+// background paths. Requires kPpuRenderFlags_NewRenderer.
 void PpuSetWidescreenLayerClampBand(Ppu *ppu, uint8_t layer, uint8_t y0,
                                     uint8_t y1);
 void PpuSetWidescreenLayerRepeatBand(Ppu *ppu, uint8_t layer, uint8_t y0,


### PR DESCRIPTION
## Summary

- make `SNESRECOMP_YIELD_STACK_DIAG=1` emit immediately, with optional `SNESRECOMP_YIELD_STACK_DIAG_FROM=<frame>` for delayed captures
- add frame-model host integration notes for direct `interp_bridge_run_loop()` users
- document that widescreen clamp/mirror/repeat layer policies require `kPpuRenderFlags_NewRenderer`
- clarify the supported pre-opcode hook and the interrupt-frame contract in headers

Fixes #24.
Fixes #25.
Addresses #22.

## Validation

- `git diff --check`
- `python tests/run_tests.py` (`81 passed, 0 failed`)
- `wsl.exe bash -lc 'cd /mnt/f/Projects/snesrecomp/snesrecomp && bash tests/run_c_tests.sh'`
- `SNESRECOMP_YIELD_STACK_DIAG=1 build/c-tests/bridge_test` emits `[yield_stack]` at frame 0
- `SNESRECOMP_YIELD_STACK_DIAG=1 SNESRECOMP_YIELD_STACK_DIAG_FROM=999999 build/c-tests/bridge_test` suppresses `[yield_stack]`