### PR TITLE
Align interp indexed read page-cross cycles

### DIFF
--- a/runner/src/snes/interp816.c
+++ b/runner/src/snes/interp816.c
@@ -364,8 +364,9 @@ static uint32_t interp816_adrIdy(Interp816* cpu, uint32_t* low, bool write) {
   uint8_t adr = interp816_readOpcode(cpu);
   if(cpu->dp & 0xff) cpu->cyclesUsed++; // dpr not 0: 1 extra cycle
   uint16_t pointer = interp816_readWord(cpu, (cpu->dp + adr) & 0xffff, (cpu->dp + adr + 1) & 0xffff);
-  if(write && (!cpu->xf || ((pointer >> 8) != ((pointer + cpu->y) >> 8)))) cpu->cyclesUsed++;
-  // x = 0 or page crossed, with writing opcode: 1 extra cycle
+  bool crossed = (pointer >> 8) != ((pointer + cpu->y) >> 8);
+  if(write ? (!cpu->xf || crossed) : crossed) cpu->cyclesUsed++;
+  // writes: x = 0 or page crossed; reads: page crossed
   *low = ((cpu->db << 16) + pointer + cpu->y) & 0xffffff;
   return ((cpu->db << 16) + pointer + cpu->y + 1) & 0xffffff;
 }
@@ -409,16 +410,18 @@ static uint32_t interp816_adrAbs(Interp816* cpu, uint32_t* low) {
 
 static uint32_t interp816_adrAbx(Interp816* cpu, uint32_t* low, bool write) {
   uint16_t adr = interp816_readOpcodeWord(cpu);
-  if(write && (!cpu->xf || ((adr >> 8) != ((adr + cpu->x) >> 8)))) cpu->cyclesUsed++;
-  // x = 0 or page crossed, with writing opcode: 1 extra cycle
+  bool crossed = (adr >> 8) != ((adr + cpu->x) >> 8);
+  if(write ? (!cpu->xf || crossed) : crossed) cpu->cyclesUsed++;
+  // writes: x = 0 or page crossed; reads: page crossed
   *low = ((cpu->db << 16) + adr + cpu->x) & 0xffffff;
   return ((cpu->db << 16) + adr + cpu->x + 1) & 0xffffff;
 }
 
 static uint32_t interp816_adrAby(Interp816* cpu, uint32_t* low, bool write) {
   uint16_t adr = interp816_readOpcodeWord(cpu);
-  if(write && (!cpu->xf || ((adr >> 8) != ((adr + cpu->y) >> 8)))) cpu->cyclesUsed++;
-  // x = 0 or page crossed, with writing opcode: 1 extra cycle
+  bool crossed = (adr >> 8) != ((adr + cpu->y) >> 8);
+  if(write ? (!cpu->xf || crossed) : crossed) cpu->cyclesUsed++;
+  // writes: x = 0 or page crossed; reads: page crossed
   *low = ((cpu->db << 16) + adr + cpu->y) & 0xffffff;
   return ((cpu->db << 16) + adr + cpu->y + 1) & 0xffffff;
 }

--- a/tests/cpu_diff/cpu_diff.c
+++ b/tests/cpu_diff/cpu_diff.c
@@ -111,6 +111,11 @@ int interp_bridge_return_targets_owner(uint16 ret_s, uint16 post_s) {
 RecompReturn interp_bridge_lle_yield_unwind(CpuState *c, uint32 pc) {
     (void)c; (void)pc; return RECOMP_RETURN_NORMAL;
 }
+int interp_bridge_lle_master_deadline_reached(const CpuState *c) {
+    (void)c; return 0;
+}
+void snes_refresh_charge(void) {}
+void snes_refresh_exempt(void) {}
 int interp816_opcode_hook(uint32_t addr) { (void)addr; return 0; }
 
 /* ── deterministic RNG (no Date/rand: reproducible) ── */

--- a/tests/interp816/interp816_test.c
+++ b/tests/interp816/interp816_test.c
@@ -185,6 +185,33 @@ int main(void) {
     run(p,1);
     CHECK(p->a==0x0077, "handler A=%04X exp 0077", p->a); }
 
+  { uint8_t c[] = {0x18,0xFB, 0xC2,0x30, 0xA2,0x10,0x00, 0xBD,0xE0,0x20};
+    Interp816 *p = prep(c,sizeof c);
+    run(p,4);
+    MEM[0x20f0]=0x34; MEM[0x20f1]=0x12;
+    int cycles = interp816_runOpcode(p);
+    printf("T22 LDA abs,X read without page cross\n");
+    CHECK(cycles==5, "cycles=%d exp 5", cycles);
+    CHECK(p->a==0x1234, "A=%04X exp 1234", p->a); }
+
+  { uint8_t c[] = {0x18,0xFB, 0xC2,0x30, 0xA2,0x10,0x00, 0xBD,0xF8,0x20};
+    Interp816 *p = prep(c,sizeof c);
+    run(p,4);
+    MEM[0x2108]=0x78; MEM[0x2109]=0x56;
+    int cycles = interp816_runOpcode(p);
+    printf("T23 LDA abs,X read with page cross\n");
+    CHECK(cycles==6, "cycles=%d exp 6", cycles);
+    CHECK(p->a==0x5678, "A=%04X exp 5678", p->a); }
+
+  { uint8_t c[] = {0x18,0xFB, 0xC2,0x30, 0xA0,0x10,0x00, 0xB9,0xF8,0x20};
+    Interp816 *p = prep(c,sizeof c);
+    run(p,4);
+    MEM[0x2108]=0xBC; MEM[0x2109]=0x9A;
+    int cycles = interp816_runOpcode(p);
+    printf("T24 LDA abs,Y read with page cross\n");
+    CHECK(cycles==6, "cycles=%d exp 6", cycles);
+    CHECK(p->a==0x9ABC, "A=%04X exp 9ABC", p->a); }
+
   printf("\n==== interp816 Phase-0: %d/%d checks passed ====\n", g_check - g_fail, g_check);
   if (g_fail) { printf("RESULT: FAIL (%d)\n", g_fail); return 1; }
   printf("RESULT: PASS\n");


### PR DESCRIPTION
## Summary
- charge interp816 abs,X / abs,Y / (dp),Y read addressing for page-cross cycles, matching the v2 AOT runtime charge model
- add focused interpreter cycle assertions for abs,X/abs,Y crossing and non-crossing reads
- add missing cpu_diff runtime seam stubs so the opcode differential harness links against current generated output

## Validation
- `tests/interp816/run.ps1`
- targeted cycle import harness: `tests/test_snes_cycles.py` + `tests/v2/test_emit_cycle_charge.py` => 22 passed
- `python tests/run_tests.py` => 81 passed
- `python tests/v2/run_tests.py` => 375 passed
- `tests/cpu_diff/run.ps1` => 1,599,000 checks, 0 divergences

Fixes #39