### PR TITLE
renderer: default OBJ overlay capture to all slots

### DIFF
--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -129,8 +129,13 @@ bool PpuSetOverlayCapture(Ppu *ppu, PpuOverlaySource source,
   capture->y0 = (int16_t)y0;
   capture->y1 = (int16_t)y1;
   capture->flags = flags & kPpuOverlayFlag_RemoveFromGame;
-  capture->oamFirst = 0;
-  capture->oamCount = 0;
+  if (source == kPpuOverlaySource_Obj) {
+    capture->oamFirst = 0;
+    capture->oamCount = 128;
+  } else {
+    capture->oamFirst = 0;
+    capture->oamCount = 0;
+  }
   return true;
 }
 

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -87,8 +87,8 @@ typedef struct PpuOverlayCapture {
   int16_t x0, x1;
   int16_t y0, y1;
   uint8_t flags;
-  /* OBJ-only selector. A zero count captures no objects. Games validate any
-   * semantic identity (HUD icon, portrait, etc.) before supplying the range. */
+  /* OBJ-only selector. Arming an OBJ capture selects all OAM slots by default;
+   * games can narrow this when they know the semantic slot range to export. */
   uint8_t oamFirst, oamCount;
 } PpuOverlayCapture;
 

--- a/tests/ppu/ppu_sprite_limit_test.c
+++ b/tests/ppu/ppu_sprite_limit_test.c
@@ -115,6 +115,15 @@ static void render_one_line(Ppu *ppu) {
     ppu_runLine(ppu, 1);
 }
 
+static unsigned count_argb_pixels(const uint32_t *pixels, size_t count) {
+    unsigned nonzero = 0;
+    for (size_t i = 0; i < count; i++) {
+        if (pixels[i] != 0)
+            nonzero++;
+    }
+    return nonzero;
+}
+
 int main(void) {
     enum { kPitch = kPpuXPixels * 4 };
     uint8_t pixels[kPitch];
@@ -189,6 +198,63 @@ int main(void) {
                           "Mode 2 half-color subscreen keeps authentic columns with extra space");
         failures += check(wide_pixels[kExtra] != 0,
                           "Mode 2 half-color subscreen draws widened first authentic column");
+    }
+
+    /* An armed OBJ overlay captures all OAM slots by default. Hosts may still
+     * narrow the slot range explicitly, but the default should not silently
+     * export an empty surface. */
+    {
+        uint32_t frame_pixels[kPpuBufWidth] = {0};
+        uint32_t obj_pixels[kPpuXPixels] = {0};
+
+        ppu_reset(ppu);
+        PpuBeginDrawing(ppu, (uint8_t *)frame_pixels,
+                        sizeof(uint32_t) * kPpuBufWidth,
+                        kPpuRenderFlags_NewRenderer);
+        failures += check(PpuBindOverlaySurface(
+                              ppu, kPpuOverlaySource_Obj,
+                              (uint8_t *)obj_pixels,
+                              sizeof(uint32_t) * kPpuXPixels),
+                          "OBJ overlay surface binds");
+        failures += check(PpuSetOverlayCapture(
+                              ppu, kPpuOverlaySource_Obj, 0, 0, 8, 1,
+                              kPpuOverlayFlag_RemoveFromGame),
+                          "OBJ overlay capture arms");
+        setup_one_sprite_line(ppu, 0);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(count_argb_pixels(obj_pixels, 8) == 8,
+                          "default OBJ capture exports selected pixels");
+        failures += check((ppu->objBuffer.data[kPpuExtraLeftRight] & 0xff) == 0,
+                          "RemoveFromGame drops captured OBJ from frame");
+
+        memset(frame_pixels, 0, sizeof frame_pixels);
+        memset(obj_pixels, 0, sizeof obj_pixels);
+        ppu_reset(ppu);
+        PpuBeginDrawing(ppu, (uint8_t *)frame_pixels,
+                        sizeof(uint32_t) * kPpuBufWidth,
+                        kPpuRenderFlags_NewRenderer);
+        failures += check(PpuBindOverlaySurface(
+                              ppu, kPpuOverlaySource_Obj,
+                              (uint8_t *)obj_pixels,
+                              sizeof(uint32_t) * kPpuXPixels),
+                          "OBJ overlay surface rebinds");
+        failures += check(PpuSetOverlayCapture(
+                              ppu, kPpuOverlaySource_Obj, 0, 0, 8, 1,
+                              kPpuOverlayFlag_RemoveFromGame),
+                          "OBJ overlay capture rearms");
+        failures += check(PpuSetOverlayOamRange(ppu, 1, 1),
+                          "OBJ overlay range narrows capture");
+        setup_one_sprite_line(ppu, 0);
+        ppu_runLine(ppu, 0);
+        ppu_runLine(ppu, 1);
+        failures += check(count_argb_pixels(obj_pixels, 8) == 0,
+                          "narrowed OBJ capture excludes other slots");
+        failures += check((ppu->objBuffer.data[kPpuExtraLeftRight] & 0xff) != 0,
+                          "excluded OBJ remains in frame");
+        failures += check(PpuBindOverlaySurface(
+                              ppu, kPpuOverlaySource_Obj, NULL, 0),
+                          "OBJ overlay surface unbinds");
     }
 
     /* Existing line-enhancer users rely on BG1 staying inside its authentic


### PR DESCRIPTION
Fixes #31.\n\nArming an OBJ overlay capture now selects all OAM slots by default, so a host that binds OBJ export and requests remove-from-game gets exported pixels without needing a separate OAM range call. Hosts can still narrow the capture with PpuSetOverlayOamRange().\n\nThe regression verifies default OBJ export, removal from the game render, and narrowed range behavior.\n\nTested:\n- ./tests/run_c_tests.sh