### PR TITLE
renderer: keep Mode 2 OPT edge stable in widescreen

### DIFF
--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -1071,22 +1071,19 @@ static void PpuDrawBackground_4bpp_opt(Ppu *ppu, uint y, bool sub, uint layer,
     const int sample_bias = ws_bias[windex];
     PpuZbufType *dstz =
         ppu->bgBuffers[sub].data + left + kPpuExtraLeftRight;
-    bool left_edge = left < 8 - (hscroll & 7);
-
     /* OPT values apply to a rendered segment, not independently to every
      * screen pixel.  The selected horizontal offset determines where the
      * next eight-pixel source-tile boundary lies; only there does the PPU
      * fetch another BG3 offset-map entry. */
     for (int screen_x = left; screen_x < right;) {
+      const int source_screen_x = screen_x + sample_bias;
       unsigned hoffset = hscroll;
       unsigned voffset = vscroll;
-      if (left_edge) {
+      if (source_screen_x < 8 - (int)(hscroll & 7)) {
         /* The SNES cannot apply OPT to the leftmost source-tile column. */
-        left_edge = false;
       } else {
         const unsigned opt_pos =
-            (opt_hscroll + (unsigned)(screen_x + sample_bias) - 1) &
-            opt_coord_mask;
+            (opt_hscroll + (unsigned)source_screen_x - 1) & opt_coord_mask;
         const int opt_x = opt_pos >> opt_shift;
         const uint16 hcell = PpuReadTilemapEntry(ppu, 2, opt_x, opt_hrow);
         const uint16 vcell = PpuReadTilemapEntry(ppu, 2, opt_x, opt_vrow);
@@ -1097,7 +1094,7 @@ static void PpuDrawBackground_4bpp_opt(Ppu *ppu, uint y, bool sub, uint layer,
       }
 
       const unsigned sx =
-          (hoffset + (unsigned)(screen_x + sample_bias)) & coord_mask;
+          (hoffset + (unsigned)source_screen_x) & coord_mask;
       const unsigned sy = (voffset + y) & coord_mask;
       unsigned width = 8 - (sx & 7);
       if (width > (unsigned)(right - screen_x))
@@ -1924,7 +1921,7 @@ static NOINLINE void PpuDrawWholeLine(Ppu *ppu, uint y) {
   uint32 cw_clip_math = ((cwin.bits & kCwBitsMod[PPU_clipMode(ppu)]) ^ kCwBitsMod[PPU_clipMode(ppu) + 4]) |
     ((cwin.bits & kCwBitsMod[PPU_preventMathMode(ppu)]) ^ kCwBitsMod[PPU_preventMathMode(ppu) + 4]) << 8;
 
-  uint32 *dst = (uint32*)&ppu->renderBuffer[(y - 1) * ppu->renderPitch], *dst_org = dst;
+  uint32 *dst = (uint32*)&ppu->renderBuffer[(y - 1) * ppu->renderPitch];
 
   dst += compose_full_budget ? 0 : (ppu->extraLeftRight - ppu->extraLeftCur);
 

--- a/tests/ppu/ppu_sprite_limit_test.c
+++ b/tests/ppu/ppu_sprite_limit_test.c
@@ -84,6 +84,37 @@ static void setup_one_sprite_line(Ppu *ppu, int raw_x) {
         ppu->cgram[i] = 0x7fff;
 }
 
+static void setup_mode2_offset_bg1(Ppu *ppu) {
+    ppu->inidisp = 0x0f;
+    ppu->bgmode = 2;
+    ppu->screenEnabled[1] = 1;
+    ppu->bgXsc[2] = 0x04;
+    ppu->bgTileAdr = 0x0001;
+    ppu->cgwsel = 0x02;
+    ppu->cgadsub = 0x60;
+    for (size_t i = 0; i < sizeof ppu->vram / sizeof ppu->vram[0]; i++)
+        ppu->vram[i] = 0;
+    ppu->cgram[0] = 0;
+    ppu->cgram[1] = 0x001f;
+    ppu->cgram[2] = 0x03e0;
+
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 32; x++) {
+            ppu->vram[y * 32 + x] = x == 0 ? 0 : 1;
+            ppu->vram[0x400 + y * 32 + x] = 0x2010;
+        }
+    }
+    for (int row = 0; row < 8; row++) {
+        ppu->vram[0x1000 + row] = 0x00ff;
+        ppu->vram[0x1000 + 16 + row] = 0xff00;
+    }
+}
+
+static void render_one_line(Ppu *ppu) {
+    ppu_runLine(ppu, 0);
+    ppu_runLine(ppu, 1);
+}
+
 int main(void) {
     enum { kPitch = kPpuXPixels * 4 };
     uint8_t pixels[kPitch];
@@ -121,10 +152,44 @@ int main(void) {
     PpuBeginDrawing(ppu, pixels, kPitch,
                     kPpuRenderFlags_NewRenderer |
                     kPpuRenderFlags_NoSpriteLimits);
-    ppu_runLine(ppu, 0);
-    ppu_runLine(ppu, 1);
+    render_one_line(ppu);
     failures += check((ppu->objBuffer.data[kPpuExtraLeftRight] & 0xff) != 0,
                       "disabling sprite limits renders the low slot");
+
+    /* Mode 2 OPT must still treat x=0 as the hardware left edge when
+     * widescreen margins are active. Otherwise backdrop + halved subscreen
+     * math samples offset BG columns and replaces authentic columns. */
+    {
+        enum { kExtra = 8, kWidePixels = kPpuXPixels + kExtra * 2 };
+        uint32_t native_pixels[kPpuXPixels] = {0};
+        uint32_t wide_pixels[kWidePixels] = {0};
+        int mismatches = 0;
+
+        ppu_reset(ppu);
+        PpuBeginDrawing(ppu, (uint8_t *)native_pixels,
+                        sizeof(uint32_t) * kPpuXPixels,
+                        kPpuRenderFlags_NewRenderer);
+        setup_mode2_offset_bg1(ppu);
+        render_one_line(ppu);
+
+        ppu_reset(ppu);
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        setup_mode2_offset_bg1(ppu);
+        render_one_line(ppu);
+
+        for (int x = 0; x < kPpuXPixels; x++) {
+            if (native_pixels[x] !=
+                wide_pixels[kExtra + x])
+                mismatches++;
+        }
+        failures += check(mismatches == 0,
+                          "Mode 2 half-color subscreen keeps authentic columns with extra space");
+        failures += check(wide_pixels[kExtra] != 0,
+                          "Mode 2 half-color subscreen draws widened first authentic column");
+    }
 
     /* Existing line-enhancer users rely on BG1 staying inside its authentic
      * destination viewport. New title-specific source insets must be opt-in


### PR DESCRIPTION
Fixes #30.\n\nMode 2 offset-per-tile rendering was treating the widened left margin as the hardware left edge. With any non-zero extra space, the first authentic tile column could consume BG3 offset entries before x=0, so a 256-wide render and the widened authentic columns diverged under backdrop + halved subscreen math.\n\nThis evaluates the OPT left-edge skip from the source/native segment x instead, and adds a ROM-free regression for the reported color-math setup.\n\nTested:\n- ./tests/run_c_tests.sh