### PR TITLE
Split #35: runtime and render fixes

### DIFF
--- a/recompiler/v2/decoder.py
+++ b/recompiler/v2/decoder.py
@@ -1172,8 +1172,8 @@ def _pea_ptrcall_return_pc(rom: Optional[bytes], bank: int, pc: int,
     return (pea_operand + 1) & 0xFFFF
 
 
-def detect_inline_arg_bytes(rom: bytes, bank: int, addr: int,
-                            entry_m: int = 1, entry_x: int = 1):
+def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
+                                        entry_m: int = 1, entry_x: int = 1):
     """Detect whether the subroutine at (bank, addr) is a JSR/JSL
     INLINE-ARGUMENT routine, returning the inline byte count N (or None).
 
@@ -1347,6 +1347,148 @@ def detect_inline_arg_bytes(rom: bytes, bank: int, addr: int,
     return None
 
 
+def _pulled_return_slots(insns) -> set:
+    """Addresses that received a byte pulled straight off the stack.
+
+    `PLA` immediately followed by `STA <dp/abs>` is how a routine copies its
+    own return address out of the stack frame. Two or more of those in a row,
+    into consecutive addresses, is a 16- or 24-bit return-address pointer.
+    Returns the base address of every such run.
+    """
+    got = []
+    pending = False
+    for ins in insns:
+        if ins.opcode == 0x68:            # PLA
+            pending = True
+            continue
+        if pending and ins.opcode in (0x85, 0x8D):   # STA dp / STA abs
+            got.append(ins.operand & 0xFFFF)
+        pending = False
+    bases = set()
+    run_start = None
+    for i, a in enumerate(got):
+        if run_start is None:
+            run_start = a
+        elif a != got[i - 1] + 1:
+            run_start = a
+        if run_start is not None and a - run_start >= 1:
+            bases.add(run_start)
+    return bases
+
+
+def _indirect_through_pulled_return(insns, last) -> bool:
+    """True when `last` is an indirect jump through a pulled return address."""
+    bases = _pulled_return_slots(insns)
+    if not bases:
+        return False
+    ptr = last.operand & 0xFFFF
+    return ptr in bases
+
+
+def detect_dp_return_inline_arg_bytes(rom: bytes, bank: int, addr: int):
+    """Inline-argument count for the PLA-into-direct-page return idiom.
+
+    `detect_inline_arg_bytes` above recognises the form that writes the
+    adjusted return address BACK TO THE STACK SLOT and leaves through RTS/RTL.
+    This is the other spelling: pull the 24-bit return address into consecutive
+    direct-page bytes, add the inline size to the low word, and leave through
+    `JML [dp]`. Gundam Wing Endless Duel's $00:8F2F is the canonical case and
+    has 37 call sites, so getting it wrong is not a local defect.
+
+        STA $E4              ; (the routine's own index argument)
+        SEP #$20
+        PLA / STA $E0        ; return address low
+        PLA / STA $E1        ;                high
+        PLA / STA $E2        ;                bank
+        ...
+        CLC / LDA $E0 / ADC #$0007 / STA $E0
+        JML [$00E0]          ; return, past 7 bytes of inline data
+
+    Returns N, or None when the shape does not match exactly.
+    """
+    from snes65816 import decode_insn, lorom_offset
+    pc = addr & 0xFFFF
+    m = x = 1
+    pulled = []          # dp addresses that received a PLA byte, in order
+    pending_pla = False
+    ret_base = None
+    armed = False        # LDA <ret_base> seen, tracking an ADC
+    added = 0
+    found_n = None
+    budget = 0
+    while budget < 160:
+        budget += 1
+        if not (0x8000 <= pc <= 0xFFFF):
+            return None
+        try:
+            off = lorom_offset(bank, pc)
+        except AssertionError:
+            return None
+        if off >= len(rom):
+            return None
+        try:
+            ins = decode_insn(rom, off, pc, bank, m=m, x=x)
+        except Exception:
+            return None
+        if ins is None:
+            return None
+        op = ins.opcode
+
+        if ins.mnem == 'REP':
+            if ins.operand & 0x20: m = 0
+            if ins.operand & 0x10: x = 0
+        elif ins.mnem == 'SEP':
+            if ins.operand & 0x20: m = 1
+            if ins.operand & 0x10: x = 1
+
+        if op == 0x68:                                  # PLA
+            pending_pla = True
+        elif pending_pla and op == 0x85:                # STA dp, right after PLA
+            pulled.append(ins.operand & 0xFF)
+            pending_pla = False
+            if len(pulled) >= 2 and pulled[-1] == pulled[-2] + 1:
+                ret_base = pulled[0]
+        else:
+            pending_pla = False
+            if ret_base is not None:
+                if op == 0xA5 and (ins.operand & 0xFF) == ret_base:   # LDA dp
+                    armed, added = True, 0
+                elif armed and op == 0x69:                            # ADC #imm
+                    added = (added + ins.operand) & 0xFFFF
+                elif armed and op == 0x85 and (ins.operand & 0xFF) == ret_base:
+                    if added:
+                        found_n = added                  # LDA/ADC/STA back to dp
+                    armed = False
+                elif op == 0xDC:                                      # JML [abs]
+                    ptr = ins.operand & 0xFFFF
+                    if (ptr & 0xFF) == ret_base and (ptr >> 8) == 0 and found_n:
+                        return found_n & 0xFF
+                    return None
+                elif ins.mnem in ('RTS', 'RTL', 'RTI', 'JMP', 'JML', 'STP'):
+                    return None
+        pc = (pc + ins.length) & 0xFFFF
+    return None
+
+
+def detect_inline_arg_bytes(rom: bytes, bank: int, addr: int,
+                            entry_m: int = 1, entry_x: int = 1):
+    """Inline-argument byte count for the routine at (bank, addr), or None.
+
+    Two spellings of the same idiom, tried in order:
+      * stack-slot write-back, leaving through RTS/RTL
+        (`_detect_inline_arg_bytes_stack_slot`)
+      * pull into direct page, leaving through `JML [dp]`
+        (`detect_dp_return_inline_arg_bytes`)
+
+    The second cannot be folded into the first: that scanner returns None the
+    moment it meets a terminator, and `JML [dp]` IS this form's terminator.
+    """
+    n = _detect_inline_arg_bytes_stack_slot(rom, bank, addr, entry_m, entry_x)
+    if n is not None:
+        return n
+    return detect_dp_return_inline_arg_bytes(rom, bank, addr)
+
+
 def classify_dispatch_helper(rom: bytes, bank: int, addr: int):
     """Identify whether the subroutine at (bank, addr) is a JSL-jump-table
     dispatch helper. Returns 'short' (16-bit table entries), 'long'
@@ -1406,6 +1548,16 @@ def classify_dispatch_helper(rom: bytes, bank: int, addr: int):
     last = insns[-1]
     if not (last.mnem in ('JMP', 'JML') and
             last.mode in (INDIR, INDIR_X, INDIR_L)):
+        return None
+    # ...but an indirect jump THROUGH THE PULLED RETURN ADDRESS is a return,
+    # not a dispatch. The inline-argument idiom pulls its own 24-bit return
+    # address into consecutive direct-page bytes, advances it past the inline
+    # data, and leaves through `JML [dp]`. That matches every structural test
+    # above — PLA present, terminal indirect jump, and an `ASL A ... TAX` that
+    # is really indexing a DATA table (Gundam Wing's $00:8F2F indexes a bitmask
+    # table for TSB, not a jump table). Classifying it as a dispatch synthesises
+    # a jump table out of unrelated data and abandons every call site.
+    if _indirect_through_pulled_return(insns, last):
         return None
     # Width: ASL A ... TAY/TAX, with ADC in between → long.
     asl_seen = False

--- a/runner/runner.cmake
+++ b/runner/runner.cmake
@@ -144,8 +144,19 @@ message(STATUS "Cx4: instruction-level HG51B S169 core (ares, ISC)")
 # a normal playable build; opt in with -DSNESRECOMP_ENABLE_TRACE=ON.
 option(SNESRECOMP_ENABLE_TRACE "Build the TCP debug server / observability rings" OFF)
 if(SNESRECOMP_ENABLE_TRACE)
+    # Compiling debug_server.c is only half of turning tracing on. The header
+    # keys off SNESRECOMP_TRACE, not off the option, and defaults it to 0 — so
+    # without this define every translation unit (debug_server.c included) sees
+    # the no-op stubs, and debug_server.c's real definitions collide with the
+    # stubs it just pulled in from its own header. The option was inert before
+    # this: -DSNESRECOMP_ENABLE_TRACE=ON did not build, it only failed.
+    add_compile_definitions(SNESRECOMP_TRACE=1)
     list(APPEND SNESRECOMP_RUNNER_SOURCES
         ${SNESRECOMP_RUNNER_ROOT}/src/debug_server.c
+        # debug_server.c's on-demand dump calls recomp_post_mortem_dump(), and
+        # this is the only translation unit that defines it. It is not in the
+        # base source list, so a trace build does not link without it.
+        ${SNESRECOMP_RUNNER_ROOT}/src/desktop/post_mortem.c
     )
     if(EXISTS ${SNESRECOMP_RUNNER_ROOT}/src/emu_oracle_cmds.c)
         list(APPEND SNESRECOMP_RUNNER_SOURCES

--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -771,6 +771,28 @@ uint8 *RomPtr(uint32_t addr) {
 static int _writereg_ppu_count = 0;
 static int _writereg_dma_count = 0;
 void WriteReg(uint16 reg, uint8 value) {
+  /* Advance emulated beam time before the write lands.
+   *
+   * AOT-compiled code never advances the PPU beam — only a $2137 read did, in
+   * ReadRegOpenBus below — so a compiled routine executes in zero PPU time no
+   * matter how many cycles it costs. The interpreter does the opposite: it
+   * calls snes_sync_master_clock after every opcode. That asymmetry is what
+   * loses raster splits scheduled close together: snes_advance_beam's IRQ
+   * comparator is a WINDOW test (target inside [h, h+span)), so a beam that
+   * jumps in one lump can step straight over a target and produce no IRQ at
+   * all rather than a late one.
+   *
+   * Measured on Gundam Wing: $00:888E is the line-21 split handler, it writes
+   * INIDISP = shadow & $80 (brightness 0, deliberate) and schedules the split
+   * that RESTORES brightness only two scanlines later at line 23. That second
+   * split was missed in ~85% of frames, leaving the gameplay demo black for
+   * ~1100 consecutive frames.
+   *
+   * Syncing on every hardware touch keeps compiled and interpreted code on the
+   * same clock. It is bounded work: register accesses are rare next to RAM, and
+   * frequent syncing keeps each delta small. */
+  if (g_snes)
+    snes_sync_master_clock(g_snes, g_cpu.master_cycles);
   // Direct dispatch — bypass emulator bus
   // MSU-1 ($2000-$2007). Inert unless a pack is armed, so the open-bus
   // default (no-op + log) is preserved byte-for-byte when disabled.
@@ -795,6 +817,12 @@ void WriteReg(uint16 reg, uint8 value) {
     cart_write(g_snes->cart, 0, reg, value);
   } else if (reg >= 0x2100 && reg < 0x2140) {
     ppu_write(g_ppu, reg & 0xff, value);
+    /* Feed the raster journal: a mid-frame write to a display-state register
+     * is a per-line fact the frame-end render would otherwise discard. The
+     * beam line is exact here — during an IRQ handler the beam is held at the
+     * latch line. ppu_rasterRecord itself filters to the journaled set. */
+    if (g_snes)
+      ppu_rasterRecord(reg, g_snes->vPos, value);
   } else if (reg >= 0x2140 && reg < 0x2180) {
 #if SNESRECOMP_ENABLE_MODS
     if (snes_mod_runtime_filter_apu_write_c(reg, value)) {
@@ -806,8 +834,14 @@ void WriteReg(uint16 reg, uint8 value) {
   } else if (reg >= 0x2180 && reg < 0x2184) {
     snes_writeBBus(g_snes, reg & 0xff, value);
   } else if (reg >= 0x4200 && reg < 0x4220) {
-    if (reg == 0x420C)
+    if (reg == 0x420C) {
       g_snesrecomp_last_hdmaen = value;
+      /* Per-line fact: this title switches the transition's HDMA
+       * channels on from the line-21 raster handler, and a frame-model
+       * host that samples the mask once at render time never sees them.
+       * See raster_reg_journaled() in ppu.c. */
+      if (g_snes) ppu_rasterRecord(reg, g_snes->vPos, value);
+    }
     if (reg == 0x420D)
       g_memsel = (uint8_t)(value & 1);  /* FastROM select; paces $80-FF code */
     recomp_write_internal_reg(reg, value);

--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -210,7 +210,10 @@ static uint64_t fp_fnv1a(const uint8_t *p, size_t n) {
  * v7: manual joypad latch/shift state appended after the existing SNES blob.
  *     Older files initialize that transient serial state to idle. */
 #define RTL_SAV_VERSION 7u
-#define RTL_SAV_VERSION_MIN 4u
+/* 4 and 5 described a Snes tail layout this struct no longer has; see
+ * snes_saveload(). Loading one would mis-map the interrupt fields, so
+ * they are rejected by the header check instead. */
+#define RTL_SAV_VERSION_MIN 6u
 
 typedef struct FileSli {
   SaveLoadInfo base;

--- a/runner/src/cpu_trace.c
+++ b/runner/src/cpu_trace.c
@@ -1808,6 +1808,14 @@ void cpu_trace_stack_op(CpuState *cpu, uint32_t pc24, uint8_t op_id,
      * for non-WRAM events, free to repurpose). */
     capture(cpu, pc24, CPU_TR_STACK_OP, op_id,
             (uint16_t)((uint16_t)(uint8_t)delta << 8));
+    /* capture() no-ops when the ring was never allocated — a trace-enabled
+     * binary that skipped cpu_trace_init(), which capture() documents as a
+     * supported configuration. Patching up "the event capture() just wrote"
+     * is only valid if it actually wrote one: otherwise g_cpu_trace_idx is
+     * still 0, just_idx underflows to UINT64_MAX, and the masked index runs
+     * off a NULL ring. Stack ops are on by default, so that is a guaranteed
+     * segfault on the first guest push rather than a rare one. */
+    if (!g_cpu_trace_ring || g_cpu_trace_capacity == 0) return;
     uint64_t just_idx = g_cpu_trace_idx - 1;
     CpuTraceEvent *just = &g_cpu_trace_ring[just_idx & (g_cpu_trace_capacity - 1)];
     just->addr16 = old_S;

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -1531,15 +1531,41 @@ static void DebugPpuRestoreHostState(Ppu *ppu,
                                  state->enhancer_context);
 }
 
+/* Render the way the HOST does, through the game's own draw_ppu_frame.
+ *
+ * This used to paint lines 0..224 with ppu_runLine and renderFlags 0, which
+ * was wrong twice over: flags 0 selects the legacy pixel-at-a-time
+ * compositor (ppu.h documents it ignoring several features) rather than the
+ * kPpuRenderFlags_NewRenderer path the host presents with, and a bare
+ * ppu_runLine loop replays no raster journal and steps no HDMA. On a title
+ * that raster-splits and drives TM per scanline by HDMA, that is a different
+ * picture: measured ~25,800 px off the presented composite, and with INIDISP
+ * left at 0x80 at end of frame it could paint the whole frame forced-blank.
+ * dump_frame_raw is built on this, so its images were misleading.
+ *
+ * The production path mutates more than pixels — ppu_rasterRenderBegin
+ * rewrites the line-0 register baseline, ppu_rasterApplyLine walks the
+ * journal cursor, dma_initHdma/dma_doHdma step every HDMA channel — so both
+ * structs are restored wholesale afterwards. An observer must leave nothing
+ * behind. */
 static void DebugPpuRenderAuthentic(uint8_t *pixels) {
-    DebugPpuHostState state;
-    DebugPpuSaveHostState(g_ppu, &state);
-    PpuBeginDrawing(g_ppu, pixels, 256 * 4, 0);
+    static Ppu save_ppu;
+    static uint8_t save_dma[sizeof(Dma)];
+    int have_dma = (g_snes && g_snes->dma) ? 1 : 0;
+    memcpy(&save_ppu, g_ppu, sizeof(Ppu));
+    if (have_dma) memcpy(save_dma, g_snes->dma, sizeof(Dma));
+
+    PpuBeginDrawing(g_ppu, pixels, 256 * 4, save_ppu.renderFlags);
     PpuSetExtraSpace(g_ppu, 0);
     PpuSetWidescreenLineEnhancer(g_ppu, NULL, NULL);
-    for (int i = 0; i <= 224; i++)
-        ppu_runLine(g_ppu, i);
-    DebugPpuRestoreHostState(g_ppu, &state);
+    if (g_rtl_game_info && g_rtl_game_info->draw_ppu_frame)
+        g_rtl_game_info->draw_ppu_frame();
+    else
+        for (int i = 0; i <= 224; i++)
+            ppu_runLine(g_ppu, i);
+
+    memcpy(g_ppu, &save_ppu, sizeof(Ppu));
+    if (have_dma) memcpy(g_snes->dma, save_dma, sizeof(Dma));
 }
 
 void debug_server_record_frame(int frame) {
@@ -1579,15 +1605,16 @@ void debug_server_record_frame(int frame) {
         /* Copy the composite the host actually presented, rather than
          * re-rendering the PPU.
          *
-         * Re-rendering (DebugPpuRenderAuthentic, which dump_frame_raw uses)
-         * paints all 224 lines from the register state in force RIGHT NOW.
-         * This game draws through a per-line raster journal and ends every
-         * frame with INIDISP back at 0x80, so a re-render at this point
-         * paints the whole frame forced-blank: 120 byte-identical black
-         * frames captured off a game that was visibly rendering. Whatever
-         * mid-frame register changes make the picture -- raster splits,
-         * per-line HDMA -- are exactly what a re-render throws away, and
-         * they are exactly what a visual defect lives in.
+         * Historically DebugPpuRenderAuthentic painted all 224 lines from
+         * the register state in force RIGHT NOW, with no journal replay and
+         * no HDMA. This game draws through a per-line raster journal and ends
+         * every frame with INIDISP back at 0x80, so that re-render painted
+         * the whole frame forced-blank: 120 byte-identical black frames
+         * captured off a game that was visibly rendering. That helper now
+         * replays through the game's own draw_ppu_frame, so it no longer
+         * throws the splits away -- but copying the presented composite is
+         * still the cheaper and more literal answer to "what did the player
+         * see", so this path keeps doing it.
          *
          * cmd_screenshot already takes this path and says why. This is the
          * last frame the host finished compositing, so file fN.raw holds
@@ -4785,30 +4812,11 @@ static void cmd_render_inject(const char *args) {
     if (clen >= 512) memcpy((uint8_t *)g_ppu->cgram, cbuf, 512);
 
     static uint8_t px[256 * 4 * 240];
-    /* Render through the PRODUCTION draw path, not a bare ppu_runLine loop.
-     *
-     * DebugPpuRenderAuthentic renders lines 0..224 with renderFlags 0 and no
-     * raster-journal replay and no HDMA. For a title that raster-splits and
-     * drives TM per scanline by HDMA, that is not the same picture: a
-     * self-test that injected our OWN state and compared against our OWN
-     * recorded composite for the SAME frame missed by ~25,800 px, against
-     * every frame in the window. Flags 0 also selects the legacy compositor
-     * rather than the kPpuRenderFlags_NewRenderer path the host presents
-     * with. An instrument that cannot reproduce a picture from the state that
-     * produced it cannot testify about anybody else's state.
-     *
-     * draw_ppu_frame is the very function the host calls each frame, so this
-     * renders exactly what would have been presented. */
-    PpuBeginDrawing(g_ppu, px, 256 * 4, save_ppu.renderFlags);
-    PpuSetExtraSpace(g_ppu, 0);
-    PpuSetWidescreenLineEnhancer(g_ppu, NULL, NULL);
-    int used_production = 0;
-    if (g_rtl_game_info && g_rtl_game_info->draw_ppu_frame) {
-        g_rtl_game_info->draw_ppu_frame();
-        used_production = 1;
-    } else {
-        for (int i = 0; i <= 224; i++) ppu_runLine(g_ppu, i);
-    }
+    /* DebugPpuRenderAuthentic now renders through the production path and
+     * restores Ppu/Dma itself; the outer save/restore here is what undoes the
+     * INJECTION. */
+    int used_production = (g_rtl_game_info && g_rtl_game_info->draw_ppu_frame) ? 1 : 0;
+    DebugPpuRenderAuthentic(px);
 
     memcpy(g_ppu, &save_ppu, sizeof(Ppu));
     if (have_dma) memcpy(g_snes->dma, save_dma, sizeof(Dma));

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -47,6 +47,7 @@ extern int snes_frame_counter;
 // Hardware state access (for exhaustive debug dumps)
 #include "snes/ppu.h"
 #include "snes/cpu.h"
+#include "common_cpu_infra.h"
 #include "snes/dma.h"
 #include "snes/apu.h"
 #include "snes/spc.h"
@@ -4711,6 +4712,144 @@ static void cmd_raster_journal(const char *args) {
     send_all_bounded("\n", 1);
 }
 
+/* render_inject <out_bmp> <vram_byte_lo_hex> <vram_bin> [oam_bin] [cgram_bin]
+ *
+ * Renders a frame from INJECTED PPU buffers and restores everything. Purely an
+ * observer: it never advances the guest and leaves no state behind.
+ *
+ * It exists to settle "is our renderer wrong, or is the state we render wrong?"
+ * — a question pixels alone cannot answer. Feed it an oracle capture's VRAM /
+ * OAM / CGRAM and compare the result against that oracle's own screenshot:
+ * matching means the renderer is faithful and the fault is which state we draw;
+ * differing means the fault is in the renderer's own addressing, and no amount
+ * of frame-model reordering would have fixed it.
+ *
+ * The VRAM file is a byte image of a SUB-RANGE starting at vram_byte_lo, so a
+ * bounded oracle capture can be injected without needing all 64K. Everything
+ * outside the named range keeps the live contents.
+ */
+static void cmd_render_inject(const char *args) {
+    if (!g_ppu) { send_fmt("{\"error\":\"ppu not available\"}"); return; }
+    char out[256], vpath[256], opath[256], cpath[256];
+    unsigned int vlo = 0;
+    out[0] = vpath[0] = opath[0] = cpath[0] = 0;
+    int n = sscanf(args ? args : "", "%255s %x %255s %255s %255s",
+                   out, &vlo, vpath, opath, cpath);
+    if (n < 3) {
+        send_fmt("{\"error\":\"usage: render_inject <out_bmp> <vram_byte_lo_hex> "
+                 "<vram_bin> [oam_bin] [cgram_bin]\"}");
+        return;
+    }
+    if (vlo >= 0x10000) { send_fmt("{\"error\":\"vram_byte_lo out of range\"}"); return; }
+
+    /* Read the blobs BEFORE touching the PPU, so a missing file cannot leave
+     * injected state behind. */
+    static uint8_t vbuf[0x10000];
+    size_t vlen = 0;
+    { FILE *f = fopen(vpath, "rb");
+      if (!f) { send_fmt("{\"error\":\"cannot open vram_bin\",\"path\":\"%s\"}", vpath); return; }
+      vlen = fread(vbuf, 1, sizeof(vbuf), f); fclose(f); }
+    if (vlo + vlen > 0x10000) vlen = 0x10000 - vlo;
+
+    uint8_t obuf[544]; size_t olen = 0;
+    if (opath[0]) {
+        FILE *f = fopen(opath, "rb");
+        if (!f) { send_fmt("{\"error\":\"cannot open oam_bin\",\"path\":\"%s\"}", opath); return; }
+        olen = fread(obuf, 1, sizeof(obuf), f); fclose(f);
+    }
+    uint8_t cbuf[512]; size_t clen = 0;
+    if (cpath[0]) {
+        FILE *f = fopen(cpath, "rb");
+        if (!f) { send_fmt("{\"error\":\"cannot open cgram_bin\",\"path\":\"%s\"}", cpath); return; }
+        clen = fread(cbuf, 1, sizeof(cbuf), f); fclose(f);
+    }
+
+    lock_mutex();
+    /* Snapshot the WHOLE Ppu and Dma, not just the buffers we inject.
+     *
+     * The render below runs the production draw path, which mutates far more
+     * than VRAM/OAM/CGRAM: ppu_rasterRenderBegin rewrites the line-0 register
+     * baseline, ppu_rasterApplyLine walks the journal cursor, and
+     * dma_initHdma/dma_doHdma step every HDMA channel's table pointers. An
+     * observer must not leave any of that behind, so the cheap and certain
+     * thing is to restore both structs wholesale. */
+    static Ppu save_ppu;
+    static uint8_t save_dma[sizeof(Dma)];
+    int have_dma = (g_snes && g_snes->dma) ? 1 : 0;
+    memcpy(&save_ppu, g_ppu, sizeof(Ppu));
+    if (have_dma) memcpy(save_dma, g_snes->dma, sizeof(Dma));
+
+    memcpy((uint8_t *)g_ppu->vram + vlo, vbuf, vlen);
+    if (olen >= 512) memcpy((uint8_t *)g_ppu->oam, obuf, 512);
+    if (olen >= 544) memcpy(g_ppu->highOam, obuf + 512, 32);
+    if (clen >= 512) memcpy((uint8_t *)g_ppu->cgram, cbuf, 512);
+
+    static uint8_t px[256 * 4 * 240];
+    /* Render through the PRODUCTION draw path, not a bare ppu_runLine loop.
+     *
+     * DebugPpuRenderAuthentic renders lines 0..224 with renderFlags 0 and no
+     * raster-journal replay and no HDMA. For a title that raster-splits and
+     * drives TM per scanline by HDMA, that is not the same picture: a
+     * self-test that injected our OWN state and compared against our OWN
+     * recorded composite for the SAME frame missed by ~25,800 px, against
+     * every frame in the window. Flags 0 also selects the legacy compositor
+     * rather than the kPpuRenderFlags_NewRenderer path the host presents
+     * with. An instrument that cannot reproduce a picture from the state that
+     * produced it cannot testify about anybody else's state.
+     *
+     * draw_ppu_frame is the very function the host calls each frame, so this
+     * renders exactly what would have been presented. */
+    PpuBeginDrawing(g_ppu, px, 256 * 4, save_ppu.renderFlags);
+    PpuSetExtraSpace(g_ppu, 0);
+    PpuSetWidescreenLineEnhancer(g_ppu, NULL, NULL);
+    int used_production = 0;
+    if (g_rtl_game_info && g_rtl_game_info->draw_ppu_frame) {
+        g_rtl_game_info->draw_ppu_frame();
+        used_production = 1;
+    } else {
+        for (int i = 0; i <= 224; i++) ppu_runLine(g_ppu, i);
+    }
+
+    memcpy(g_ppu, &save_ppu, sizeof(Ppu));
+    if (have_dma) memcpy(g_snes->dma, save_dma, sizeof(Dma));
+    unlock_mutex();
+
+    FILE *f = fopen(out, "wb");
+    if (!f) { send_fmt("{\"error\":\"cannot open out_bmp\",\"path\":\"%s\"}", out); return; }
+    const int w = 256, h = 224;
+    int row_bytes = w * 3;
+    int pad = (4 - (row_bytes % 4)) % 4;
+    int stride = row_bytes + pad;
+    int img_size = stride * h;
+    int file_size = 54 + img_size;
+    uint8_t hdr[54] = {0};
+    hdr[0] = 'B'; hdr[1] = 'M';
+    hdr[2] = file_size; hdr[3] = file_size >> 8; hdr[4] = file_size >> 16; hdr[5] = file_size >> 24;
+    hdr[10] = 54; hdr[14] = 40;
+    hdr[18] = (uint8_t)(w & 0xFF); hdr[19] = (uint8_t)((w >> 8) & 0xFF);
+    { int neg_h = -h; memcpy(&hdr[22], &neg_h, 4); }
+    hdr[26] = 1; hdr[28] = 24;
+    hdr[34] = img_size; hdr[35] = img_size >> 8; hdr[36] = img_size >> 16; hdr[37] = img_size >> 24;
+    fwrite(hdr, 1, 54, f);
+    uint8_t row_buf[256 * 3 + 4];
+    memset(row_buf, 0, sizeof(row_buf));
+    for (int y = 0; y < h; y++) {
+        const uint8_t *src = px + (size_t)y * w * 4;
+        for (int x = 0; x < w; x++) {
+            row_buf[x * 3 + 0] = src[x * 4 + 0];
+            row_buf[x * 3 + 1] = src[x * 4 + 1];
+            row_buf[x * 3 + 2] = src[x * 4 + 2];
+        }
+        fwrite(row_buf, 1, stride, f);
+    }
+    fclose(f);
+    send_fmt("{\"ok\":true,\"path\":\"%s\",\"vram_lo\":\"0x%04x\",\"vram_bytes\":%u,"
+             "\"oam_bytes\":%u,\"cgram_bytes\":%u,\"width\":%d,\"height\":%d,"
+             "\"path_used\":\"%s\"}",
+             out, vlo, (unsigned)vlen, (unsigned)olen, (unsigned)clen, w, h,
+             used_production ? "production-draw_ppu_frame" : "fallback-ppu_runLine");
+}
+
 static void cmd_get_ppu_state(const char *args) {
     if (!g_ppu) { send_fmt("{\"error\":\"ppu not available\"}"); return; }
     Ppu *p = g_ppu;
@@ -7886,6 +8025,7 @@ static const CmdEntry s_commands[] = {
     {"get_apu_state", cmd_get_apu_state},
     {"dump_apu_ram",  cmd_dump_apu_ram},
     {"screenshot",     cmd_screenshot},
+    {"render_inject",  cmd_render_inject},
     {"dump_frame_raw", cmd_dump_frame_raw},
     {"stackbal",       cmd_stackbal},
     {"fingerprint",    cmd_fingerprint},

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -2635,19 +2635,46 @@ static void cmd_get_vram_trace(const char *args) {
     }
     int nostack = args && strstr(args, "nostack") != NULL;
     static char buf[524288];
+    /* Pagination. Without it this walked from the OLDEST entry and stopped when
+     * the buffer filled, so a long-lived ring answered with its first few
+     * thousand rows and silently dropped everything recent — a capture taken on
+     * frame 4384 came back holding nothing but frame 46. That reads as "nothing
+     * wrote here", which is a false negative, not a truncation anyone notices.
+     *
+     * So the DEFAULT is now the NEWEST window that fits, and `idx_from` /
+     * `idx_lim` (indices into the live ring, oldest = 0) select explicitly.
+     * The reply says which slice it actually returned. */
+    int budget = (int)sizeof(buf) - 4096;
+    uint64_t cap = s_vram_trace.capacity ? s_vram_trace.capacity : 1;
+    uint64_t avail = s_vram_trace.count < cap ? s_vram_trace.count : cap;
+    /* Conservative bytes-per-row so the window we promise actually fits. */
+    uint64_t rows_fit = (uint64_t)(budget / (nostack ? 180 : 260));
+    if (rows_fit < 1) rows_fit = 1;
+    uint64_t want = rows_fit;
+    uint64_t from = avail > want ? avail - want : 0;
+    if (args) {
+        const char *p2 = strstr(args, "idx_from=");
+        if (p2) { unsigned long long v = 0; sscanf(p2 + 9, "%llu", &v); from = (uint64_t)v; }
+        p2 = strstr(args, "idx_lim=");
+        if (p2) { unsigned long long v = 0; sscanf(p2 + 8, "%llu", &v);
+                  if (v && v < want) want = (uint64_t)v; }
+    }
+    if (from > avail) from = avail;
+    if (from + want > avail) want = avail - from;
+
     int pos = snprintf(buf, sizeof(buf), "{\"ranges\":[");
     for (int i = 0; i < s_vram_trace.nranges; i++)
         pos += snprintf(buf + pos, sizeof(buf) - pos,
             "%s[\"0x%04x\",\"0x%04x\"]", i ? "," : "",
             s_vram_trace.ranges[i].lo, s_vram_trace.ranges[i].hi);
     pos += snprintf(buf + pos, sizeof(buf) - pos,
-        "],\"entries\":%llu,\"log\":[",
-        (unsigned long long)s_vram_trace.count);
-    uint64_t cap = s_vram_trace.capacity ? s_vram_trace.capacity : 1;
-    uint64_t start = s_vram_trace.count < cap ?
-                     0 : s_vram_trace.write_idx - cap;
-    int budget = (int)sizeof(buf) - 4096;
-    for (uint64_t i = 0; i < s_vram_trace.count && pos < budget; i++) {
+        "],\"entries\":%llu,\"idx_from\":%llu,\"returned\":%llu,\"log\":[",
+        (unsigned long long)s_vram_trace.count,
+        (unsigned long long)from, (unsigned long long)want);
+    uint64_t base = s_vram_trace.count < cap ?
+                    0 : s_vram_trace.write_idx - cap;
+    uint64_t start = base + from;
+    for (uint64_t i = 0; i < want && pos < budget; i++) {
         uint64_t idx = (start + i) % cap;
         if (nostack) {
             pos += snprintf(buf + pos, sizeof(buf) - pos,

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -1479,6 +1479,23 @@ static volatile int s_fdump_target = -1;
 static volatile int s_fdump_done   = -1;
 static char s_fdump_path[512];
 
+/* Burst capture of CONSECUTIVE frames (dump_frame_range).
+ *
+ * dump_frame_raw cannot do this. It returns at the moment frame N is
+ * recorded, but it polls s_fdump_done on a 10 ms tick, and a frame is
+ * 16.7 ms — so by the time the caller is woken, round-trips, and arms N+1,
+ * N+1 has usually already gone past. Every frame after the first times out.
+ * A one-frame animation glitch is exactly what needs consecutive frames, so
+ * the range is armed ONCE here and the emulation thread writes each frame as
+ * it passes. Still no pausing: same non-pausing capture path as the single
+ * shot, just left armed. */
+static volatile int s_frange_start   = -1;
+static volatile int s_frange_end     = -1;   /* exclusive */
+static volatile int s_frange_written = 0;
+static volatile int s_frange_errno   = 0;
+static volatile int s_frange_active  = 0;
+static char s_frange_dir[400];
+
 typedef struct DebugPpuHostState {
     uint8_t *render_buffer;
     uint32_t render_pitch, render_flags;
@@ -1550,6 +1567,64 @@ void debug_server_record_frame(int frame) {
         if (f) { fwrite(fdump_scr, 1, 256 * 224 * 4, f); fclose(f); }
         s_fdump_target = -1;
         s_fdump_done = frame;
+    }
+
+    if (s_frange_active && frame >= s_frange_start && frame < s_frange_end
+        && g_ppu) {
+        static uint8_t frange_scr[256 * 4 * 240];
+        size_t want = (size_t)256 * 224 * 4;
+        char path[512];
+        FILE *f;
+        /* Copy the composite the host actually presented, rather than
+         * re-rendering the PPU.
+         *
+         * Re-rendering (DebugPpuRenderAuthentic, which dump_frame_raw uses)
+         * paints all 224 lines from the register state in force RIGHT NOW.
+         * This game draws through a per-line raster journal and ends every
+         * frame with INIDISP back at 0x80, so a re-render at this point
+         * paints the whole frame forced-blank: 120 byte-identical black
+         * frames captured off a game that was visibly rendering. Whatever
+         * mid-frame register changes make the picture -- raster splits,
+         * per-line HDMA -- are exactly what a re-render throws away, and
+         * they are exactly what a visual defect lives in.
+         *
+         * cmd_screenshot already takes this path and says why. This is the
+         * last frame the host finished compositing, so file fN.raw holds
+         * the picture presented for frame N-1; a consistent off-by-one is
+         * harmless for animation work and is stated in the reply. */
+        {
+            uint8_t *rb = g_ppu->renderBuffer;
+            uint32_t rp = g_ppu->renderPitch;
+            int rw = 256 + 2 * g_ppu->extraLeftRight;
+            int cols = rw < 256 ? rw : 256;
+            int y;
+            if (rb && rp >= (uint32_t)rw * 4) {
+                memset(frange_scr, 0, want);
+                for (y = 0; y < 224; y++)
+                    memcpy(frange_scr + (size_t)y * 256 * 4,
+                           rb + (size_t)y * rp, (size_t)cols * 4);
+            } else {
+                /* No composite to copy yet. Say so rather than writing a
+                 * black frame that reads as a rendering bug. */
+                if (!s_frange_errno) s_frange_errno = ENODATA;
+                s_frange_active = 0;
+                goto frange_done;
+            }
+        }
+        snprintf(path, sizeof(path), "%s/f%06d.raw", s_frange_dir, frame);
+        f = fopen(path, "wb");
+        if (!f) {
+            if (!s_frange_errno) s_frange_errno = errno ? errno : EIO;
+        } else {
+            if (fwrite(frange_scr, 1, want, f) != want && !s_frange_errno)
+                s_frange_errno = errno ? errno : EIO;
+            if (fclose(f) != 0 && !s_frange_errno)
+                s_frange_errno = errno ? errno : EIO;
+            s_frange_written++;
+        }
+        if (frame + 1 >= s_frange_end)
+            s_frange_active = 0;
+frange_done: ;
     }
 
     lock_mutex();
@@ -1835,7 +1910,13 @@ static struct {
     OamWriteEntry *log; /* calloc'd at init */
 } s_oam_wr = {0};
 
-typedef struct { uint8_t y, xlow, tile, attr, xhigh; } OamSlotSnap;
+/* `big` is high-OAM bit 1: the per-sprite size select, which picks
+ * between the two sizes OBSEL names. It was omitted here, and its
+ * absence is a blind spot rather than a detail: two frames whose
+ * y/x/tile/attr are byte-identical still draw at different sizes if
+ * this bit differs, so a size-swap bug looked like "OAM did not
+ * change" while the picture plainly did. */
+typedef struct { uint8_t y, xlow, tile, attr, xhigh, big; } OamSlotSnap;
 
 typedef struct {
     uint64_t    seq;
@@ -1883,6 +1964,7 @@ void debug_server_on_oam_render(void) {
         e->slot[s].tile  = (uint8_t)(w1 & 0xff);
         e->slot[s].attr  = (uint8_t)(w1 >> 8);
         e->slot[s].xhigh = (uint8_t)((g_ppu->highOam[s >> 2] >> ((s & 3) * 2)) & 1);
+        e->slot[s].big   = (uint8_t)((g_ppu->highOam[s >> 2] >> ((s & 3) * 2 + 1)) & 1);
         if (y < 0xE0) active++;
     }
     e->active = active;
@@ -2738,7 +2820,11 @@ static void cmd_oam_state(const char *args) {
              (unsigned long long)s_oam_rd.count, OAM_RENDER_RING_ENTRIES);
 }
 
-/* oam_write_get [count=64] — most recent N OAM write events, oldest-first.
+/* oam_render_get [snaps=4] [slots=16] — per-frame OAM snapshots, oldest-first.
+ * Each slot row is [y, xlow, xhigh, tile, attr, big] where `big` is the
+ * high-OAM size-select bit.
+ *
+ * oam_write_get [count=64] — most recent N OAM write events, oldest-first.
  * Each: seq, frame f, h=is_high, i=index, v=value (hex), func. The seq lets
  * you interleave these against oam_render_get to see whether the DMA burst
  * for a frame landed BEFORE the render-read that consumed it, and whether the
@@ -2797,9 +2883,9 @@ static void cmd_oam_render_get(const char *args) {
             k ? "," : "", (unsigned long long)e->seq, e->frame, e->active);
         for (unsigned s = 0; s < slots && pos < budget; s++)
             pos += snprintf(buf + pos, sizeof(buf) - pos,
-                "%s[%u,%u,%u,%u,%u]", s ? "," : "",
+                "%s[%u,%u,%u,%u,%u,%u]", s ? "," : "",
                 e->slot[s].y, e->slot[s].xlow, e->slot[s].xhigh,
-                e->slot[s].tile, e->slot[s].attr);
+                e->slot[s].tile, e->slot[s].attr, e->slot[s].big);
         pos += snprintf(buf + pos, sizeof(buf) - pos, "]}");
     }
     snprintf(buf + pos, sizeof(buf) - pos, "]}");
@@ -7245,7 +7331,80 @@ static void cmd_audio_shadow_div(const char *args) {
              (unsigned long long)st.echo_div_count, erms_db, emax_db);
 }
 
-/* dump_frame_raw <frame> <path> — arm a non-pausing capture of frame N's pixels
+/* dump_frame_range <start> <count> <dir> — arm a non-pausing capture of
+ * `count` CONSECUTIVE frames beginning at `start`, one raw BGRX 256x224x4
+ * file per frame at <dir>/fNNNNNN.raw, and block until the range has passed.
+ * <dir> must already exist and is resolved against the RUNTIME's working
+ * directory, so pass it absolute. See the note beside s_frange_start for why
+ * repeated dump_frame_raw calls cannot do this. */
+static void cmd_dump_frame_range(const char *args) {
+    char dir[400] = {0};
+    int start = -1, count = 0, i;
+    int budget_ticks;
+
+    if (sscanf(args, "%d %d %399s", &start, &count, dir) < 3
+        || start < 0 || count < 1) {
+        send_fmt("{\"error\":\"usage: dump_frame_range <start> <count> <dir>\"}");
+        return;
+    }
+    if (count > 4096) count = 4096;
+    if (s_frange_active) {
+        send_fmt("{\"error\":\"a range capture is already armed\"}");
+        return;
+    }
+    strncpy(s_frange_dir, dir, sizeof(s_frange_dir) - 1);
+    s_frange_dir[sizeof(s_frange_dir) - 1] = 0;
+    s_frange_written = 0;
+    s_frange_errno = 0;
+    s_frange_start = start;
+    s_frange_end = start + count;
+    s_frange_active = 1;
+
+    /* Wait for the range to pass, with headroom: the frames themselves plus
+     * the wait for `start` to arrive. Ticks are 10 ms. */
+    budget_ticks = 1500 + count * 4;
+    for (i = 0; i < budget_ticks && s_frange_active; i++) {
+#ifdef _WIN32
+        Sleep(10);
+#else
+        usleep(10000);
+#endif
+    }
+    if (s_frange_active) {
+        s_frange_active = 0;
+        send_fmt("{\"error\":\"timeout waiting for frames %d..%d "
+                 "(already passed?)\",\"written\":%d}",
+                 start, start + count - 1, s_frange_written);
+        return;
+    }
+    if (s_frange_errno == ENODATA) {
+        send_fmt("{\"error\":\"the host has not composited a frame yet "
+                 "(renderBuffer unset) -- nothing to capture\",\"written\":%d}",
+                 s_frange_written);
+        return;
+    }
+    if (s_frange_errno) {
+        send_fmt("{\"error\":\"writing into %s failed: %s\",\"written\":%d,"
+                 "\"hint\":\"the directory must exist and is relative to the "
+                 "runtime's working directory\"}",
+                 dir, strerror(s_frange_errno), s_frange_written);
+        return;
+    }
+    send_fmt("{\"ok\":true,\"start\":%d,\"count\":%d,\"written\":%d,"
+             "\"dir\":\"%s\",\"width\":256,\"height\":224,"
+             "\"source\":\"presented-composite\",\"lag\":1}",
+             start, count, s_frange_written, dir);
+}
+
+/* dump_frame_raw <frame> <path> — RE-RENDERS the PPU rather than copying the
+ * presented composite, so it drops every mid-frame effect: raster splits,
+ * per-line HDMA, anything the host's per-line loop applied. On a game that
+ * ends its frame in forced blank the result is an all-black image of a
+ * perfectly good picture. Kept as-is for the bsnes framebuffer diff, which
+ * wants the register-authentic render; use dump_frame_range for what the
+ * player actually sees.
+ *
+ * dump_frame_raw <frame> <path> — arm a non-pausing capture of frame N's pixels
  * (debug_server_record_frame writes raw BGRX 256x224x4 when the frame passes) and
  * block until done. For the PPU framebuffer diff vs the bsnes oracle. */
 static void cmd_dump_frame_raw(const char *args) {
@@ -7623,6 +7782,7 @@ static const CmdEntry s_commands[] = {
     {"get_spc_pc_hist", cmd_get_spc_pc_hist},
     {"get_apu_misc",   cmd_get_apu_misc},
     {"frame",         cmd_frame},
+    {"dump_frame_range", cmd_dump_frame_range},
     {"read_ram",      cmd_read_ram},
     {"dump_ram",      cmd_dump_ram},
     {"read_sram",     cmd_read_sram},

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -1390,12 +1390,18 @@ typedef struct {
     uint8_t e;      // emulation mode
 } FrameCpuSnap;
 
-// Per-frame PPU register snapshot (32 bytes)
+// Per-frame PPU register snapshot
 typedef struct {
     uint8_t inidisp, bgmode, mosaic, obsel, setini;
     uint8_t screenEnabled[2], cgadsub, cgwsel, pad;
     uint16_t hScroll[4], vScroll[4];
     uint16_t fixedColor, vramPointer;
+    /* Decoder inputs (asset tooling): per-BG tilemap base/size ($210[7-A])
+     * and the packed BG char bases ($210B/C). Without these a frame-keyed
+     * VRAM snapshot cannot be decoded into layers — only the LIVE registers
+     * were queryable, which is the wrong frame by the time a tool asks. */
+    uint8_t bgXsc[4];
+    uint16_t bgTileAdr;
 } FramePpuSnap;
 
 // Per-frame interrupt/timing snapshot. Added 2026-04-23 after the tooling-
@@ -1600,6 +1606,8 @@ void debug_server_record_frame(int frame) {
         memcpy(r->ppu.vScroll, g_ppu->vScroll, sizeof(r->ppu.vScroll));
         r->ppu.fixedColor = g_ppu->fixedColor;
         r->ppu.vramPointer = g_ppu->vramPointer;
+        memcpy(r->ppu.bgXsc, g_ppu->bgXsc, sizeof(r->ppu.bgXsc));
+        r->ppu.bgTileAdr = g_ppu->bgTileAdr;
         // CGRAM + OAM snapshots
         memcpy(r->cgram, g_ppu->cgram, sizeof(r->cgram));
         memcpy(r->oam, g_ppu->oam, sizeof(r->oam));
@@ -4918,7 +4926,9 @@ static void cmd_get_frame_extended(const char *args) {
         "\"screenEnabled\":[\"0x%02x\",\"0x%02x\"],"
         "\"cgadsub\":\"0x%02x\",\"cgwsel\":\"0x%02x\","
         "\"hScroll\":[%d,%d,%d,%d],\"vScroll\":[%d,%d,%d,%d],"
-        "\"fixedColor\":\"0x%04x\",\"vramPointer\":\"0x%04x\"},",
+        "\"fixedColor\":\"0x%04x\",\"vramPointer\":\"0x%04x\","
+        "\"bgXsc\":[\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],"
+        "\"bgTileAdr\":\"0x%04x\"},",
         r->frame_number,
         r->cpu.a, r->cpu.x, r->cpu.y, r->cpu.sp, r->cpu.pc, r->cpu.dp,
         r->cpu.k, r->cpu.db, r->cpu.flags, r->cpu.e,
@@ -4928,7 +4938,9 @@ static void cmd_get_frame_extended(const char *args) {
         r->ppu.cgadsub, r->ppu.cgwsel,
         r->ppu.hScroll[0], r->ppu.hScroll[1], r->ppu.hScroll[2], r->ppu.hScroll[3],
         r->ppu.vScroll[0], r->ppu.vScroll[1], r->ppu.vScroll[2], r->ppu.vScroll[3],
-        r->ppu.fixedColor, r->ppu.vramPointer);
+        r->ppu.fixedColor, r->ppu.vramPointer,
+        r->ppu.bgXsc[0], r->ppu.bgXsc[1], r->ppu.bgXsc[2], r->ppu.bgXsc[3],
+        r->ppu.bgTileAdr);
     send(s_client_sock, buf, pos, 0);
 
     // DMA channels (incl. HDMA state fields captured per-frame)

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -4585,6 +4585,19 @@ static void cmd_screenshot(const char *args) {
              path, w, h, (int)g_ppu->extraLeftRight, snes_frame_counter);
 }
 
+/* raster_journal — the per-line register waveform the renderer will replay.
+ * A frame-model host runs all of a frame's CPU work and only then draws its
+ * 224 lines, so "what the game wrote mid-frame" and "what the renderer saw"
+ * are different things. This is where the two can be compared. */
+static void cmd_raster_journal(const char *args) {
+    (void)args;
+    static char buf[65536];
+    int n = ppu_rasterDebugDump(buf, (int)sizeof(buf));
+    if (n <= 0) { send_fmt("{\"error\":\"journal unavailable\"}"); return; }
+    send_all_bounded(buf, n);
+    send_all_bounded("\n", 1);
+}
+
 static void cmd_get_ppu_state(const char *args) {
     if (!g_ppu) { send_fmt("{\"error\":\"ppu not available\"}"); return; }
     Ppu *p = g_ppu;
@@ -4636,7 +4649,11 @@ static void cmd_get_interrupt_state(const char *args) {
     send_fmt("{\"inNmi\":%s,\"inIrq\":%s,\"inVblank\":%s,"
              "\"nmiEnabled\":%s,\"hIrqEnabled\":%s,\"vIrqEnabled\":%s,"
              "\"autoJoyRead\":%s,\"hPos\":%u,\"vPos\":%u,"
-             "\"hTimer\":%u,\"vTimer\":%u,\"autoJoyTimer\":%u}",
+             "\"hTimer\":%u,\"vTimer\":%u,\"autoJoyTimer\":%u,"
+             "\"irqLatches\":%u,\"irqMissedFields\":%u,\"lastMissedLine\":%u,"
+             "\"irqOvershot\":%u,\"lastOvershotLine\":%u,\"lastOvershotBy\":%u,"
+             "\"targetInPast\":%u,\"lastPastTarget\":%u,\"lastPastBeam\":%u,"
+             "\"nmiBeamLine\":%u,\"nmiLateCount\":%u,\"beamLagAtNmi\":%llu}",
              s->inNmi       ? "true" : "false",
              s->inIrq       ? "true" : "false",
              s->inVblank    ? "true" : "false",
@@ -4644,7 +4661,12 @@ static void cmd_get_interrupt_state(const char *args) {
              s->hIrqEnabled ? "true" : "false",
              s->vIrqEnabled ? "true" : "false",
              s->autoJoyRead ? "true" : "false",
-             s->hPos, s->vPos, s->hTimer, s->vTimer, s->autoJoyTimer);
+             s->hPos, s->vPos, s->hTimer, s->vTimer, s->autoJoyTimer,
+             s->dbgIrqLatches, s->dbgIrqMissed, s->dbgLastMissedLine,
+             s->dbgIrqOvershot, s->dbgLastOvershotLine, s->dbgLastOvershotBy,
+             s->dbgTargetInPast, s->dbgLastPastTarget, s->dbgLastPastBeam,
+             s->dbgNmiBeamLine, s->dbgNmiLateCount,
+             (unsigned long long)s->dbgBeamLagAtNmi);
 }
 
 /* cx4_state [n] — instruction-level Cx4 (HG51B S169) status plus the always-on
@@ -7668,6 +7690,7 @@ static const CmdEntry s_commands[] = {
     {"dump_cgram",    cmd_dump_cgram},
     {"dump_oam",      cmd_dump_oam},
     {"get_ppu_state", cmd_get_ppu_state},
+    {"raster_journal", cmd_raster_journal},
     {"ppu_lines",     cmd_ppu_lines},
     {"ppu_window",    cmd_ppu_window},
     {"get_cpu_state", cmd_get_cpu_state},

--- a/runner/src/snes/dma.c
+++ b/runner/src/snes/dma.c
@@ -261,6 +261,74 @@ static void dma_transferByte(Dma* dma, uint16_t aAdr, uint8_t aBank, uint8_t bAd
   }
 }
 
+/* ── HDMA ────────────────────────────────────────────────────────────────
+ *
+ * dma_startDma(..., hdma=true) has always set channel[i].hdmaActive from
+ * $420C, and DmaChannel has carried tableAdr / repCount / doTransfer /
+ * terminated / indBank since forever — but nothing ever consumed any of it.
+ * There was no HDMA transfer engine in the tree at all, so a game's per-
+ * scanline register stream simply never happened.
+ *
+ * Measured on Gundam Wing Endless Duel: through the intro cutscene, channel 1
+ * is HDMA-active onto $212C (TM, main-screen layer enable), rewriting which
+ * BG layers are on per scanline. That is the letterbox — BG off on the top
+ * and bottom bands, on in the middle, with OBJ left enabled so the characters
+ * still draw over the bars. Without the engine every line got one TM value
+ * and the whole effect was lost.
+ *
+ * Standard algorithm: dma_initHdma() reloads each enabled channel's table
+ * pointer at the top of the field; dma_doHdma() runs once per scanline.
+ * `size` doubles as the indirect address, as the struct comment notes. */
+
+void dma_initHdma(Dma* dma) {
+  for(int i = 0; i < 8; i++) {
+    DmaChannel* ch = &dma->channel[i];
+    if(!ch->hdmaActive) continue;
+    ch->tableAdr = ch->aAdr;
+    ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
+    ch->terminated = (ch->repCount == 0);
+    if(ch->indirect) {
+      ch->size = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
+      ch->size |= snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++) << 8;
+    }
+    ch->doTransfer = true;
+    ch->offIndex = 0;
+  }
+}
+
+void dma_doHdma(Dma* dma) {
+  for(int i = 0; i < 8; i++) {
+    DmaChannel* ch = &dma->channel[i];
+    if(!ch->hdmaActive || ch->terminated) continue;
+
+    if(ch->doTransfer) {
+      int len = transferLength[ch->mode];
+      for(int j = 0; j < len; j++) {
+        uint8_t b = (uint8_t)(ch->bAdr + bAdrOffsets[ch->mode][j]);
+        if(ch->indirect) {
+          dma_transferByte(dma, ch->size++, ch->indBank, b, false);
+        } else {
+          dma_transferByte(dma, ch->tableAdr++, ch->aBank, b, false);
+        }
+      }
+    }
+
+    ch->repCount--;
+    /* Bit 7 of the line-count byte is the "continue" flag: keep transferring
+     * on each of the next (count & 0x7F) lines rather than only the first. */
+    ch->doTransfer = (ch->repCount & 0x80) != 0;
+    if((ch->repCount & 0x7f) == 0) {
+      ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
+      if(ch->indirect) {
+        ch->size = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
+        ch->size |= snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++) << 8;
+      }
+      ch->terminated = (ch->repCount == 0);
+      ch->doTransfer = true;
+    }
+  }
+}
+
 bool dma_cycle(Dma* dma) {
   if(dma->dmaBusy) {
     dma_doDma(dma);

--- a/runner/src/snes/dma.c
+++ b/runner/src/snes/dma.c
@@ -50,6 +50,7 @@ void dma_free(Dma* dma) {
 }
 
 void dma_reset(Dma* dma) {
+  dma->hdmaPendingInit = 0;
   for(int i = 0; i < 8; i++) {
     dma->channel[i].bAdr = 0xff;
     dma->channel[i].aAdr = 0xffff;
@@ -284,6 +285,8 @@ void dma_initHdma(Dma* dma) {
   for(int i = 0; i < 8; i++) {
     DmaChannel* ch = &dma->channel[i];
     if(!ch->hdmaActive) continue;
+    /* A start-of-frame init supersedes any pending mid-frame one. */
+    dma->hdmaPendingInit &= (uint8_t)~(1u << i);
     ch->tableAdr = ch->aAdr;
     ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
     ch->terminated = (ch->repCount == 0);
@@ -299,7 +302,32 @@ void dma_initHdma(Dma* dma) {
 void dma_doHdma(Dma* dma) {
   for(int i = 0; i < 8; i++) {
     DmaChannel* ch = &dma->channel[i];
-    if(!ch->hdmaActive || ch->terminated) continue;
+    if(!ch->hdmaActive) continue;
+
+    /* A channel switched on part-way through a frame spends its first HDMA
+     * slot loading the table header, and only transfers from the slot after.
+     * Measured against Mesen on Gundam Wing's pre-fight screen, which enables
+     * $420C at line 21 and whose first HDMA write of $212C lands on line 23:
+     *
+     *     enable L21  ->  init L22  ->  first transfer L23
+     *
+     * Initializing and transferring in the same slot put every band edge one
+     * scanline early (L22/54/102/134/182 against hardware's
+     * L23/55/103/135/183) -- the whole raster split shifted up a pixel. */
+    if(dma->hdmaPendingInit & (1u << i)) {
+      dma->hdmaPendingInit &= (uint8_t)~(1u << i);
+      ch->tableAdr = ch->aAdr;
+      ch->repCount = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
+      ch->terminated = (ch->repCount == 0);
+      if(ch->indirect) {
+        ch->size = snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++);
+        ch->size |= snes_read(dma->snes, (ch->aBank << 16) | ch->tableAdr++) << 8;
+      }
+      ch->doTransfer = true;
+      ch->offIndex = 0;
+      continue;             /* this slot was the init; no transfer yet */
+    }
+    if(ch->terminated) continue;
 
     if(ch->doTransfer) {
       int len = transferLength[ch->mode];
@@ -340,7 +368,14 @@ bool dma_cycle(Dma* dma) {
 void dma_startDma(Dma* dma, uint8_t val, bool hdma) {
   for(int i = 0; i < 8; i++) {
     if(hdma) {
-      dma->channel[i].hdmaActive = val & (1 << i);
+      /* Only a channel going from off to on owes an initialization; rewriting
+       * $420C with a channel already running must not restart its table. */
+      bool now_on = (val & (1 << i)) != 0;
+      if(now_on && !dma->channel[i].hdmaActive)
+        dma->hdmaPendingInit |= (uint8_t)(1u << i);
+      else if(!now_on)
+        dma->hdmaPendingInit &= (uint8_t)~(1u << i);
+      dma->channel[i].hdmaActive = now_on;
     } else {
       dma->channel[i].dmaActive = val & (1 << i);
     }

--- a/runner/src/snes/dma.h
+++ b/runner/src/snes/dma.h
@@ -40,6 +40,14 @@ typedef struct DmaChannel {
 
 struct Dma {
   Snes* snes;
+  /* Bitmask of channels whose HDMA was switched on part-way through a frame
+   * and still owe their one-slot table initialization. See dma_doHdma().
+   *
+   * Declared BEFORE `channel` on purpose: dma_saveload() serializes from
+   * `channel` to the end of the struct, so putting it here leaves the
+   * savestate layout byte-identical. That is also the honest place for it --
+   * it is transient within-frame sequencing, not guest-visible state. */
+  uint8_t hdmaPendingInit;
   DmaChannel channel[8];
   uint32_t dmaTimer;
   bool dmaBusy;

--- a/runner/src/snes/dma.h
+++ b/runner/src/snes/dma.h
@@ -51,6 +51,11 @@ void dma_reset(Dma* dma);
 uint8_t dma_read(Dma* dma, uint16_t adr); // 43x0-43xf
 void dma_write(Dma* dma, uint16_t adr, uint8_t val); // 43x0-43xf
 void dma_doDma(Dma* dma);
+/* Per-scanline HDMA. A frame-model host owns these edges: call dma_initHdma()
+ * once at the top of the visible field and dma_doHdma() before rendering each
+ * scanline (FRAME_MODEL_HOSTS.md). */
+void dma_initHdma(Dma* dma);
+void dma_doHdma(Dma* dma);
 bool dma_cycle(Dma* dma);
 void dma_startDma(Dma* dma, uint8_t val, bool hdma);
 void dma_saveload(Dma *dma, SaveLoadInfo *sli);

--- a/runner/src/snes/interp_bridge.c
+++ b/runner/src/snes/interp_bridge.c
@@ -664,8 +664,22 @@ void interp_bridge_dump_recent_steps(int n, FILE *out) {
 
 /* Install the ring dump as cpu_state.c's halt-path hook (explicit hook, not
  * a PE weak symbol — see cpu_state.c). Constructor runs at image load. */
+static void itrace_install_dump_hook(void);
+#if defined(_MSC_VER)
+#  pragma section(".CRT$XCU", read)
+__declspec(allocate(".CRT$XCU"))
+void (*itrace_install_dump_hook_ctor)(void) = itrace_install_dump_hook;
+#  if defined(_M_IX86)
+#    pragma comment(linker, "/include:_itrace_install_dump_hook_ctor")
+#  else
+#    pragma comment(linker, "/include:itrace_install_dump_hook_ctor")
+#  endif
+static void itrace_install_dump_hook(void)
+#else
 __attribute__((constructor))
-static void itrace_install_dump_hook(void) {
+static void itrace_install_dump_hook(void)
+#endif
+{
     g_interp_recent_dump_hook = interp_bridge_dump_recent_steps;
 }
 

--- a/runner/src/snes/interp_bridge.c
+++ b/runner/src/snes/interp_bridge.c
@@ -1506,6 +1506,50 @@ static int _interp_run_core(CpuState *cpu, uint32_t entry_pc24,
     return 0;
 }
 
+/* ── interpreter attribution scope ────────────────────────────────────────
+ *
+ * Every bridge run pushes a synthesized name (interp@$XXXXXX, the entry PC)
+ * onto the recomp call stack and installs it as g_last_recomp_func for the
+ * run's duration. The debug server's write rings (VramTraceEntry.func/stack,
+ * OamWriteEntry.func) copy those at write time, so without this an
+ * interpreted write is attributed to the stale enclosing AOT frame — or, in
+ * a whole-program-LLE port, to nothing at all. The entry PC is the useful
+ * identity: it is a real guest function entry, the exact address a
+ * symbols.toml [[func]] would name. Nested calls that bounce to compiled
+ * bodies push their own names over this one, so only still-interpreted
+ * depth stays attributed to the bridge entry.
+ *
+ * Names are interned in a fixed open-addressed table: RecompStackPush keeps
+ * the pointer, not a copy, so it must outlive the run. On table overflow a
+ * shared static name is returned rather than evicting — attribution degrades
+ * to "some interpreted code", never to a dangling pointer.
+ */
+extern const char *g_last_recomp_func; /* common_cpu_infra.c */
+
+#define INTERP_SCOPE_NAMES 4096u /* power of two; ~1400 tier sites seen in MMX */
+static char s_interp_scope_names[INTERP_SCOPE_NAMES][20];
+static uint32_t s_interp_scope_pc[INTERP_SCOPE_NAMES];
+static uint8_t s_interp_scope_used[INTERP_SCOPE_NAMES];
+
+static const char *interp_scope_name(uint32_t pc24) {
+    pc24 &= 0xFFFFFFu;
+    uint32_t h = (pc24 * 2654435761u) & (INTERP_SCOPE_NAMES - 1u);
+    for (uint32_t probe = 0; probe < INTERP_SCOPE_NAMES; probe++) {
+        uint32_t slot = (h + probe) & (INTERP_SCOPE_NAMES - 1u);
+        if (!s_interp_scope_used[slot]) {
+            s_interp_scope_used[slot] = 1;
+            s_interp_scope_pc[slot] = pc24;
+            snprintf(s_interp_scope_names[slot],
+                     sizeof(s_interp_scope_names[slot]),
+                     "interp@$%06X", (unsigned)pc24);
+            return s_interp_scope_names[slot];
+        }
+        if (s_interp_scope_pc[slot] == pc24)
+            return s_interp_scope_names[slot];
+    }
+    return "interp@(table full)";
+}
+
 /* Wrapper: mark the interp tier as APU-driving for the whole run (nesting-safe
  * save/restore) so rtl_accumulate_apu_catchup skips the per-touch synthetic
  * estimate — the core advances the SPC per opcode instead. */
@@ -1530,11 +1574,20 @@ static int interp_bridge_run_ex2(CpuState *cpu, uint32_t entry_pc24,
     s_interp_owner_exit_s = s_exit;
     s_interp_owner_exit_valid = 1;
     s_interp_bridge_depth++;
+    /* Attribution scope (see interp_scope_name above). Saved/restored rather
+     * than assumed clean: a bounce chain re-enters this wrapper with an AOT
+     * name installed, and that name must come back on our exit. */
+    const char *_saved_func = g_last_recomp_func;
+    const char *_scope_name = interp_scope_name(entry_pc24);
+    g_last_recomp_func = _scope_name;
+    RecompStackPush(_scope_name);
     int _r = _interp_run_core(cpu, entry_pc24, s_exit, out_landing,
                               out_return_pc, yield_pc,
                               yield_flag_addr, yield_flag_value,
                               reset_cap_on_bounce, stop_pcs, n_stop,
                               stop_on_rti);
+    RecompStackPop();
+    g_last_recomp_func = _saved_func;
     s_interp_bridge_depth--;
     s_interp_owner_exit_s = _saved_owner_exit_s;
     s_interp_owner_exit_valid = _saved_owner_exit_valid;

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -1,4 +1,6 @@
 #include "ppu.h"
+
+extern unsigned char g_snesrecomp_last_hdmaen;
 #include "ppu_legacy.h"
 
 #include <stdio.h>
@@ -2246,6 +2248,192 @@ uint8_t ppu_read(Ppu* ppu, uint8_t adr) {
       assert(0);
       return 0;
     }
+  }
+}
+
+/* ── raster journal ────────────────────────────────────────────────────────
+ * Per-line replay of mid-frame PPU writes, for frame-model hosts.
+ *
+ * Such a host runs the frame's CPU work first and renders all 224 lines
+ * afterwards, so the PPU register file at render time is the LAST-written
+ * state. A raster-split game turns these registers into per-line waveforms.
+ * Gundam Wing's IRQ chain (lines 21/23/71/72/215) writes INIDISP, BG1
+ * scroll, TM, TMW and CGADSUB per band: the HUD band at the top has its own
+ * scroll and layer set, the playfield another, the letterbox a third.
+ * Rendering the whole frame with the final state drew the demo black
+ * (measured: 61/61 frames rendered forcedBlank), and with INIDISP-only
+ * replay the HUD band drew black while the reference shows the health bars.
+ *
+ * Same defect class the HDMA engine solved (dma_initHdma/dma_doHdma):
+ * record during CPU time, replay per line at render time. The host brackets:
+ *   ppu_rasterBegin(ppu)              after its vblank-edge work — snapshots
+ *                                     line-0 state, including the write-twice
+ *                                     scroll latch
+ *   ppu_rasterApplyLine(ppu, line)    in the render loop before ppu_runLine
+ * The register-write path calls ppu_rasterRecord with the beam line.
+ *
+ * Registers journaled: the set the split handlers write. Data ports (VRAM/
+ * CGRAM/OAM) are deliberately excluded — those are uploads, not per-line
+ * display state, and replaying them would double-apply the data. */
+#define PPU_RASTER_MAX 256
+typedef struct { uint8_t line; uint16_t reg; uint8_t val; } PpuRasterEntry;
+static PpuRasterEntry s_raster[PPU_RASTER_MAX];
+static int s_raster_count;
+static int s_raster_armed;
+static int s_raster_next;
+static uint8_t s_raster_hdmaen;
+static int s_raster_hdmaen_pending;
+static struct {
+  uint8_t inidisp;
+  uint16_t hScroll0, vScroll0;
+  uint8_t tm, tmw, cgadsub, hdmaen;
+  uint8_t scrollPrev, scrollPrev2;
+} s_raster0;
+
+static int raster_reg_journaled(uint16_t reg) {
+  switch (reg) {
+    case 0x2100:                 /* INIDISP */
+    case 0x210D: case 0x210E:    /* BG1HOFS / BG1VOFS */
+    case 0x212C: case 0x212E:    /* TM / TMW */
+    case 0x2131:                 /* CGADSUB */
+    /* HDMAEN is a per-line fact as much as any PPU register. This title
+     * enables the transition's HDMA channels MID-FRAME from the line-21 raster
+     * handler ($00:888E writes $420C = 0x90, channels 4 and 7, channel 7
+     * driving $2128 = window 2 left for the shutter wipe). A frame-model host
+     * that reads the enable mask once at render time sees only the end-of-frame
+     * value, so a channel switched on at line 21 and off again later never runs
+     * at all — measured, the whole wipe was missing while the NMI-enabled
+     * letterbox on channel 1 rendered fine. */
+    case 0x420C:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+void ppu_rasterBegin(Ppu *ppu) {
+  s_raster_count = 0;
+  s_raster_next = 0;
+  s_raster_armed = 1;
+  s_raster0.inidisp = ppu->inidisp;      /* post-vblank state = line-0 state */
+  s_raster0.hScroll0 = ppu->hScroll[0];
+  s_raster0.vScroll0 = ppu->vScroll[0];
+  s_raster0.tm = ppu->screenEnabled[0];
+  s_raster0.tmw = ppu->screenWindowed[0];
+  s_raster0.cgadsub = ppu->cgadsub;
+  s_raster0.hdmaen = g_snesrecomp_last_hdmaen;
+  s_raster0.scrollPrev = ppu->scrollPrev;
+  s_raster0.scrollPrev2 = ppu->scrollPrev2;
+}
+
+void ppu_rasterRecord(uint16_t reg, uint16_t line, uint8_t val) {
+  if (!s_raster_armed || !raster_reg_journaled(reg)) return;
+  if (line == 0 || line >= 225) {
+    /* A write outside active display is next frame's baseline, not a split.
+     * Track it in the snapshot so late-vblank writes are not lost. */
+    switch (reg) {
+      case 0x2100: s_raster0.inidisp = val; break;
+      case 0x210D:
+        s_raster0.hScroll0 =
+            (uint16_t)((val << 8 | s_raster0.scrollPrev) & 0x3FF);
+        s_raster0.scrollPrev = val;
+        s_raster0.scrollPrev2 = val;
+        break;
+      case 0x210E:
+        s_raster0.vScroll0 =
+            (uint16_t)((val << 8 | s_raster0.scrollPrev) & 0x3FF);
+        s_raster0.scrollPrev = val;
+        break;
+      case 0x212C: s_raster0.tm = val; break;
+      case 0x212E: s_raster0.tmw = val; break;
+      case 0x2131: s_raster0.cgadsub = val; break;
+      case 0x420C: s_raster0.hdmaen = val; break;
+    }
+    return;
+  }
+  if (s_raster_count < PPU_RASTER_MAX) {
+    s_raster[s_raster_count].line = (uint8_t)line;
+    s_raster[s_raster_count].reg = reg;
+    s_raster[s_raster_count].val = val;
+    s_raster_count++;
+  }
+}
+
+/* Restore the line-0 snapshot. Called by the host BEFORE its render loop —
+ * i.e. before dma_initHdma and the first dma_doHdma — never inside line 1:
+ * HDMA writes the same registers per line (this title's intro letterbox is an
+ * HDMA stream onto TM), and a restore after line 1's HDMA write would stomp
+ * it. Measured as exactly that regression: the intro's top black bar
+ * disappeared while the HDMA bars below survived. */
+int ppu_rasterTakeHdmaen(uint8_t *out) {
+  if (!s_raster_hdmaen_pending) return 0;
+  s_raster_hdmaen_pending = 0;
+  *out = s_raster_hdmaen;
+  return 1;
+}
+
+void ppu_rasterRenderBegin(Ppu *ppu) {
+  if (!s_raster_armed) return;
+  s_raster_hdmaen_pending = 0;
+  ppu->inidisp = s_raster0.inidisp;
+  ppu->hScroll[0] = s_raster0.hScroll0;
+  ppu->vScroll[0] = s_raster0.vScroll0;
+  ppu->screenEnabled[0] = s_raster0.tm;
+  ppu->screenWindowed[0] = s_raster0.tmw;
+  ppu->cgadsub = s_raster0.cgadsub;
+  ppu->scrollPrev = s_raster0.scrollPrev;
+  ppu->scrollPrev2 = s_raster0.scrollPrev2;
+  s_raster_next = 0;
+}
+
+/* Snapshot of the journal as the renderer will consume it, for the debug
+ * server. The journal is the difference between "what the game wrote" and
+ * "what got drawn", so when a frame looks wrong this is the only place the two
+ * can be compared. Format: one "line:reg=val" token per entry, in beam order,
+ * preceded by the line-0 baseline. */
+int ppu_rasterDebugDump(char *out, int cap) {
+  int pos = 0;
+  int i;
+  pos += snprintf(out + pos, cap - pos,
+                  "{\"count\":%d,\"armed\":%d,"
+                  "\"base\":{\"inidisp\":\"0x%02X\",\"tm\":\"0x%02X\","
+                  "\"tmw\":\"0x%02X\",\"cgadsub\":\"0x%02X\","
+                  "\"bg1h\":%u,\"bg1v\":%u},\"entries\":[",
+                  s_raster_count, s_raster_armed,
+                  s_raster0.inidisp, s_raster0.tm, s_raster0.tmw,
+                  s_raster0.cgadsub,
+                  (unsigned)s_raster0.hScroll0, (unsigned)s_raster0.vScroll0);
+  for (i = 0; i < s_raster_count && pos < cap - 64; i++) {
+    pos += snprintf(out + pos, cap - pos, "%s{\"l\":%u,\"r\":\"0x%04X\",\"v\":\"0x%02X\"}",
+                    i ? "," : "", (unsigned)s_raster[i].line,
+                    s_raster[i].reg, s_raster[i].val);
+  }
+  pos += snprintf(out + pos, cap - pos, "]}");
+  return pos;
+}
+
+void ppu_rasterApplyLine(Ppu *ppu, int line) {
+  if (!s_raster_armed) return;
+  /* Entries are appended in beam order (the host walks the beam forward), so
+   * a moving cursor is enough. A write at line L lands mid-line on hardware;
+   * whole-line granularity applies it from line L on. Replaying through
+   * ppu_write keeps the write-twice scroll latch semantics — the latch state
+   * was restored above to its frame-start value, and the handlers write the
+   * two bytes in pairs, so the pairing reproduces exactly. */
+  while (s_raster_next < s_raster_count &&
+         s_raster[s_raster_next].line <= (uint8_t)line) {
+    const uint16_t reg = s_raster[s_raster_next].reg;
+    const uint8_t val = s_raster[s_raster_next].val;
+    if (reg == 0x420C) {
+      /* Not ours to apply — HDMA lives in the DMA unit and enabling a channel
+       * mid-frame also has to (re)start its table. Hand it to the host, which
+       * owns the render loop and calls dma_initHdma/dma_doHdma. */
+      s_raster_hdmaen = val;
+      s_raster_hdmaen_pending = 1;
+    } else {
+      ppu_write(ppu, (uint8_t)(reg & 0xFF), val);
+    }
+    s_raster_next++;
   }
 }
 

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -415,13 +415,29 @@ static inline uint8 PpuMosaicAt(Ppu *ppu, int i) {
   return ppu->mosaicModulo[(unsigned)i < (unsigned)kPpuXPixels ? i : (i < 0 ? 0 : kPpuXPixels - 1)];
 }
 
+/* Frame of the last OAM ring snapshot; see the note in ppu_runLine. Debug
+ * instrumentation only -- it never affects rendering. */
+static int s_oam_snap_frame = -1;
+
 void ppu_runLine(Ppu* ppu, int line) {
   /* Per-line HDMA state must be captured here, not at end-of-frame: games can
    * rewrite windows and scroll registers before every scanline. */
   debug_server_on_ppu_line(line);
-  if(line == 0) {
-    // Always-on: snapshot the OAM the scanline renderer is about to consume.
+  /* Snapshot the OAM the scanline renderer is about to consume, once per
+   * frame, on whichever line the host actually starts with.
+   *
+   * This used to sit inside the line == 0 block, which silently disabled it
+   * for every frame-model host: those render the visible field as lines
+   * 1..224 and never pass line 0 at all. The ring therefore stayed empty
+   * forever and oam_render_get answered {"count":0,"snaps":[]} -- "no
+   * sprites recorded" -- for a screen full of sprites. An instrument that
+   * reports nothing is indistinguishable from a subsystem that did nothing,
+   * which is the most expensive way for a probe to fail. */
+  if (s_oam_snap_frame != snes_frame_counter) {
+    s_oam_snap_frame = snes_frame_counter;
     debug_server_on_oam_render();
+  }
+  if(line == 0) {
     if (PPU_mosaicSize(ppu) != ppu->lastMosaicModulo) {
       int mod = PPU_mosaicSize(ppu);
       ppu->lastMosaicModulo = mod;

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -1741,7 +1741,43 @@ static void PpuDrawBackgrounds(Ppu *ppu, int y, bool sub) {
   //  1: BG3 tiles with priority 0
   //  0: backdrop
 
-  if (PPU_mode(ppu) == 1) {
+  if (PPU_mode(ppu) == 0) {
+    /* Mode 0: four 2bpp layers, each with its OWN palette group.
+     *
+     * This branch did not exist. Modes 1/2/3 were handled and everything else
+     * fell through to the mode-7 path, so a mode-0 screen was rendered as
+     * mode 7 and produced nothing. Gundam Wing's OPTION menu is mode 0: its
+     * starfield (BG3) and menu text (BG2) decode perfectly from a captured
+     * frame yet never reached the screen, and with colour math bypassed the
+     * output was 100% black — the layers were contributing nothing at all.
+     *
+     * The palette split is what makes mode 0 more than "four 2bpp layers":
+     * BG1 uses CGRAM 0-31, BG2 32-63, BG3 64-95, BG4 96-127. The 2bpp drawer
+     * already folds the tile's palette field into the low bits of z
+     * (`z += (tile & 0x1c00) >> kPaletteShift`), so the group is a constant
+     * 32*layer added to that same field; the low byte of each z base is free.
+     *
+     * Priority order, front to back:
+     *   OBJ3, BG1.hi, BG2.hi, OBJ2, BG1.lo, BG2.lo,
+     *   OBJ1, BG3.hi, BG4.hi, OBJ0, BG3.lo, BG4.lo, backdrop
+     * BG1/BG2 reuse mode 1's bases; BG3 keeps its mode-1 band and BG4 sits one
+     * step below it at each priority. */
+    static const PpuZbufType kMode0Hi[4] = { 0xc000, 0xb100, 0x3200, 0x3100 };
+    static const PpuZbufType kMode0Lo[4] = { 0x8000, 0x7100, 0x1200, 0x1100 };
+    bool mosaic_size0 = PPU_mosaicSize(ppu) > 1;
+    uint layer0;
+    if (ppu->lineHasSprites)
+      PpuDrawSprites(ppu, y, sub, true);
+    for (layer0 = 0; layer0 < 4; layer0++) {
+      PpuPixelPrioBufs *lb = PpuBeginBackgroundOverlay(ppu, y, sub, layer0);
+      PpuDrawBackground_2bpp_policy(
+          ppu, lb, y, sub, layer0,
+          (PpuZbufType)(kMode0Hi[layer0] + 32u * layer0),
+          (PpuZbufType)(kMode0Lo[layer0] + 32u * layer0),
+          mosaic_size0 && PPU_mosaicEnabled(ppu, layer0));
+      PpuFinishBackgroundOverlay(ppu, y, sub, layer0, lb);
+    }
+  } else if (PPU_mode(ppu) == 1) {
     if (ppu->lineHasSprites)
       PpuDrawSprites(ppu, y, sub, true);
 

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -400,6 +400,17 @@ void ppu_handleVblank(Ppu* ppu);
 void ppu_runLine(Ppu* ppu, int line);
 uint8_t ppu_read(Ppu* ppu, uint8_t adr);
 void ppu_write(Ppu* ppu, uint8_t adr, uint8_t val);
+
+/* Raster journal — per-line replay of mid-frame INIDISP writes for frame-model
+ * hosts. See the block comment in ppu.c. Host calls Begin after its
+ * vblank-edge work and ApplyLine in its render loop; the register write path
+ * calls Record with the beam line. */
+void ppu_rasterBegin(Ppu *ppu);
+void ppu_rasterRenderBegin(Ppu *ppu);
+int  ppu_rasterTakeHdmaen(uint8_t *out);
+void ppu_rasterRecord(uint16_t reg, uint16_t line, uint8_t val);
+void ppu_rasterApplyLine(Ppu *ppu, int line);
+int  ppu_rasterDebugDump(char *out, int cap);
 void ppu_saveload(Ppu *ppu, SaveLoadInfo *sli);
 void PpuBeginDrawing(Ppu *ppu, uint8_t *pixels, size_t pitch, uint32_t render_flags);
 

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -262,7 +262,17 @@ uint16_t SwapInputBits(uint16_t x) {
   return joypad_auto_read_word(x);
 }
 
-static void snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
+/* Returns the master clocks actually consumed. Normally == clocks; less when
+ * the walk LATCHES an IRQ, where it stops one clock past the comparator match
+ * and leaves the remainder pending. An IRQ pre-empts: beam time between the
+ * latch and the handler belongs to code the real CPU would only execute after
+ * the handler returned, so walking it before the handler runs makes any split
+ * the handler schedules close ahead land in the past (Gundam Wing schedules
+ * VTIME=+2 lines from its line-21 handler; that split was lost ~85% of frames
+ * and the gameplay demo rendered black at brightness 0). While inIrq is
+ * pending the walk consumes nothing; the host frame loop dispatches promptly,
+ * the handler runs under snes_beam_hold, and the walk resumes on release. */
+static uint32_t snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
   /* One NTSC scanline is 1364 master clocks, 262 scanlines per frame. Keep
    * the live beam counters moving while LLE code executes so SLHV/OPHCT/OPVCT
    * polling observes hardware time rather than a frame-frozen PPU.
@@ -273,6 +283,9 @@ static void snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
    * H+V IRQ on scanline 228 and blocks until that IRQ completes an NMI task. */
   uint32_t h = snes->hPos;
   uint32_t v = snes->vPos;
+  uint32_t consumed = 0;
+  if (check_irq && snes->inIrq)
+    return 0;                      /* frozen until the pending IRQ is taken */
   while (clocks) {
     uint32_t span = 1364u - h;
     if (span > clocks) span = clocks;
@@ -291,29 +304,147 @@ static void snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
     if (check_irq && (snes->hIrqEnabled || snes->vIrqEnabled)) {
       bool line_matches = !snes->vIrqEnabled || v == snes->vTimer;
       uint32_t target = snes->hIrqEnabled ? (uint32_t)snes->hTimer * 4u : 0u;
-      if (line_matches && target < 1364u && target >= h && target < h + span)
+      /* Overshoot detection, exact. We are ON the target line but the beam is
+       * already PAST the target column, so the window test below cannot fire
+       * and the walk will leave this line without an interrupt. That is a lost
+       * match, and it is invisible to any external probe: the comparator stays
+       * armed and the beam keeps moving, which looks identical to a scene that
+       * simply has no split there.
+       *
+       * Deduplicated per (field, target): the span loop can visit one line in
+       * several iterations, and a repeat is the same miss, not a new one. */
+      if (line_matches && target < 1364u && target < h &&
+          !snes->dbgLatchedThisField &&
+          snes->dbgMissDedupe != (uint32_t)((v << 16) | target)) {
+        snes->dbgMissDedupe = (uint32_t)((v << 16) | target);
+        snes->dbgIrqOvershot++;
+        snes->dbgLastOvershotLine = (uint16_t)v;
+        snes->dbgLastOvershotBy = (uint16_t)(h - target);
+      }
+      if (line_matches && target < 1364u && target >= h && target < h + span) {
+        uint32_t upto = target - h + 1u;   /* stop one clock past the match */
         snes->inIrq = true;
+        snes->dbgIrqLatches++;
+        snes->dbgLatchedThisField = 1;
+        h += upto;
+        consumed += upto;
+        if (h >= 1364u) { h = 0; v++; if (v >= 262u) v = 0; }
+        snes->hPos = (uint16_t)h;
+        snes->vPos = (uint16_t)v;
+        snes->inVblank = v >= 225u;
+        return consumed;
+      }
     }
 
     h += span;
     clocks -= span;
+    consumed += span;
     if (h >= 1364u) {
       h = 0;
       v++;
-      if (v >= 262u) v = 0;
+      if (v >= 262u) {
+        v = 0;
+        /* End of field. Armed the whole way round and nothing latched means
+         * the beam swept past the target without firing — a LOST interrupt,
+         * not a pending one. */
+        if (check_irq && (snes->hIrqEnabled || snes->vIrqEnabled) &&
+            !snes->dbgLatchedThisField) {
+          snes->dbgIrqMissed++;
+          snes->dbgLastMissedLine = snes->vTimer;
+        }
+        snes->dbgLatchedThisField = 0;
+      }
     }
   }
   snes->hPos = (uint16_t)h;
   snes->vPos = (uint16_t)v;
   snes->inVblank = v >= 225u;
+  return consumed;
 }
 
 void snes_advance_master_cycles(Snes *snes, uint32_t clocks) {
-  snes_advance_beam(snes, clocks, true);
-  snes->beamMasterLast += clocks;
+  uint32_t consumed = snes_advance_beam(snes, clocks, true);
+  snes->beamMasterLast += consumed;
 }
 
+/* Master clocks from the beam's current position to the start of scanline
+ * `line` in the CURRENT or next field. Zero when already exactly there.
+ *
+ * A frame-model host needs this to put its frame boundary on the PPU's field
+ * boundary. Without it the host's "one frame" is a fixed 357368-clock budget
+ * measured from wherever the previous frame happened to stop, so the phase
+ * between the host frame and the PPU field is arbitrary and drifts. NMI then
+ * arrives at a random scanline instead of at vblank, and any split the NMI
+ * schedules for an early line can already be behind the beam — which is a
+ * silently lost interrupt, because the comparator is a window test. Measured
+ * on Gundam Wing: NMI arrived at line 18 on the first attract loop and lines
+ * 30/34 on later ones, and from the moment it passed line 21 the raster chain
+ * lost its first link on every single frame. */
+uint32_t snes_master_clocks_until_line(const Snes *snes, uint32_t line) {
+  uint32_t h, v, lines;
+  if (!snes || line >= 262u) return 0;
+  h = snes->hPos;
+  v = snes->vPos;
+  if (v == line && h == 0u) return 0;
+  lines = (line > v) ? (line - v) : (262u - v + line);
+  return lines * 1364u - h;
+}
+
+uint32_t snes_master_clocks_until_irq(const Snes *snes) {
+  if (!snes) return 0;
+  if (snes->inIrq) return 0;                       /* already pending */
+  if (!snes->hIrqEnabled && !snes->vIrqEnabled) return 0;
+
+  uint32_t h = snes->hPos;
+  uint32_t v = snes->vPos;
+  uint32_t target_h = snes->hIrqEnabled ? (uint32_t)snes->hTimer * 4u : 0u;
+  if (target_h >= 1364u) return 0;                 /* unreachable H target */
+
+  if (!snes->vIrqEnabled) {
+    /* H-only: fires every line — later this line, or on the next. */
+    return target_h > h ? (target_h - h) : (1364u - h + target_h);
+  }
+
+  {
+    /* V (with or without H): one match per field, at (vTimer, target_h). */
+    uint32_t target_v = snes->vTimer;
+    uint32_t lines;
+    uint64_t d;
+    if (target_v >= 262u) return 0;
+    if (target_v > v)      lines = target_v - v;
+    else if (target_v < v) lines = 262u - v + target_v;
+    else                   lines = (target_h > h) ? 0u : 262u;
+    /* lines==0 implies target_h>h, so this stays positive; every other branch
+       adds at least a whole line, so the subtraction cannot underflow. */
+    d = (uint64_t)lines * 1364u + (uint64_t)target_h - (uint64_t)h;
+    return d > 0xFFFFFFFFull ? 0xFFFFFFFFu : (uint32_t)d;
+  }
+}
+
+/* ── beam hold ─────────────────────────────────────────────────────────────
+ * While set, snes_sync_master_clock is a no-op: the beam stays where it is and
+ * the CPU-time delta simply accumulates, to be walked on the first sync after
+ * release.
+ *
+ * Why this exists: a raster-IRQ handler on silicon runs within ~tens of master
+ * clocks of the latch — the beam barely moves before the handler's register
+ * writes land. This runtime cannot pre-empt AOT-compiled code mid-function, so
+ * by the time a handler is dispatched, master_cycles already carries scanlines
+ * of mainline execution the real CPU would have performed AFTER the handler.
+ * Letting the beam walk through that inflated delta DURING the handler makes
+ * the handler appear scanlines long, and any split it schedules close ahead
+ * (Gundam Wing: VTIME=+2 lines from the line-21 handler) lands in the past and
+ * never fires. Holding the beam for the handler's duration models the truth —
+ * handlers are short — rather than the artefact.
+ *
+ * While held, beam-position reads ($2137/$4212) return the latch-point line;
+ * that is exactly what a real handler racing its own splits would observe. */
+static int s_beam_hold;
+
+void snes_beam_hold(int hold) { s_beam_hold = hold; }
+
 void snes_sync_master_clock(Snes *snes, uint64_t master_clock) {
+  if (s_beam_hold) return;
   if (master_clock < snes->beamMasterLast) {
     snes->beamMasterLast = master_clock;
     return;
@@ -321,7 +452,13 @@ void snes_sync_master_clock(Snes *snes, uint64_t master_clock) {
   uint64_t delta=master_clock-snes->beamMasterLast;
   while(delta) {
     uint32_t chunk=delta>UINT32_MAX?UINT32_MAX:(uint32_t)delta;
+    uint64_t before=snes->beamMasterLast;
     snes_advance_master_cycles(snes,chunk);
+    /* A short walk means an IRQ latched (or is still pending): the beam
+     * pre-empts there. The remaining delta stays owed and is walked on the
+     * first sync after the handler has been taken. */
+    if (snes->beamMasterLast - before < chunk)
+      break;
     delta-=chunk;
   }
 }
@@ -493,6 +630,26 @@ void snes_writeReg(Snes* snes, uint16_t adr, uint8_t val) {
     }
     case 0x4209: {
       snes->vTimer = (snes->vTimer & 0x100) | val;
+      /* Was this target programmed into the PAST? A raster chain schedules its
+       * next split from inside the current one, so the new target is normally
+       * a few lines ahead of the beam. If it is already behind, the comparator
+       * cannot match until the counter wraps — and by then the NMI has reset
+       * the chain, so the split is lost for good.
+       *
+       * This is the one failure an external probe cannot see: the comparator
+       * stays armed, the beam keeps sweeping, nothing is "missed" on the target
+       * line because the beam is never on it. It looks exactly like a scene
+       * that simply has no split there. */
+      /* Only while the beam is in the VISIBLE field. A target programmed
+       * during vblank is for the next field and is legitimately "behind" the
+       * current beam position — counting it would flag correct scheduling as a
+       * fault, which is how an instrument invents a regression. */
+      if (snes->vIrqEnabled && snes->vPos < 225u &&
+          snes->vTimer < snes->vPos) {
+        snes->dbgTargetInPast++;
+        snes->dbgLastPastTarget = snes->vTimer;
+        snes->dbgLastPastBeam = snes->vPos;
+      }
       break;
     }
     case 0x420a: {

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -76,22 +76,35 @@ void snes_saveload(Snes *snes, SaveLoadInfo *sli) {
   cart_saveload(snes->cart, sli);
 
   if (s_saveload_version <= 5) {
-    /* Old layout: [hPos..vPos][pad][beamMasterLast][apuCatchup..divideResult].
-     * Read/write the legacy 48-byte tail and map into the current struct.
-     * Legacy size: 4 (hPos/vPos) + 4 pad + 8 beam + rest(=32) = 48. */
-    enum { kLegacySnesTail = 48 };
-    uint8_t blob[kLegacySnesTail];
-    const size_t new_tail = sizeof(*snes) - offsetof(Snes, hPos);
-    const size_t head = offsetof(Snes, apuCatchupCycles) - offsetof(Snes, hPos);
-    const size_t rest = new_tail - head; /* apuCatchupCycles .. end */
-    assert(new_tail == 40 && head == 8 && rest == 32);
-    memset(blob, 0, sizeof(blob));
-    memcpy(blob, &snes->hPos, 4);
-    memcpy(blob + 16, &snes->apuCatchupCycles, rest);
-    sli->func(sli, blob, kLegacySnesTail);
-    memcpy(&snes->hPos, blob, 4);
-    memcpy(&snes->apuCatchupCycles, blob + 16, rest);
+    /* Format 4/5 can no longer be mapped onto this struct, so refuse it
+     * rather than mis-load it.
+     *
+     * The old layout was [hPos..vPos][pad][beamMasterLast][apuCatchup..
+     * divideResult], and the code here copied that trailing region as one
+     * 32-byte block on the assumption that it was still contiguous and still
+     * 32 bytes. Both stopped being true: the dbgIrq / dbgNmi counters were
+     * later inserted between the interrupt fields and inVblank, so
+     * the region now measures 88 bytes AND has different contents in the
+     * middle. The copy therefore overran a 48-byte stack buffer by 56 bytes
+     * (caught by -Wfortify-source), and had it been merely clamped it would
+     * have loaded the wrong bytes into hTimer/vTimer and the IRQ flags --
+     * a silent corruption, which is worse than a refusal.
+     *
+     * Reconstructing a correct v4/v5 mapping is possible but untestable here
+     * with no such file to verify against, so this states the limit instead
+     * of guessing at it. RTL_SAV_VERSION_MIN is raised to 6 to match, which
+     * means this branch is unreachable through RtlLoadSnapshot; it stays as
+     * the explanation for anyone who tries to lower that bound again. */
+    assert(!"savestate format 4/5 is no longer supported");
   } else {
+    /* The savestate format IS this byte range. Adding or reordering any field
+     * after hPos silently changes it and quietly invalidates every existing
+     * save, so pin the size: if this fires, bump RTL_SAV_VERSION rather than
+     * deleting the assertion. (The blob is raw struct memory, so it was never
+     * portable across differing layouts; pinning it here at least makes a
+     * change visible at compile time.) */
+    _Static_assert(sizeof(Snes) - offsetof(Snes, hPos) == 96,
+                   "Snes savestate tail changed size -- bump RTL_SAV_VERSION");
     sli->func(sli, &snes->hPos, sizeof(*snes) - offsetof(Snes, hPos));
   }
   sli->func(sli, snes->ram, 0x20000);

--- a/runner/src/snes/snes.h
+++ b/runner/src/snes/snes.h
@@ -51,6 +51,41 @@ struct Snes {
   uint16_t vTimer;
   bool inNmi;
   bool inIrq;
+
+  /* IRQ comparator instrumentation. A frame-model host cannot measure these
+   * from outside: polling the debug server tops out around 20 samples/second
+   * against a 60 Hz field, so a match that is swept over is invisible to any
+   * external probe. Counted here, they are exact.
+   *   dbgIrqLatches   comparator matches that asserted the IRQ line
+   *   dbgIrqMissed    FIELDS that ended with the comparator armed and nothing
+   *                   latched — i.e. the beam stepped OVER the target, which
+   *                   the window test (target inside [h, h+span)) turns into
+   *                   no interrupt at all rather than a late one
+   *   dbgLastMissedLine  the vTimer value in force when that last happened */
+  uint32_t dbgIrqLatches;
+  uint32_t dbgIrqMissed;
+  uint16_t dbgLastMissedLine;
+  uint8_t  dbgLatchedThisField;
+  /* Overshoot: arrived on the target line already past the target column, so
+   * the match cannot fire this field. The one number that separates "the beam
+   * stepped over the interrupt" from "the game never asked for one". */
+  uint32_t dbgIrqOvershot;
+  uint32_t dbgMissDedupe;
+  uint16_t dbgLastOvershotLine;
+  uint16_t dbgLastOvershotBy;
+  /* Targets programmed behind the beam — see the comment at the $4209 write. */
+  uint32_t dbgTargetInPast;
+  uint16_t dbgLastPastTarget;
+  uint16_t dbgLastPastBeam;
+  /* Where the beam actually was when the host delivered NMI, and how far
+   * behind the CPU the beam had fallen at that moment. On hardware NMI is a
+   * vblank event, so the beam is at ~line 225-262; a value inside the visible
+   * field means the host's frame boundary and the PPU's field boundary have
+   * drifted apart, and every split the NMI schedules for an early line is
+   * already in the past. */
+  uint16_t dbgNmiBeamLine;
+  uint32_t dbgNmiLateCount;
+  uint64_t dbgBeamLagAtNmi;
   bool inVblank;
   // joypad
   bool autoJoyRead;
@@ -98,6 +133,26 @@ void snes_sync_master_clock(Snes *snes, uint64_t master_clock);
  * execution slice at this clock so every comparator edge is delivered at its
  * own beam position. See docs/FRAME_MODEL_HOSTS.md. */
 bool snes_next_irq_master(const Snes *snes, uint64_t now, uint64_t *out);
+
+/* Master clocks from the current beam position to the next programmed H/V IRQ
+ * match, or 0 when none is scheduled (or one is already pending).
+ *
+ * For a frame-model host this is a SCHEDULER bound, not a step size: run the
+ * CPU only up to the next event, so it cannot execute past a raster split and
+ * make the IRQ arrive late. snes_advance_beam's comparator is a window test
+ * (target inside [h, h+span)), so an overshoot yields no IRQ at all rather
+ * than a late one — and a split scheduled two scanlines after the one that
+ * scheduled it, as Gundam Wing does at $00:888E, is lost outright. */
+uint32_t snes_master_clocks_until_irq(const Snes *snes);
+
+/* Clocks to the start of scanline `line`, for a host that needs to place its
+ * frame boundary on the PPU's field boundary. See the implementation. */
+uint32_t snes_master_clocks_until_line(const Snes *snes, uint32_t line);
+
+/* Freeze (1) / release (0) the beam across an IRQ handler dispatch — see the
+ * comment on the implementation. The host's frame loop brackets
+ * interp_bridge_run_interrupt with this for raster IRQs. */
+void snes_beam_hold(int hold);
 
 extern int snes_frame_counter;
 #endif

--- a/tests/interp816/bridge_test.c
+++ b/tests/interp816/bridge_test.c
@@ -65,6 +65,26 @@ void debug_on_block_enter(uint32_t pc, uint32_t a, uint32_t x, uint32_t y) {
 }
 void RtlApuLock(void) {}
 void RtlApuUnlock(void) {}
+
+/* Attribution-scope stubs (common_cpu_infra.c in the real runner). The test
+ * doubles record what the bridge pushed so the interp scope is testable: the
+ * write rings copy g_last_recomp_func / the stack at write time, and if the
+ * bridge stops installing its interp@$ name, interpreted writes silently
+ * re-attribute to the stale enclosing AOT frame. */
+const char *g_last_recomp_func = "(none)";
+static const char *g_push_log[16];
+static int g_push_count = 0;
+static int g_push_depth = 0;
+static int g_pop_underflow = 0;
+void RecompStackPush(const char *name) {
+    if (g_push_count < 16) g_push_log[g_push_count] = name;
+    g_push_count++;
+    g_push_depth++;
+}
+void RecompStackPop(void) {
+    if (g_push_depth <= 0) g_pop_underflow = 1;
+    g_push_depth--;
+}
 void snes_catchupApu(Snes *snes) { (void)snes; }
 void snes_sync_master_clock(Snes *snes, uint64_t master_clock) {
     (void)snes; (void)master_clock;
@@ -332,12 +352,26 @@ int main(void) {
       uint8_t c[] = {0xA9,0x09, 0x60};
       load(0x8000, c, sizeof c);
       cpu_push_jsr_return_frame(&g_c);
+      g_push_count = 0; g_push_depth = 0; g_pop_underflow = 0;
+      const char *func_before = g_last_recomp_func;
       int rc = interp_bridge_run(&g_c, 0x008000);
       printf("S2 pure interp routine\n");
       CHECK(rc == 1, "rc=%d exp 1", rc);
       CHECK(g_aot_called == 0, "aot_called=%d exp 0", g_aot_called);
       CHECK((g_c.A & 0xFF) == 0x09, "A.lo=%02X exp 09", g_c.A & 0xFF);
-      CHECK(g_c.S == 0x01FF, "S=%04X exp 01FF", g_c.S); }
+      CHECK(g_c.S == 0x01FF, "S=%04X exp 01FF", g_c.S);
+      /* Attribution scope: the run pushed its interp@$ entry name, popped it
+       * on exit, and restored g_last_recomp_func. */
+      CHECK(g_push_count >= 1, "push_count=%d exp >=1 (interp scope pushed)",
+            g_push_count);
+      CHECK(g_push_count >= 1 && g_push_log[0] &&
+            strcmp(g_push_log[0], "interp@$008000") == 0,
+            "pushed name '%s' exp 'interp@$008000'",
+            g_push_count >= 1 && g_push_log[0] ? g_push_log[0] : "(null)");
+      CHECK(g_push_depth == 0, "push_depth=%d exp 0 (balanced)", g_push_depth);
+      CHECK(!g_pop_underflow, "pop underflow");
+      CHECK(g_last_recomp_func == func_before,
+            "g_last_recomp_func not restored after run"); }
 
     /* S3: JSR $8200 (NOT compiled) ; RTS  /  $8200: LDA #$33 ; RTS */
     { memset(RAM, 0, MEMSZ); init_cpu(); g_aot_called = 0;

--- a/tests/ppu/ppu_sprite_limit_test.c
+++ b/tests/ppu/ppu_sprite_limit_test.c
@@ -9,6 +9,10 @@
 
 Snes *g_snes;
 
+/* ppu.c references these runtime globals, but this harness links ppu.c alone. */
+int snes_frame_counter;
+unsigned char g_snesrecomp_last_hdmaen;
+
 uint16_t WsShadowTile(int layer, int screen_x, uint32_t wrapped_y,
                       uint16_t real_tile) {
     (void)layer;


### PR DESCRIPTION
Split out from #35.

This PR keeps the runtime/render side of the change set separate from the global DMA/refresh timing charges. It includes:

- interpreter attribution/debug bridge support
- BG mode 0 rendering and raster journal/debug plumbing
- mid-frame HDMA enable handling
- the #40 MSVC constructor prerequisite for the trace dump hook
- isolated test stubs needed by the PPU harness

Validation run locally:

- tests/interp816/run.ps1
- tests/ppu/run.ps1

Four-title regression smoke will be done against this and the stacked timing PR before merge.