### PR TITLE
Clarify frame-model host timing contracts

### DIFF
--- a/docs/FRAME_MODEL_HOSTS.md
+++ b/docs/FRAME_MODEL_HOSTS.md
@@ -13,9 +13,11 @@ advances an independent beam can split a frame between two clocks. Device work
 derived from only the host-side clock can then miss edges that the bridge-side
 clock crossed.
 
-Prefer scheduling host device work from the shared `Snes` beam state, or keep a
-single explicit host-owned beam and audit every framework edge that must be
-called manually.
+`interp_bridge_run_loop()` and related LLE bridge entry points are therefore not
+"CPU only" helpers. While they execute guest instructions, they also advance the
+shared `Snes` beam to the interpreted CPU master clock. Prefer scheduling host
+device work from that shared `Snes` beam state, or keep a single explicit
+host-owned beam and audit every framework edge that must be called manually.
 
 Frame-model hosts that own HBlank/VBlank edges are responsible for hardware
 work normally driven by the framework timeline, including:
@@ -35,10 +37,12 @@ part of the requested SPC time. Frame-model hosts should catch up the APU at
 smaller timing slices or use the framework frame runner that owns the audio
 timeline.
 
-When the bridge is running with the absolute SA-1 frame timeline, interpreted
-APU deltas are consumed by that absolute clock. Hosts outside that model should
-not assume bridge exits alone have advanced all deferred SPC time; flush or
-catch up at explicit integration points.
+Ordinary SNES interpreter fallback still applies relative bridge catch-up for
+interpreted CPU time. Only the active SA-1 absolute frame timeline suppresses
+that relative catch-up, because its port accesses and frame boundary sync to the
+same guest timestamp. Hosts outside that model should not assume bridge exits
+alone have advanced all deferred SPC time; flush or catch up at explicit
+integration points.
 
 ## Bridge Hooks
 

--- a/runner/src/snes/interp_bridge.h
+++ b/runner/src/snes/interp_bridge.h
@@ -71,7 +71,12 @@ int interp_bridge_run_scheduler(CpuState *cpu, uint32_t entry_pc24,
 
 /* General infinite-loop driver.  This is the scheduler helper with an
  * explicit byte value for games whose vblank wait flag is asserted while
- * waiting (Super Metroid), rather than cleared after a slot walk (MMX). */
+ * waiting (Super Metroid), rather than cleared after a slot walk (MMX).
+ *
+ * This is not a CPU-only helper: interpreted opcodes advance the shared Snes
+ * beam through snes_sync_master_clock(). Frame-model hosts that also own a
+ * beam loop must integrate with that shared clock or manually reproduce the
+ * framework edges listed in docs/FRAME_MODEL_HOSTS.md. */
 int interp_bridge_run_loop(CpuState *cpu, uint32_t entry_pc24,
                            uint32_t yield_pc, uint16_t flag_addr,
                            uint8_t flag_value);
@@ -92,7 +97,9 @@ int interp_bridge_lle_took_wai(void);
 /* Optional whole-program LLE deadline.  When nonzero, the auto-quiescent
  * bridge yields at the first architectural instruction boundary whose master
  * clock reaches this value.  Event-driven game schedulers use this to prevent
- * a productive CPU/MMIO loop from running across multiple vblanks atomically. */
+ * a productive CPU/MMIO loop from running across multiple vblanks atomically.
+ * Combine with snes_next_irq_master() when raster IRQs can occur before the
+ * next frame boundary. */
 void interp_bridge_set_master_deadline(uint64_t master_clock);
 
 /* True only while a paired AOT bounce is executing inside an auto-quiescent

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -149,7 +149,10 @@ uint64_t g_apu_timer0_total_ticks = 0;
 void snes_catchupApu(Snes* snes) {
   /* Upper cap is a guard against accumulator runaway after a long
    * stall; SPC runs at ~1 MHz so 10000 cycles is about 10 ms of real
-   * SPC time per catchup, plenty to absorb any spike. */
+   * SPC time per catchup, plenty to absorb any spike. This is a frequent
+   * catch-up API, not a frame-at-a-time pacing API; hosts that own their
+   * own frame model should catch up at smaller slices or use the guest-time
+   * frame runner path. See docs/FRAME_MODEL_HOSTS.md. */
   if (snes->apuCatchupCycles > 10000)
     snes->apuCatchupCycles = 10000;
 

--- a/tests/interp816/run.ps1
+++ b/tests/interp816/run.ps1
@@ -28,10 +28,12 @@ if ($LASTEXITCODE -ne 0) { throw "interp816 core test failed" }
 $bridgeOut = Join-Path $outDir "bridge_test.exe"
 Build-BelowNormal @(
     "-std=c11", "-Wall", "-Wextra", "-Wno-unused-parameter", "-O1",
+    "-DSNESRECOMP_TIER2_TEST=1",
     "-I$root\runner\src", "-I$root\runner\src\snes",
     "$root\tests\interp816\bridge_test.c",
     "$root\runner\src\snes\interp816.c",
     "$root\runner\src\snes\interp_bridge.c",
+    "$root\runner\src\snes\tier2_capture.c",
     "$root\runner\src\snes\cx4.c",
     "-lm", "-o", $bridgeOut
 ) $bridgeOut

--- a/tests/interp816/run.sh
+++ b/tests/interp816/run.sh
@@ -15,8 +15,9 @@ gcc $CFLAGS -I runner/src/snes \
 
 echo ""
 echo "=== Phase 1: interp_bridge contract ==="
-gcc $CFLAGS -I runner/src -I runner/src/snes \
+gcc $CFLAGS -DSNESRECOMP_TIER2_TEST=1 -I runner/src -I runner/src/snes \
     tests/interp816/bridge_test.c \
     runner/src/snes/interp816.c runner/src/snes/interp_bridge.c \
+    runner/src/snes/tier2_capture.c \
     runner/src/snes/cx4.c -lm -o build/bridge_test
 exec ./build/bridge_test


### PR DESCRIPTION
Follow-up for #22.

Summary:
- clarify that `interp_bridge_run_loop()` and related bridge entries are not CPU-only helpers: interpreted opcodes advance the shared `Snes` beam
- clarify the current APU policy: ordinary SNES interpreter fallback still uses relative catch-up; only active SA-1 absolute timeline suppresses duplicate catch-up
- point frame-model hosts from the relevant bridge/deadline APIs to `docs/FRAME_MODEL_HOSTS.md`
- document `snes_catchupApu()` as a frequent-slice catch-up API rather than a frame-at-a-time pacing API
- fix the per-directory interp816 test runners so `bridge_test` is built with the same Tier2 test define/source as the top-level C runner

Validation:
- `git diff --check`
- `tests/interp816/run.ps1`
- `tests/runtime_dispatch/run_apu_port_guest_time_test.ps1`
- `bash tests/run_c_tests.sh` (passes; existing renderer warnings only)