### PR TITLE
Add opt-in hooks for Star Fox Enhanced widescreen

### DIFF
--- a/recompiler-rs/src/cfg.rs
+++ b/recompiler-rs/src/cfg.rs
@@ -107,6 +107,7 @@ pub struct BankCfg {
     pub includes: Vec<String>,
     pub entries: Vec<BankEntry>,
     pub names: Vec<NameDecl>,
+    pub symbols: Vec<NameDecl>,
     /// Exact 24-bit executable function boundaries which must remain LLE.
     pub force_lle: BTreeSet<u32>,
     pub exclude_ranges: Vec<(u32, u32)>,
@@ -693,6 +694,25 @@ pub fn parse_bank_cfg(text: &str, path: &str) -> Result<BankCfg, String> {
                 Err(_) => continue,
             };
             cfg.names.push(NameDecl {
+                addr_24: addr,
+                name: tokens[2].to_string(),
+            });
+            continue;
+        }
+        // symbol <hex_addr> <friendly_name>
+        //
+        // Non-promoting label overlay. Unlike `name`, this is not
+        // auto-promoted into cfg.entries; it is only a friendly label for
+        // code discovered through real control flow.
+        if head == "symbol" {
+            if tokens.len() < 3 {
+                continue;
+            }
+            let addr = match parse_hex(tokens[1]) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            cfg.symbols.push(NameDecl {
                 addr_24: addr,
                 name: tokens[2].to_string(),
             });

--- a/recompiler/v2/cfg_loader.py
+++ b/recompiler/v2/cfg_loader.py
@@ -25,6 +25,9 @@ v2 KEEPS:
 - `name <hex_addr> <name>` — friendly-naming for cross-bank labels.
   v2 emits these as `void NAME(CpuState *cpu);` forward declarations
   in funcs.h (Phase 6e/f). For now we just retain them.
+- `symbol <hex_addr> <name>` — non-promoting friendly label. Unlike
+  `name`, this never creates an emit entry or funcs.h declaration; it
+  only names an address if analysis reaches it through real code flow.
 - `force_lle <pc24>` — keep an exact architectural function boundary on
   the interpreter tier even when profile promotion or static reachability
   would otherwise materialise it as native code.
@@ -80,6 +83,7 @@ class BankCfg:
     includes: List[str] = field(default_factory=list)
     entries: List[BankEntry] = field(default_factory=list)
     names: List[NameDecl] = field(default_factory=list)
+    symbols: List[NameDecl] = field(default_factory=list)
     # Exact 24-bit function boundaries which must stay interpreter-only.
     # Unlike exclude_range, these are executable ROM routines; they merely
     # rely on behavior (for example return-stack rewriting) that the native
@@ -730,6 +734,22 @@ def load_bank_cfg(path: str) -> BankCfg:
                     continue
                 friendly = tokens[2]
                 cfg.names.append(NameDecl(addr_24=addr, name=friendly))
+                continue
+
+            # symbol <hex_addr> <friendly_name>
+            #
+            # Non-promoting label overlay. This feeds the name resolver for
+            # analysis/emission comments and discovered functions, but unlike
+            # `name` it never auto-promotes same-bank labels into cfg.entries.
+            if head == 'symbol':
+                if len(tokens) < 3:
+                    continue
+                try:
+                    addr = _parse_hex(tokens[1])
+                except ValueError:
+                    continue
+                friendly = tokens[2]
+                cfg.symbols.append(NameDecl(addr_24=addr, name=friendly))
                 continue
 
             # exclude_range <start> <end>

--- a/recompiler/v2/program_emit.py
+++ b/recompiler/v2/program_emit.py
@@ -162,6 +162,15 @@ def _cfg_name_maps(parsed):
                 continue
             name_for_pc[pc24] = nd.name
             claimed_names.add(nd.name)
+    for bank, _path, cfg in parsed:
+        for nd in getattr(cfg, "symbols", ()):
+            pc24 = nd.addr_24 & 0xFFFFFF
+            if pc24 in name_for_pc:
+                continue
+            if not nd.name or nd.name in claimed_names:
+                continue
+            name_for_pc[pc24] = nd.name
+            claimed_names.add(nd.name)
     return (name_for_pc, canonical_for_pc, templates_exact,
             templates_any, cfg_by_bank)
 

--- a/runner/src/common_cpu_infra.h
+++ b/runner/src/common_cpu_infra.h
@@ -28,6 +28,24 @@ void SnesEnterNativeMode(void);
 typedef void CpuInfraInitializeFunc(void);
 typedef void RunOneFrameOfGameFunc(void);
 
+typedef enum RtlEnhancedRenderResult {
+  kRtlEnhancedRender_NotHandled = 0,
+  kRtlEnhancedRender_Handled = 1,
+} RtlEnhancedRenderResult;
+
+typedef struct RtlEnhancedRendererFrame {
+  uint8 *pixels;
+  size_t pitch;
+  int width;
+  int height;
+  uint32 render_flags;
+  uint16 widescreen_extra;
+  int default_renderer_done;
+} RtlEnhancedRendererFrame;
+
+typedef RtlEnhancedRenderResult RtlEnhancedRenderFrameFunc(
+    RtlEnhancedRendererFrame *frame);
+
 void WatchdogCheck(void);
 void snes_refresh_charge(void);   /* DRAM refresh tax; see common_cpu_infra.c */
 void snes_refresh_exempt(void);   /* mark a master-clock teleport (park, load) */
@@ -82,6 +100,9 @@ typedef struct RtlGameInfo {
   CpuInfraInitializeFunc *initialize;
   RunOneFrameOfGameFunc *run_frame;
   RunOneFrameOfGameFunc *draw_ppu_frame;
+  /* Optional title-owned native/enhanced presentation hook. Hosts must keep
+   * this opt-in and leave draw_ppu_frame as the default console renderer. */
+  RtlEnhancedRenderFrameFunc *enhanced_render_frame;
   // Filename prefix used by RtlSaveLoad, e.g. "save" produces
   // "saves/save%d.sav". If NULL, framework uses "%s_save" with title.
   const char *save_name_prefix;

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -86,6 +86,7 @@ static socket_t s_listen_sock = SOCKET_INVALID;
 static socket_t s_client_sock = SOCKET_INVALID;
 static uint8_t *s_ram = NULL;
 static uint32_t s_ram_size = 0;
+static DebugServerGameCommandHandler s_game_command_handler = NULL;
 // Note: s_frame_counter pointer removed — use snes_frame_counter directly
 static volatile int s_paused = 0;
 static volatile int s_step_remaining = 0;  // frames remaining before auto-re-pause
@@ -2024,6 +2025,34 @@ static void cmd_ping(const char *args) {
 static void cmd_frame(const char *args) {
     send_fmt("{\"frame\":%d,\"func\":\"%s\"}", snes_frame_counter,
              g_last_recomp_func ? g_last_recomp_func : "?");
+}
+
+static void cmd_game(const char *args) {
+    char cmd[64];
+    size_t n;
+    const char *rest;
+    if (!args) args = "";
+    while (*args == ' ') args++;
+    if (!*args) {
+        send_line("{\"error\":\"missing game command\"}");
+        return;
+    }
+    rest = strchr(args, ' ');
+    n = rest ? (size_t)(rest - args) : strlen(args);
+    if (n >= sizeof(cmd))
+        n = sizeof(cmd) - 1;
+    memcpy(cmd, args, n);
+    cmd[n] = 0;
+    if (rest) {
+        while (*rest == ' ') rest++;
+    } else {
+        rest = "";
+    }
+    if (s_game_command_handler &&
+        s_game_command_handler(cmd, rest, send_line)) {
+        return;
+    }
+    send_fmt("{\"error\":\"unknown game command\",\"cmd\":\"%s\"}", cmd);
 }
 
 // read_ram: space-separated hex, streamed to handle arbitrary lengths up to
@@ -7930,6 +7959,7 @@ static const CmdEntry s_commands[] = {
     {"get_apu_misc",   cmd_get_apu_misc},
     {"frame",         cmd_frame},
     {"dump_frame_range", cmd_dump_frame_range},
+    {"game",          cmd_game},
     {"read_ram",      cmd_read_ram},
     {"dump_ram",      cmd_dump_ram},
     {"read_sram",     cmd_read_sram},
@@ -8197,6 +8227,10 @@ int debug_server_init(int port) {
 void debug_server_set_ram(uint8_t *ram, uint32_t ram_size) {
     s_ram = ram;
     s_ram_size = ram_size;
+}
+
+void debug_server_set_game_command_handler(DebugServerGameCommandHandler handler) {
+    s_game_command_handler = handler;
 }
 
 static void check_watchpoints(void) {

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -1500,7 +1500,7 @@ static char s_frange_dir[400];
 typedef struct DebugPpuHostState {
     uint8_t *render_buffer;
     uint32_t render_pitch, render_flags;
-    uint8_t extra_left_cur, extra_right_cur, extra_left_right;
+    uint16_t extra_left_cur, extra_right_cur, extra_left_right;
     uint8_t extra_bottom_cur;
     PpuWidescreenLineEnhancer *enhancer;
     void *enhancer_context;

--- a/runner/src/debug_server.h
+++ b/runner/src/debug_server.h
@@ -30,6 +30,9 @@
 #if SNESRECOMP_TRACE
 
 typedef struct CpuState CpuState;
+typedef void (*DebugServerGameSendLine)(const char *line);
+typedef int (*DebugServerGameCommandHandler)(
+    const char *cmd, const char *args, DebugServerGameSendLine send_line);
 
 // Initialize the debug TCP server on the given port. Non-blocking.
 // Returns 0 on success, -1 on failure.
@@ -75,6 +78,10 @@ void debug_server_record_frame(int frame);
 
 // Set pointers the server needs to inspect game state.
 void debug_server_set_ram(uint8_t *ram, uint32_t ram_size);
+
+// Register an optional game-owned TCP command handler. Commands are reached
+// through `game <subcommand> [args]` so runner commands remain generic.
+void debug_server_set_game_command_handler(DebugServerGameCommandHandler handler);
 
 // MMIO register-write trace. Call from snes_write paths after the write
 // completes. Captures entries for addresses in [s_reg_trace_lo, s_reg_trace_hi).
@@ -134,6 +141,10 @@ static inline uint32_t debug_server_get_controller_inputs(void) { return 0; }
 static inline uint32_t debug_server_get_controller_active_mask(void) { return 0; }
 static inline void debug_server_record_frame(int frame) { (void)frame; }
 static inline void debug_server_set_ram(uint8_t *ram, uint32_t ram_size) { (void)ram; (void)ram_size; }
+typedef void (*DebugServerGameSendLine)(const char *line);
+typedef int (*DebugServerGameCommandHandler)(
+    const char *cmd, const char *args, DebugServerGameSendLine send_line);
+static inline void debug_server_set_game_command_handler(DebugServerGameCommandHandler handler) { (void)handler; }
 static inline void debug_server_on_reg_write(uint16_t adr, uint8_t val) { (void)adr; (void)val; }
 static inline void debug_server_on_vram_write(uint32_t byte_addr, uint8_t value) { (void)byte_addr; (void)value; }
 static inline void debug_server_on_oracle_vram_write(uint32_t byte_addr, uint8_t value) { (void)byte_addr; (void)value; }

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -183,7 +183,7 @@ int PpuWsExtraOverride(void) {
   return s_ov;
 }
 
-void PpuSetExtraSpace(Ppu *ppu, uint8_t extra) {
+void PpuSetExtraSpace(Ppu *ppu, uint16_t extra) {
   if (extra > kPpuExtraLeftRight)
     extra = kPpuExtraLeftRight;
   // Symmetric border: equal columns added on each side. extraLeftRight is the
@@ -195,7 +195,7 @@ void PpuSetExtraSpace(Ppu *ppu, uint8_t extra) {
   PpuResetLayerPolicies(ppu);
 }
 
-void PpuSetExtraSpaceCentered(Ppu *ppu, uint8_t budget) {
+void PpuSetExtraSpaceCentered(Ppu *ppu, uint16_t budget) {
   if (budget > kPpuExtraLeftRight)
     budget = kPpuExtraLeftRight;
   // Render only the authentic 256 columns but keep the centering budget so the
@@ -214,8 +214,8 @@ void PpuSetExtraSideSpace(Ppu *ppu, int left, int right, int bottom) {
   // the line renderer's window edges stay inside the priority buffers, bottom
   // clamps to the 16px overscan band. See ppu.h for the symmetric-vs-dynamic
   // distinction.
-  ppu->extraLeftCur = (uint8_t)IntMin(IntMax(left, 0), ppu->extraLeftRight);
-  ppu->extraRightCur = (uint8_t)IntMin(IntMax(right, 0), ppu->extraLeftRight);
+  ppu->extraLeftCur = (uint16_t)IntMin(IntMax(left, 0), ppu->extraLeftRight);
+  ppu->extraRightCur = (uint16_t)IntMin(IntMax(right, 0), ppu->extraLeftRight);
   ppu->extraBottomCur = (uint8_t)IntMin(IntMax(bottom, 0), 16);
 }
 

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -31,9 +31,9 @@ enum {
   // Maximum widescreen expansion *per side*, baked into the priority-buffer
   // capacity. This is a compile-time ceiling only; the actual extra columns
   // rendered each frame are the runtime ppu->extraLeftCur/extraRightCur, which
-  // default to 0 (authentic 256-wide output). 96 per side allows up to a
-  // 448-pixel internal width, comfortably past 16:9 at 224 lines.
-  kPpuExtraLeftRight = 96,
+  // default to 0 (authentic 256-wide output). 272 per side allows up to an
+  // 800-pixel internal width, matching Star Fox Enhanced's 32:9 mode.
+  kPpuExtraLeftRight = 272,
   // Full internal width of the priority buffers (logical 256 + both borders).
   kPpuBufWidth = kPpuXPixels + kPpuExtraLeftRight * 2,
   // Split-screen games can assign distinct anchor layouts to each viewport.
@@ -182,7 +182,8 @@ struct Ppu {
   // pixel buffer (xbgr)
   // times 2 for even and odd frame
 
-  uint8_t extraLeftCur, extraRightCur, extraLeftRight, extraBottomCur;
+  uint16_t extraLeftCur, extraRightCur, extraLeftRight;
+  uint8_t extraBottomCur;
   // Widescreen BG3 HUD split (see PpuSetWidescreenHudSplit). 0 height = off.
   uint8_t wsHudSplitHeight, wsHudLeftEnd, wsHudRightStart;
   // Widescreen HUD OAM anchor (see PpuSetWsHudOamShiftRange): an OAM slot
@@ -454,12 +455,12 @@ bool PpuSetOverlayOamRange(Ppu *ppu, uint8_t first, uint8_t count);
 // kPpuExtraLeftRight). 0 restores authentic 256-wide rendering. The internal
 // render width becomes 256 + 2*extra. Drives the dormant extraLeftCur/
 // extraRightCur/extraLeftRight machinery used by the line renderer.
-void PpuSetExtraSpace(Ppu *ppu, uint8_t extra);
+void PpuSetExtraSpace(Ppu *ppu, uint16_t extra);
 
 // Render authentic 256-wide content centered within a `budget`-per-side wider
 // framebuffer (no border columns drawn). For bounded screens; caller blacks
 // out the side margins to pillarbox.
-void PpuSetExtraSpaceCentered(Ppu *ppu, uint8_t budget);
+void PpuSetExtraSpaceCentered(Ppu *ppu, uint16_t budget);
 
 // Asymmetric per-side widescreen margin (the snesrev/zelda3 model, see
 // attribution in IMPROVEMENTS.md). The centering budget (extraLeftRight) must

--- a/runner/src/snes/superfx.c
+++ b/runner/src/snes/superfx.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-enum { kSuperFxWsMaxExtra = 111, kSuperFxWsMaxWidth = 446 };
+enum { kSuperFxWsMaxExtra = 288, kSuperFxWsMaxWidth = 800 };
 
 enum {
   SFR_Z = 1u << 1, SFR_CY = 1u << 2, SFR_S = 1u << 3,
@@ -473,7 +473,7 @@ void superfx_reset(SuperFx *f) {
   uint8_t *ws_present_valid=f->ws_present_valid;
   void *ws_task_state=f->ws_task_state; uint8_t *ws_task_ram=f->ws_task_ram;
   SuperFxEnhancementMode enhancement_mode=f->enhancement_mode;
-  uint8_t ws_extra=f->ws_extra;
+  uint16_t ws_extra=f->ws_extra;
   memset(f,0,sizeof(*f)); f->rom=rom;f->rom_size=rs;f->rom_mask=rs-1;f->ram=ram;f->ram_size=rm;f->ram_mask=rm-1;
   f->ws_pixels=ws_pixels;f->ws_valid=ws_valid;f->ws_task_state=ws_task_state;
   f->ws_present_pixels=ws_present_pixels;
@@ -577,7 +577,7 @@ SuperFxEnhancementMode superfx_get_enhancement_mode(const SuperFx *f) {
   return f ? f->enhancement_mode : kSuperFxEnhancement_None;
 }
 
-void superfx_set_widescreen(SuperFx *f, uint8_t extra, uint8_t task_pbr,
+void superfx_set_widescreen(SuperFx *f, uint16_t extra, uint8_t task_pbr,
                             uint16_t task_address, uint16_t center_x_ram,
                             uint16_t max_x_ram, uint8_t height) {
   if (!f) return;

--- a/runner/src/snes/superfx.h
+++ b/runner/src/snes/superfx.h
@@ -77,8 +77,8 @@ typedef struct SuperFx {
   uint8_t *ws_present_valid;
   void *ws_task_state;
   uint8_t *ws_task_ram;
-  uint16_t ws_width;
-  uint8_t ws_height, ws_extra;
+  uint16_t ws_width, ws_extra;
+  uint8_t ws_height;
   bool ws_render_active, ws_replay_pending, ws_replay_mode, ws_frame_ready;
   bool ws_pending_ready;
   uint8_t ws_replay_zero_word_count;
@@ -114,7 +114,7 @@ SuperFxEnhancementMode superfx_get_enhancement_mode(const SuperFx *fx);
  * selected above. The task's projection center and maximum X are supplied as
  * GSU RAM offsets, keeping title-specific addresses out of the LLE core.
  * `extra` is the added projected width per side; zero disables it. */
-void superfx_set_widescreen(SuperFx *fx, uint8_t extra, uint8_t task_pbr,
+void superfx_set_widescreen(SuperFx *fx, uint16_t extra, uint8_t task_pbr,
                             uint16_t task_address, uint16_t center_x_ram,
                             uint16_t max_x_ram, uint8_t height);
 /* Clear title-selected word flags only in the presentation replay. This lets

--- a/runner/src/widescreen.h
+++ b/runner/src/widescreen.h
@@ -45,12 +45,11 @@ extern bool g_ws_active;
 // clamped to room bounds) is set separately via PpuSetExtraSideSpace.
 extern int g_ws_extra;
 
-// Hard cap on g_ws_extra from the SNES 9-bit OAM x space (see ppu.c and
-// ENHANCEMENTS Rule 5): the wrap threshold is 256+extra and the widest
-// left-margin sprite tiles sit at 512-(64+extra), which must stay >= the
-// threshold => 2*extra <= 192 => extra <= 95. Beyond this, outer-margin
-// sprites are unrepresentable. Every consumer clamps to this same constant.
-enum { kWsExtraMax = 95 };
+// Hard cap on g_ws_extra for the shared host framebuffer. Classic 9-bit OAM
+// positions only represent a limited right margin without game-provided hints,
+// so wide-aspect titles must still own their sprite/HUD policy. The buffer cap
+// itself is large enough for 800x224 output (Star Fox Enhanced's 32:9 mode).
+enum { kWsExtraMax = 272 };
 
 // Per-frame present: copy the PPU's rendered framebuffer `src` (rows of
 // row_bytes = snes_width*4, as written by the line renderer at that pitch)


### PR DESCRIPTION
## Summary
- raise widescreen extra-pixel caps so title-specific renderers can request ultrawide outputs
- add an opt-in enhanced frame presentation hook for games that own their own native presenter
- add non-promoting cfg symbol labels for game-specific semantic overlays
- add a debug-server game command hook for title-specific TCP diagnostics

## Notes
This is framework plumbing only. The Star Fox renderer remains game-specific in StarFoxSNESRecomp and is adapted from kandowontu's starfox-enhanced native renderer model.

## Testing
Not run per integration decision: changes are opt-in hooks/caps and StarFoxSNESRecomp validates its consuming path separately.