### PR TITLE
Fix rbengine submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,5 @@
 
 [submodule "lib/retcomm-rbengine"]
 	path = lib/retcomm-rbengine
+	url = https://github.com/TechnicallyComputers/retcomm-rbengine.git
 	branch = main


### PR DESCRIPTION
## Summary
- Add the missing URL for the tracked lib/retcomm-rbengine submodule.
- Keep branch = main because the current gitlink commit ebd94a4729abe2c0615070cef3ffe05b3f9ebf28 is reachable from that branch.
- Preserve the submodule for incoming netplay/rollback work instead of removing it.

Fixes #41

## Validation
- git config -f .gitmodules --get-regexp '^submodule\\..*\\.(path|url|branch)$'
- git submodule sync -- lib/retcomm-rbengine
- git submodule update --init lib/retcomm-rbengine
- git submodule status --recursive
- git diff --check