### PR TITLE
Fix scheduler deadline unwind

### DIFF
--- a/runner/src/snes/interp_bridge.c
+++ b/runner/src/snes/interp_bridge.c
@@ -348,6 +348,8 @@ static int      s_lle_sched_depth   = 0;
 static int      s_lle_unwind_active = 0;
 static uint32_t s_lle_unwind_pc24   = 0;
 static int      s_lle_unwind_owner_depth = 0;
+static int      s_lle_unwind_is_deadline = 0;
+static int      s_lle_next_unwind_is_deadline = 0;
 static uint32_t s_lle_resume_pc24   = 0;
 static int      s_lle_wai_yield     = 0;
 static uint64_t s_lle_master_deadline = 0;
@@ -446,9 +448,13 @@ void interp_bridge_set_master_deadline(uint64_t master_clock) {
 }
 
 int interp_bridge_lle_master_deadline_reached(const CpuState *cpu) {
-    return cpu && s_lle_sched_depth > 0 && s_interp_bounce_owner_depth > 0 &&
-           s_lle_master_deadline != 0 &&
-           cpu->master_cycles >= s_lle_master_deadline;
+    const int reached =
+        cpu && s_lle_sched_depth > 0 && s_interp_bounce_owner_depth > 0 &&
+        s_lle_master_deadline != 0 &&
+        cpu->master_cycles >= s_lle_master_deadline;
+    if (reached)
+        s_lle_next_unwind_is_deadline = 1;
+    return reached;
 }
 
 RecompReturn interp_bridge_lle_yield_unwind(CpuState *cpu, uint32 resume_pc24) {
@@ -462,6 +468,8 @@ RecompReturn interp_bridge_lle_yield_unwind(CpuState *cpu, uint32 resume_pc24) {
     s_lle_unwind_active = 1;
     s_lle_unwind_pc24   = resume_pc24 & 0xFFFFFFu;
     s_lle_unwind_owner_depth = s_interp_bounce_owner_depth;
+    s_lle_unwind_is_deadline = s_lle_next_unwind_is_deadline;
+    s_lle_next_unwind_is_deadline = 0;
     return (RecompReturn)RECOMP_RETURN_LLE_UNWIND_BASE;
 }
 
@@ -1284,6 +1292,7 @@ static int _interp_run_core(CpuState *cpu, uint32_t entry_pc24,
                 int _saved_bounce_owner = s_interp_bounce_owner_depth;
                 s_interp_bounce_recomp_base = g_recomp_stack_top;
                 s_interp_bounce_owner_depth = s_interp_bridge_depth;
+                s_lle_next_unwind_is_deadline = 0;
                 RecompReturn _air = cpu_dispatch_pc_paired(cpu, target, _fs);
                 s_interp_bounce_owner_depth = _saved_bounce_owner;
                 s_interp_bounce_recomp_base = _saved_bounce_base;
@@ -1309,6 +1318,15 @@ static int _interp_run_core(CpuState *cpu, uint32_t entry_pc24,
                                         (unsigned)_sp_pre, (unsigned)in.sp,
                                         (unsigned)s_lle_unwind_pc24);
                             }
+                            if (s_lle_unwind_is_deadline) {
+                                s_lle_resume_pc24 = s_lle_unwind_pc24;
+                                s_lle_unwind_active = 0;
+                                s_lle_unwind_owner_depth = 0;
+                                s_lle_unwind_is_deadline = 0;
+                                sync_interp_to_cpu(&in, cpu);
+                                bridge_apu_flush(cpu);
+                                return 1;
+                            }
                             /* Fiber-free yield: the bounced body reached a
                              * yield primitive; its stub unwound the host
                              * stack to here. Consume the request and resume
@@ -1319,6 +1337,7 @@ static int _interp_run_core(CpuState *cpu, uint32_t entry_pc24,
                              * switch runs byte-exact. */
                             s_lle_unwind_active = 0;
                             s_lle_unwind_owner_depth = 0;
+                            s_lle_unwind_is_deadline = 0;
                             sync_cpu_to_interp(cpu, &in);
                             in.k  = (uint8)((s_lle_unwind_pc24 >> 16) & 0xFF);
                             in.pc = (uint16)(s_lle_unwind_pc24 & 0xFFFF);
@@ -1490,6 +1509,8 @@ static int interp_bridge_run_ex2(CpuState *cpu, uint32_t entry_pc24,
         if (s_lle_unwind_active) {
             s_lle_unwind_active = 0;
             s_lle_unwind_owner_depth = 0;
+            s_lle_unwind_is_deadline = 0;
+            s_lle_next_unwind_is_deadline = 0;
             fprintf(stderr, "[interp_bridge] stale LLE yield unwind cleared "
                     "at scheduler exit (pc=$%06X)\n",
                     (unsigned)s_lle_unwind_pc24);

--- a/tests/interp816/bridge_test.c
+++ b/tests/interp816/bridge_test.c
@@ -37,6 +37,7 @@ static int      g_aot_interp_nlr;
 static int      g_aot_double_rewrite;
 static int      g_aot_crosses_interp_owner;
 static int      g_aot_skips_interp_owner;
+static int      g_aot_deadline_unwind;
 static int      g_owner_target_result;
 static int      g_aot_tail_chain_probe;
 static int      g_aot_skips_root;
@@ -147,6 +148,15 @@ RecompReturn cpu_dispatch_pc_paired(CpuState *cpu, uint32 pc24,
         g_recomp_stack_top = base;
         if (g_owner_target_result)
             return interp_bridge_lle_yield_unwind(cpu, 0x008003);
+        return RECOMP_RETURN_NORMAL;
+    }
+    if (g_aot_deadline_unwind && (pc24 & 0xFFFFFF) == FAKE_AOT) {
+        g_aot_called++;
+        cpu->master_cycles = 200;
+        if (interp_bridge_lle_master_deadline_reached(cpu))
+            return interp_bridge_lle_yield_unwind(cpu, 0x008100);
+        cpu->A = 0x0100;
+        cpu->S = (uint16)(cpu->S + frame_size);
         return RECOMP_RETURN_NORMAL;
     }
     if (g_aot_skips_root && (pc24 & 0xFFFFFF) == FAKE_AOT) {
@@ -560,6 +570,35 @@ int main(void) {
             "A.lo=%02X exp 5A (scheduler continuation executed)", g_c.A & 0xFF);
       CHECK(g_c.S == 0x01FF, "S=%04X exp 01FF (JSL frame consumed once)", g_c.S);
       g_aot_skips_root = 0; }
+
+    /* S8c: a compiled callee that reaches the host's master deadline while
+     * bounced from scheduler mode must return to the host. It must not be
+     * treated like a cooperative yield primitive, because that would continue
+     * interpreting past the host's expired bound. */
+    { memset(RAM, 0, MEMSZ); init_cpu(); g_aot_called = 0;
+      g_aot_deadline_unwind = 1;
+      interp_bridge_set_master_deadline(100);
+      uint8_t scheduler[] = {
+          0x22,0x00,0x81,0x00,                 /* JSL fake compiled root */
+          0xA9,0x5A,                           /* must not execute */
+          0xAD,0x20,0x00, 0xD0,0xFB            /* cooperative wait loop */
+      };
+      load(0x8000, scheduler, sizeof scheduler);
+      RAM[0x20] = 0;
+      int rc = interp_bridge_run_loop(&g_c, 0x008000, 0x008006, 0x0020, 0);
+      printf("S8c scheduler deadline unwind returns to host\n");
+      CHECK(rc == 1, "rc=%d exp 1", rc);
+      CHECK(g_aot_called == 1, "aot_called=%d exp 1", g_aot_called);
+      CHECK((g_c.A & 0xFF) == 0x00,
+            "A.lo=%02X exp 00 (scheduler continuation not executed)",
+            g_c.A & 0xFF);
+      CHECK(g_c.S == 0x01FC,
+            "S=%04X exp 01FC (compiled JSL frame retained)", g_c.S);
+      CHECK(interp_bridge_lle_resume_pc() == 0x008100,
+            "resume=$%06X exp $008100 (compiled deadline resume)",
+            (unsigned)interp_bridge_lle_resume_pc());
+      interp_bridge_set_master_deadline(0);
+      g_aot_deadline_unwind = 0; }
 
     /* S9: the same rewrite below the paired AOT root belongs to a compiled
      * ancestor, not directly to the scheduler interpreter.  Finish that


### PR DESCRIPTION
## Summary

Fixes the scheduler-mode master-deadline unwind path so an expired deadline returns control to the host instead of resuming interpretation at the yield primitive.

This adds a focused bridge regression test for the unwind behavior.

Related to #23. Holding merge for reporter confirmation.

## Validation

Framework checks:
- `python tests/run_tests.py` passed: 81/81
- `tests/run_c_tests.sh` passed; DSP1 firmware-dependent check skipped because no firmware dump was configured

Game build/runtime checks against this branch:
- A Link to the Past: build passed
- Mega Man X: build passed
- Super Mario World: build passed and was also included in the v0.11.1 public release validation
- Super Metroid: build passed; initial black-screen concern did not reproduce after retest. Direct framedump reached in-game frame 4920, and the current/previous builds were revalidated as passing.