### PR TITLE
Add left-margin OAM hints for widescreen

### DIFF
--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -268,6 +268,16 @@ void PpuSetWidescreenBg3Widen(Ppu *ppu, uint8_t from_y) {
   ppu->wsBg3WidenY = from_y;
 }
 
+void PpuWsSetOamLeftHints(Ppu *ppu, const uint8_t *hints) {
+  if (hints) {
+    ppu->wsOamLeftHintStrict = 1;
+    memcpy(ppu->wsOamLeftHint, hints, sizeof(ppu->wsOamLeftHint));
+  } else {
+    ppu->wsOamLeftHintStrict = 0;
+    memset(ppu->wsOamLeftHint, 0, sizeof(ppu->wsOamLeftHint));
+  }
+}
+
 void PpuWsSetOamRightHints(Ppu *ppu, const uint8_t *hints) {
   if (hints) {
     ppu->wsOamRightHintStrict = 1;
@@ -1991,6 +2001,16 @@ static int PpuDecodeOamX(Ppu *ppu, uint8_t index) {
   return x;
 }
 
+static bool PpuWidescreenOamLeftHintAllows(Ppu *ppu, uint8_t index, int x,
+                                           int sprite_size,
+                                           int left_extra) {
+  if (!ppu->wsOamLeftHintStrict || x >= 0 || x + sprite_size > 0 ||
+      x + sprite_size <= -left_extra)
+    return true;
+  int slot = index >> 1;
+  return (ppu->wsOamLeftHint[slot >> 3] & (1u << (slot & 7))) != 0;
+}
+
 static bool ppu_evaluateSprites(Ppu* ppu, int line) {
   static const uint8 spriteSizes[8][2] = {
     {8, 16}, {8, 32}, {8, 64}, {16, 32},
@@ -2012,21 +2032,24 @@ static bool ppu_evaluateSprites(Ppu* ppu, int line) {
     int spriteHeight = PPU_objInterlace(ppu) ? spriteSize / 2 : spriteSize;
     if(row < spriteHeight) {
       int x = PpuDecodeOamX(ppu, index);
-      x = PpuAdjustWidescreenHudOamX(ppu, index, y, x);
       const int left_extra =
           PpuWidescreenHudOamSlot(ppu, index, y) &&
                   (ppu->wsHudSplitHeight & 0x80)
               ? ppu->extraLeftRight
               : ppu->extraLeftCur;
-      if(x + spriteSize > -left_extra) {
-        spritesFound++;
-        if(spritesFound > 32 &&
-           !(ppu->renderFlags & kPpuRenderFlags_NoSpriteLimits)) {
-          ppu->rangeOver = true;
-          spritesFound = 32;
-          break;
+      if (PpuWidescreenOamLeftHintAllows(ppu, index, x, spriteSize,
+                                          left_extra)) {
+        x = PpuAdjustWidescreenHudOamX(ppu, index, y, x);
+        if(x + spriteSize > -left_extra) {
+          spritesFound++;
+          if(spritesFound > 32 &&
+             !(ppu->renderFlags & kPpuRenderFlags_NoSpriteLimits)) {
+            ppu->rangeOver = true;
+            spritesFound = 32;
+            break;
+          }
+          foundSprites[spritesFound - 1] = index;
         }
-        foundSprites[spritesFound - 1] = index;
       }
     }
     index += 2;

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -234,14 +234,20 @@ struct Ppu {
   // margins. Layer bits use the PPU window layer numbering (BG1..BG4, OBJ,
   // color); window bits select W1/W2. Zero is the hardware-authentic default.
   uint8_t wsWindowExpandLayers, wsWindowExpandWindows;
-  // Strict decode of the ambiguous 9-bit OAM X band [256, 256+extraRightCur).
-  // A raw value there is either a genuine right-margin sprite (widescreen
-  // host emitted it on purpose) or a sprite the game parked off-screen-left
-  // at x-512 (invisible on hardware). When strict is set, only slots marked
-  // in wsOamRightHint keep the positive decode; unmarked slots wrap negative
-  // like hardware, so parked sprites don't ghost into the right margin.
-  // Default off preserves the legacy always-positive band (SMW relies on it).
-  // Games publish per NMI via PpuWsSetOamRightHints. 1 bit per OAM slot.
+  // Strict decode of ambiguous 9-bit OAM X margin bands. 1 bit per OAM slot.
+  // Left: sprites fully clipped by the authentic 256-wide viewport may become
+  // visible in [-extraLeftCur, 0). With strict left hints enabled, only marked
+  // slots render there; unmarked slots stay hardware-hidden.
+  // Right: raw X values in [256, 256+extraRightCur) are either genuine
+  // right-margin sprites or off-screen-left parked sprites wrapped through
+  // 9-bit OAM X. With strict right hints enabled, only marked slots keep the
+  // positive decode; unmarked slots wrap negative like hardware.
+  // Default off preserves the legacy margin behavior. Games publish hints per
+  // NMI after CPU-side OAM staging is final and before the frame is presented.
+  // A NULL hint pointer disables strict mode. Pass a zeroed array for strict
+  // mode with no slots marked.
+  uint8_t wsOamLeftHintStrict;
+  uint8_t wsOamLeftHint[16];
   uint8_t wsOamRightHintStrict;
   uint8_t wsOamRightHint[16];
   uint8_t lastMosaicModulo;
@@ -502,9 +508,16 @@ void PpuSetWsHudOamShiftRange(Ppu *ppu, uint8_t first_slot, uint8_t nslots);
  * reserve. nslots 0 disables. Publish every frame like the first range. */
 void PpuSetWsHudOamShiftRange2(Ppu *ppu, uint8_t first_slot, uint8_t nslots);
 
+// Publish this frame's OAM left-margin hints (see wsOamLeftHintStrict).
+// `hints` is a 128-bit set (16 bytes, bit N of byte N/8 = OAM slot N), or
+// NULL to disable strict decode and restore the legacy left-margin behavior.
+// Pass a zeroed array for strict mode with no left-margin slots marked.
+void PpuWsSetOamLeftHints(Ppu *ppu, const uint8_t *hints);
+
 // Publish this frame's OAM right-margin hints (see wsOamRightHintStrict).
 // `hints` is a 128-bit set (16 bytes, bit N of byte N/8 = OAM slot N), or
 // NULL to disable strict decode and restore the legacy always-positive band.
+// Pass a zeroed array for strict mode with no right-margin slots marked.
 // Games that stage OAM CPU-side should call this each NMI, after the staging
 // buffer is final and before the frame is presented.
 void PpuWsSetOamRightHints(Ppu *ppu, const uint8_t *hints);

--- a/tests/ppu/ppu_sprite_limit_test.c
+++ b/tests/ppu/ppu_sprite_limit_test.c
@@ -55,6 +55,31 @@ static void no_op_line_enhancer(Ppu *ppu, uint y, bool sub, void *context) {
     (void)context;
 }
 
+static void setup_solid_obj(Ppu *ppu, int slot, int x, int y) {
+    int high_index = slot >> 2;
+    int x_high_bit = (slot & 3) * 2;
+    ppu->oam[slot * 2] = (uint16_t)((y << 8) | (x & 0xff));
+    ppu->oam[slot * 2 + 1] = 0;
+    if (x & 0x100)
+        ppu->highOam[high_index] |= (uint8_t)(1u << x_high_bit);
+    else
+        ppu->highOam[high_index] &= (uint8_t)~(1u << x_high_bit);
+}
+
+static void setup_one_sprite_line(Ppu *ppu, int raw_x) {
+    ppu->inidisp = 0x0f;
+    ppu->screenEnabled[0] = 1 << 4;
+    memset(ppu->highOam, 0, sizeof ppu->highOam);
+    for (int slot = 0; slot < 128; slot++)
+        ppu->oam[slot * 2] = 0xf000;
+    setup_solid_obj(ppu, 0, raw_x, 0);
+    for (size_t i = 0; i < sizeof ppu->vram / sizeof ppu->vram[0]; i++)
+        ppu->vram[i] = 0xffff;
+    ppu->cgram[0] = 0;
+    for (size_t i = 1; i < sizeof ppu->cgram / sizeof ppu->cgram[0]; i++)
+        ppu->cgram[i] = 0x7fff;
+}
+
 int main(void) {
     enum { kPitch = kPpuXPixels * 4 };
     uint8_t pixels[kPitch];
@@ -315,6 +340,97 @@ int main(void) {
         failures += check(wide_pixels[0] == 0 &&
                               wide_pixels[kExtra] != 0,
                           "unselected world OAM remains centered");
+    }
+
+    /* Strict OAM margin hints are symmetric. A raw negative X may be a parked
+     * hardware-hidden sprite or a genuine widened-world sprite. Hosts can mark
+     * the genuine slots; unmarked fully-offscreen-left slots stay clipped. */
+    {
+        enum { kExtra = 16, kWidePixels = kPpuXPixels + kExtra * 2 };
+        uint32_t wide_pixels[kWidePixels];
+        uint8_t no_hints[16] = {0};
+        uint8_t slot0_hint[16] = {1};
+
+        ppu_reset(ppu);
+        memset(wide_pixels, 0, sizeof wide_pixels);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuWsSetOamLeftHints(ppu, no_hints);
+        setup_one_sprite_line(ppu, 0x1f8);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(wide_pixels[kExtra - 1] == 0 &&
+                              wide_pixels[kExtra - 8] == 0,
+                          "unhinted fully-off-left OAM stays clipped");
+
+        ppu_reset(ppu);
+        memset(wide_pixels, 0, sizeof wide_pixels);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuWsSetOamLeftHints(ppu, slot0_hint);
+        setup_one_sprite_line(ppu, 0x1f8);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(wide_pixels[kExtra - 1] != 0 &&
+                              wide_pixels[kExtra - 8] != 0,
+                          "hinted fully-off-left OAM renders in left margin");
+
+        ppu_reset(ppu);
+        memset(wide_pixels, 0, sizeof wide_pixels);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuWsSetOamLeftHints(ppu, no_hints);
+        setup_one_sprite_line(ppu, 0x1fc);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(wide_pixels[kExtra] != 0 &&
+                              wide_pixels[kExtra + 3] != 0,
+                          "strict left hints keep native-edge OAM visible");
+
+        ppu_reset(ppu);
+        memset(wide_pixels, 0, sizeof wide_pixels);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuWsSetOamRightHints(ppu, no_hints);
+        setup_one_sprite_line(ppu, 0x108);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(wide_pixels[kExtra + kPpuXPixels + 8] == 0,
+                          "unhinted right-band OAM wraps negative");
+
+        ppu_reset(ppu);
+        memset(wide_pixels, 0, sizeof wide_pixels);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuWsSetOamRightHints(ppu, slot0_hint);
+        setup_one_sprite_line(ppu, 0x108);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(wide_pixels[kExtra + kPpuXPixels + 8] != 0,
+                          "hinted right-band OAM remains positive");
+
+        ppu_reset(ppu);
+        memset(wide_pixels, 0, sizeof wide_pixels);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuWsSetOamLeftHints(ppu, NULL);
+        setup_one_sprite_line(ppu, 0x1f8);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(wide_pixels[kExtra - 1] != 0,
+                          "NULL left hints restore legacy margin behavior");
     }
 
     ppu_free(ppu);


### PR DESCRIPTION
Fixes #28.

Summary:
- add `PpuWsSetOamLeftHints()` and left-side strict hint storage
- gate only fully hardware-hidden negative-X sprites in the widened left margin
- preserve partially visible native-edge sprites and legacy behavior when hints are NULL
- document NULL vs zeroed-array strict-mode semantics for both left and right hints

Validation:
- `tests/ppu/run.ps1` passes (`ppu_sprite_limit_test: PASS`; existing renderer warnings only)
- `git diff --check` passes
- built SimCity widescreen branch against this framework patch with a temporary left-hint consumer
- SimCity `SC_WIDESCREEN=96 SC_WS_OAM=1 --qualify 600` passes
- Matthew manually checked the widened SimCity selector and reported it looks good