### PR TITLE
Split #35: DMA and refresh timing charges

### DIFF
--- a/runner/src/common_cpu_infra.c
+++ b/runner/src/common_cpu_infra.c
@@ -516,8 +516,48 @@ void WatchdogFrameStart(void) {
   g_interrupt_context_depth = 0;
 }
 
+/* ── DRAM refresh ──
+ * Hardware stalls the CPU ~40 master clocks once per scanline, vblank
+ * included — a ~2.9% tax on execution this runtime never paid. Unpaid, a
+ * scene load completes its lag blocks early (measured 33/46/32 frames vs
+ * Mesen's 36/47/35 before this and the DMA-time charge), shifting the parity
+ * of the pass that spawns objects; the sprite hover (gated on the pass
+ * counter) then pairs with the wrong animation phase and publishes sprite
+ * tables hardware never shows.
+ *
+ * One watermark serves both tiers: generated code charges from
+ * WatchdogCheck() per block, the interpreter from its per-opcode advance.
+ * The park path (idle-spin skip) exempts its own jumps — parked time
+ * displaces no work, and taxing it would drift IRQ latch points. A jump of
+ * more than 4096 lines is treated as a teleport (boot, savestate load) and
+ * exempted rather than charged. */
+uint64_t g_refresh_charged_upto;
+static uint64_t s_refresh_phase;
+void snes_refresh_exempt(void) { g_refresh_charged_upto = g_cpu.master_cycles; }
+void snes_refresh_charge(void) {
+  uint64_t m = g_cpu.master_cycles;
+  if (g_refresh_charged_upto == 0 || m < g_refresh_charged_upto) {
+    g_refresh_charged_upto = m;
+    return;
+  }
+  uint64_t delta = m - g_refresh_charged_upto;
+  s_refresh_phase += delta;
+  uint64_t lines = s_refresh_phase / 1364u;
+  if (lines > 4096u) {            /* teleport, not execution */
+    s_refresh_phase = 0;
+    g_refresh_charged_upto = m;
+    return;
+  }
+  if (lines) {
+    s_refresh_phase -= lines * 1364u;
+    g_cpu.master_cycles += 40u * lines;
+  }
+  g_refresh_charged_upto = g_cpu.master_cycles;
+}
+
 // Called at loop headers in generated code — detect infinite loops
 void WatchdogCheck(void) {
+  snes_refresh_charge();
 #ifdef SNES_COSIM
   /* Co-sim WRAM watchpoint (dev, env-gated): name the recompiled function that
    * writes a given low-WRAM address. WatchdogCheck runs per-block with

--- a/runner/src/common_cpu_infra.h
+++ b/runner/src/common_cpu_infra.h
@@ -29,6 +29,8 @@ typedef void CpuInfraInitializeFunc(void);
 typedef void RunOneFrameOfGameFunc(void);
 
 void WatchdogCheck(void);
+void snes_refresh_charge(void);   /* DRAM refresh tax; see common_cpu_infra.c */
+void snes_refresh_exempt(void);   /* mark a master-clock teleport (park, load) */
 void WatchdogFrameStart(void);
 void RecompStackPush(const char *name);
 void RecompStackPop(void);

--- a/runner/src/snes/dma.c
+++ b/runner/src/snes/dma.c
@@ -281,6 +281,36 @@ static void dma_transferByte(Dma* dma, uint16_t aAdr, uint8_t aBank, uint8_t bAd
  * pointer at the top of the field; dma_doHdma() runs once per scanline.
  * `size` doubles as the indirect address, as the struct comment notes. */
 
+/* Estimated master clocks one frame of HDMA steals from the CPU.
+ *
+ * Hardware pauses the CPU during every active channel's per-line transfer:
+ * ~18 clocks of per-line overhead when any channel is live, plus per channel
+ * 8 clocks of address work and 8 per byte moved (1/2/2/4/4/4/2/4 bytes for
+ * modes 0-7), plus 16 more when the channel reloads an indirect address.
+ * With the six-channel gradient/scroll setup this title runs on its menu and
+ * VS screens that is ~170 clocks x 224 lines = ~10.7%% of the frame -- more
+ * than DRAM refresh -- and it was never charged: measured, our menu lag
+ * blocks ran one frame short of Mesen's (7 vs 8) while the HDMA-off loading
+ * screens matched exactly. The phase error that mispairs the sprite-table
+ * and tile-art updates at scene entry rides on exactly that deficit.
+ *
+ * An estimate from the live channel state at frame start; terminated-early
+ * tables overcharge slightly, which is the conservative side. */
+uint64_t dma_hdmaMasterEstimate(Dma* dma) {
+  static const uint8_t bytesPerUnit[8] = {1, 2, 2, 4, 4, 4, 2, 4};
+  uint64_t perLine = 0;
+  int any = 0;
+  for (int i = 0; i < 8; i++) {
+    DmaChannel* c = &dma->channel[i];
+    if (!c->hdmaActive) continue;
+    any = 1;
+    perLine += 8u + 8u * bytesPerUnit[c->mode & 7];
+    if (c->indirect) perLine += 16u;
+  }
+  if (!any) return 0;
+  return (18u + perLine) * 224u + 128u /* per-frame init */;
+}
+
 void dma_initHdma(Dma* dma) {
   for(int i = 0; i < 8; i++) {
     DmaChannel* ch = &dma->channel[i];

--- a/runner/src/snes/dma.h
+++ b/runner/src/snes/dma.h
@@ -64,6 +64,7 @@ void dma_doDma(Dma* dma);
  * scanline (FRAME_MODEL_HOSTS.md). */
 void dma_initHdma(Dma* dma);
 void dma_doHdma(Dma* dma);
+uint64_t dma_hdmaMasterEstimate(Dma* dma); /* per-frame CPU-stall estimate */
 bool dma_cycle(Dma* dma);
 void dma_startDma(Dma* dma, uint8_t val, bool hdma);
 void dma_saveload(Dma *dma, SaveLoadInfo *sli);

--- a/runner/src/snes/interp_bridge.c
+++ b/runner/src/snes/interp_bridge.c
@@ -1198,6 +1198,9 @@ static int _interp_run_core(CpuState *cpu, uint32_t entry_pc24,
             uint64_t _master = s_interp_bus_master + (uint64_t)_internal * 6u;
             cpu->cycles        += (uint64_t)_cyc;
             cpu->master_cycles += _master;
+            /* DRAM refresh tax — shared watermark with the AOT tier's
+             * WatchdogCheck charge; see common_cpu_infra.c. */
+            snes_refresh_charge();
             cpu->coprocessor_master_cycles = cpu->master_cycles;
             if (g_snes) snes_sync_master_clock(g_snes, cpu->master_cycles);
             if (g_snes && g_snes->cart)

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -678,6 +678,31 @@ void snes_writeReg(Snes* snes, uint16_t adr, uint8_t val) {
           ppudma_record_dma(ch, c->fromB, c->aBank, c->aAdr, c->bAdr, c->size);
         }
       }
+      /* Charge the transfer's guest time BEFORE running it. On hardware a
+       * general-purpose DMA halts the CPU for ~8 master clocks per byte plus
+       * small per-channel setup; this loop used to complete the whole
+       * transfer in ZERO guest time. That is not a rounding error: a scene
+       * load moves enough data that the free time let the loader finish its
+       * lag blocks measurably earlier than hardware (33/46/32 frames vs
+       * Mesen's 36/47/35 for the identical flow), which shifted the parity
+       * of the pass that spawns the mechs — and the sprite hover (gated on
+       * the pass counter) then paired with the wrong animation phase,
+       * publishing Y±1 sprite tables hardware never shows. See
+       * gundamwing-parity-root-cause. HDMA stays uncharged here (per-line,
+       * far smaller; out of scope for this fix). */
+      {
+        extern CpuState g_cpu;
+        uint64_t dma_master = 12;
+        for (int ch = 0; ch < 8; ch++) {
+          if (val & (1 << ch)) {
+            uint32_t n = snes->dma->channel[ch].size;
+            if (n == 0) n = 0x10000;
+            dma_master += 8 + (uint64_t)n * 8;
+          }
+        }
+        g_cpu.master_cycles += dma_master;
+        snes_sync_master_clock(snes, g_cpu.master_cycles);
+      }
       dma_startDma(snes->dma, val, false);
       while (dma_cycle(snes->dma)) {}
       break;

--- a/tests/interp816/bridge_test.c
+++ b/tests/interp816/bridge_test.c
@@ -65,6 +65,7 @@ void debug_on_block_enter(uint32_t pc, uint32_t a, uint32_t x, uint32_t y) {
 }
 void RtlApuLock(void) {}
 void RtlApuUnlock(void) {}
+void snes_refresh_charge(void) {}
 
 /* Attribution-scope stubs (common_cpu_infra.c in the real runner). The test
  * doubles record what the bridge pushed so the interp scope is testable: the


### PR DESCRIPTION
Split out from #35.

This PR is stacked on #43 and contains only the timing-sensitive portion:

- charge MDMA transfer time
- charge the DRAM refresh tax
- charge HDMA per-line CPU stalls
- add the bridge-test stub needed because the harness does not link the full runtime

Validation run locally:

- tests/interp816/run.ps1
- tests/ppu/run.ps1

This is the higher-risk split and should get the four-title smoke pass before merge.