### PR TITLE
Fix inline argument stack provenance

### DIFF
--- a/recompiler-rs/src/decoder.rs
+++ b/recompiler-rs/src/decoder.rs
@@ -2905,16 +2905,68 @@ pub fn detect_inline_arg_bytes(
         )
     }
 
+    fn return_mask(start: i32, size: u8) -> u8 {
+        let end = start + i32::from(size);
+        let mut mask = 0;
+        if start <= 1 && 1 < end {
+            mask |= 0b01;
+        }
+        if start <= 2 && 2 < end {
+            mask |= 0b10;
+        }
+        mask
+    }
+
+    fn return_bytes_valid(valid: u8, start: i32, size: u8) -> bool {
+        if start != 1 || !matches!(size, 1 | 2) {
+            return false;
+        }
+        let mask = (1u8 << size) - 1;
+        valid & mask == mask
+    }
+
+    fn invalidate_stack_write(
+        valid: &mut u8,
+        status_slots: &mut HashMap<i32, (u8, u8)>,
+        start: i32,
+        size: u8,
+    ) {
+        *valid &= !return_mask(start, size);
+        for pos in start..start + i32::from(size) {
+            status_slots.remove(&pos);
+        }
+    }
+
+    fn push_bytes(
+        depth: &mut i32,
+        valid: &mut u8,
+        status_slots: &mut HashMap<i32, (u8, u8)>,
+        size: u8,
+    ) -> i32 {
+        *depth -= i32::from(size);
+        let start = *depth + 1;
+        invalidate_stack_write(valid, status_slots, start, size);
+        start
+    }
+
     let mut pc = addr & 0xFFFF;
     let mut m = entry_m & 1;
     let mut x = entry_x & 1;
+    let mut stack_depth = 0i32;
+    let mut return_valid = 0b11u8;
+    let mut status_slots: HashMap<i32, (u8, u8)> = HashMap::new();
     let mut a_slot: Option<u8> = None;
+    let mut a_slot_size = 0u8;
     let mut a_pulled = false;
+    let mut a_pulled_size = 0u8;
     let mut a_added = 0u32;
     let mut y_slot: Option<u8> = None;
+    let mut y_slot_size = 0u8;
     let mut y_pulled = false;
+    let mut y_pulled_size = 0u8;
     let mut y_added = 0u32;
     let mut x_pulled = false;
+    let mut x_pulled_size = 0u8;
     let mut x_added = 0u32;
 
     for _ in 0..96 {
@@ -2930,113 +2982,275 @@ pub fn detect_inline_arg_bytes(
         match ins.mnem {
             "REP" => {
                 if ins.operand & 0x20 != 0 {
+                    let changed = m != 0;
                     m = 0;
+                    if changed {
+                        a_slot = None;
+                        a_slot_size = 0;
+                        a_pulled = false;
+                        a_pulled_size = 0;
+                        a_added = 0;
+                    }
                 }
                 if ins.operand & 0x10 != 0 {
+                    let changed = x != 0;
                     x = 0;
-                    x_pulled = false;
-                    x_added = 0;
+                    if changed {
+                        y_slot = None;
+                        y_slot_size = 0;
+                        y_pulled = false;
+                        y_pulled_size = 0;
+                        y_added = 0;
+                        x_pulled = false;
+                        x_pulled_size = 0;
+                        x_added = 0;
+                    }
                 }
             }
             "SEP" => {
                 if ins.operand & 0x20 != 0 {
+                    let changed = m != 1;
                     m = 1;
+                    if changed {
+                        a_slot = None;
+                        a_slot_size = 0;
+                        a_pulled = false;
+                        a_pulled_size = 0;
+                        a_added = 0;
+                    }
                 }
                 if ins.operand & 0x10 != 0 {
+                    let changed = x != 1;
                     x = 1;
-                    x_pulled = false;
-                    x_added = 0;
+                    if changed {
+                        y_slot = None;
+                        y_slot_size = 0;
+                        y_pulled = false;
+                        y_pulled_size = 0;
+                        y_added = 0;
+                        x_pulled = false;
+                        x_pulled_size = 0;
+                        x_added = 0;
+                    }
                 }
             }
             "LDA" if ins.mode == Mode::Stk => {
-                a_slot = Some((ins.operand & 0xFF) as u8);
+                let slot = (ins.operand & 0xFF) as u8;
+                let size = if m != 0 { 1 } else { 2 };
+                let tracked = return_bytes_valid(return_valid, stack_depth + i32::from(slot), size);
+                a_slot = tracked.then_some(slot);
+                a_slot_size = if tracked { size } else { 0 };
                 a_pulled = false;
+                a_pulled_size = 0;
                 a_added = 0;
             }
             "PLA" => {
+                let size = if m != 0 { 1 } else { 2 };
                 a_slot = None;
-                a_pulled = true;
+                a_slot_size = 0;
+                a_pulled = return_bytes_valid(return_valid, stack_depth + 1, size);
+                a_pulled_size = if a_pulled { size } else { 0 };
                 a_added = 0;
+                stack_depth += i32::from(size);
             }
             "TAY" => {
-                y_slot = a_slot;
-                y_pulled = a_pulled;
-                y_added = if a_slot.is_some() || a_pulled {
-                    a_added
-                } else {
-                    0
-                };
+                let tracked = m == x && (a_slot.is_some() || a_pulled);
+                y_slot = if tracked { a_slot } else { None };
+                y_slot_size = if tracked { a_slot_size } else { 0 };
+                y_pulled = tracked && a_pulled;
+                y_pulled_size = if y_pulled { a_pulled_size } else { 0 };
+                y_added = if tracked { a_added } else { 0 };
             }
             "TYA" => {
-                a_slot = y_slot;
-                a_pulled = y_pulled;
-                a_added = if y_slot.is_some() || y_pulled {
-                    y_added
-                } else {
-                    0
-                };
+                let tracked = m == x && (y_slot.is_some() || y_pulled);
+                a_slot = if tracked { y_slot } else { None };
+                a_slot_size = if tracked { y_slot_size } else { 0 };
+                a_pulled = tracked && y_pulled;
+                a_pulled_size = if a_pulled { y_pulled_size } else { 0 };
+                a_added = if tracked { y_added } else { 0 };
             }
             "ADC" if ins.opcode == 0x69 && (a_slot.is_some() || a_pulled) => {
                 a_added = (a_added + ins.operand) & 0xFFFF;
             }
             "STA" if ins.opcode == 0x83 && ins.mode == Mode::Stk => {
-                if a_slot == Some((ins.operand & 0xFF) as u8) && a_added != 0 {
+                let slot = (ins.operand & 0xFF) as u8;
+                let size = if m != 0 { 1 } else { 2 };
+                let start = stack_depth + i32::from(slot);
+                let writeback = a_slot == Some(slot) && a_slot_size == size && start == 1;
+                let mask = return_mask(start, size);
+                if writeback && a_added != 0 && return_valid | mask == 0b11 {
                     return Some((a_added & 0xFF) as u8);
+                }
+                invalidate_stack_write(&mut return_valid, &mut status_slots, start, size);
+                if writeback && a_added == 0 {
+                    return_valid |= mask;
                 }
             }
-            "PHA" if a_pulled => {
-                if a_added != 0 {
-                    return Some((a_added & 0xFF) as u8);
+            "PHA" => {
+                let size = if m != 0 { 1 } else { 2 };
+                let start =
+                    push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, size);
+                if a_pulled && a_pulled_size == size && start == 1 {
+                    if a_added != 0 {
+                        if return_valid | return_mask(start, size) == 0b11 {
+                            return Some((a_added & 0xFF) as u8);
+                        }
+                    } else {
+                        return_valid |= return_mask(start, size);
+                    }
                 }
                 a_pulled = false;
+                a_pulled_size = 0;
                 a_added = 0;
             }
             "PLX" => {
-                x_pulled = true;
+                let size = if x != 0 { 1 } else { 2 };
+                x_pulled = return_bytes_valid(return_valid, stack_depth + 1, size);
+                x_pulled_size = if x_pulled { size } else { 0 };
                 x_added = 0;
+                stack_depth += i32::from(size);
             }
             "INX" if x_pulled => {
                 x_added = x_added.wrapping_add(1);
             }
-            "PHX" if x_pulled => {
-                if x_added != 0 {
-                    return Some((x_added & 0xFF) as u8);
+            "PHX" => {
+                let size = if x != 0 { 1 } else { 2 };
+                let start =
+                    push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, size);
+                if x_pulled && x_pulled_size == size && start == 1 {
+                    if x_added != 0 {
+                        if return_valid | return_mask(start, size) == 0b11 {
+                            return Some((x_added & 0xFF) as u8);
+                        }
+                    } else {
+                        return_valid |= return_mask(start, size);
+                    }
                 }
                 x_pulled = false;
+                x_pulled_size = 0;
                 x_added = 0;
             }
-            _ if breaks_carrier_flow(ins.opcode) => {
+            "PHY" => {
+                push_bytes(
+                    &mut stack_depth,
+                    &mut return_valid,
+                    &mut status_slots,
+                    if x != 0 { 1 } else { 2 },
+                );
+                y_pulled = false;
+                y_pulled_size = 0;
+                y_added = 0;
+            }
+            "PHP" => {
+                let start = push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, 1);
+                status_slots.insert(start, (m, x));
+            }
+            "PHB" | "PHK" => {
+                push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, 1);
+            }
+            "PHD" => {
+                push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, 2);
+            }
+            "PEA" | "PEI" | "PER" => {
+                push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, 2);
                 a_slot = None;
+                a_slot_size = 0;
                 a_pulled = false;
+                a_pulled_size = 0;
+                a_added = 0;
+            }
+            "PLY" => {
+                stack_depth += if x != 0 { 1 } else { 2 };
+                a_slot = None;
+                a_slot_size = 0;
+                a_pulled = false;
+                a_pulled_size = 0;
                 a_added = 0;
                 y_slot = None;
                 y_pulled = false;
+                y_pulled_size = 0;
+                y_added = 0;
+            }
+            "PLB" => {
+                stack_depth += 1;
+                a_slot = None;
+                a_slot_size = 0;
+                a_pulled = false;
+                a_pulled_size = 0;
+                a_added = 0;
+            }
+            "PLD" => {
+                stack_depth += 2;
+                a_slot = None;
+                a_slot_size = 0;
+                a_pulled = false;
+                a_pulled_size = 0;
+                a_added = 0;
+            }
+            "PLP" => {
+                let saved = status_slots.remove(&(stack_depth + 1))?;
+                stack_depth += 1;
+                (m, x) = saved;
+                a_slot = None;
+                a_slot_size = 0;
+                a_pulled = false;
+                a_pulled_size = 0;
+                a_added = 0;
+                y_slot = None;
+                y_slot_size = 0;
+                y_pulled = false;
+                y_pulled_size = 0;
                 y_added = 0;
                 x_pulled = false;
+                x_pulled_size = 0;
+                x_added = 0;
+            }
+            "TXS" | "TCS" | "XCE" => return None,
+            _ if breaks_carrier_flow(ins.opcode) => {
+                a_slot = None;
+                a_slot_size = 0;
+                a_pulled = false;
+                a_pulled_size = 0;
+                a_added = 0;
+                y_slot = None;
+                y_slot_size = 0;
+                y_pulled = false;
+                y_pulled_size = 0;
+                y_added = 0;
+                x_pulled = false;
+                x_pulled_size = 0;
                 x_added = 0;
             }
             _ if preserves_a(ins.opcode) => {
                 if mutates_y(ins.opcode) {
                     y_slot = None;
+                    y_slot_size = 0;
                     y_pulled = false;
+                    y_pulled_size = 0;
                     y_added = 0;
                 }
                 if mutates_x(ins.opcode) {
                     x_pulled = false;
+                    x_pulled_size = 0;
                     x_added = 0;
                 }
             }
             _ => {
                 a_slot = None;
+                a_slot_size = 0;
                 a_pulled = false;
+                a_pulled_size = 0;
                 a_added = 0;
                 if mutates_y(ins.opcode) {
                     y_slot = None;
+                    y_slot_size = 0;
                     y_pulled = false;
+                    y_pulled_size = 0;
                     y_added = 0;
                 }
                 if mutates_x(ins.opcode) {
                     x_pulled = false;
+                    x_pulled_size = 0;
                     x_added = 0;
                 }
             }
@@ -3474,6 +3688,246 @@ mod tests {
             0x22, 0x34, 0x12, 0x00, // JSL $001234
             0xDA, // PHX
             0x6B, // RTL
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_x_save_restore_as_inline_argument_adjustment() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x10, // REP #$10
+            0xDA, // PHX
+            0x20, 0x00, 0x81, // JSR $8100
+            0xFA, // PLX
+            0xE8, // INX
+            0xDA, // PHX
+            0x20, 0x00, 0x81, // JSR $8100
+            0xFA, // PLX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_a_save_restore_as_inline_argument_adjustment() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x20, // REP #$20
+            0x48, // PHA
+            0x20, 0x00, 0x81, // JSR $8100
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x20, 0x00, 0x81, // JSR $8100
+            0x68, // PLA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_local_stack_slot_adjustment() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xDA, // PHX
+            0xA3, 0x01, // LDA $01,S
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x83, 0x01, // STA $01,S
+            0xFA, // PLX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_return_slot_below_saved_register() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xDA, // PHX
+            0xA3, 0x03, // LDA $03,S
+            0x18, // CLC
+            0x69, 0x03, 0x00, // ADC #$0003
+            0x83, 0x03, // STA $03,S
+            0xFA, // PLX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn rejects_return_slot_overwritten_by_push() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xFA, // PLX
+            0x48, // PHA
+            0xA3, 0x01, // LDA $01,S
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x83, 0x01, // STA $01,S
+            0x68, // PLA
+            0xDA, // PHX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_return_slot_overwritten_by_stack_store() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xA9, 0x34, 0x12, // LDA #$1234
+            0x83, 0x01, // STA $01,S
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_partially_overwritten_return_slot() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xE2, 0x20, // SEP #$20
+            0xA9, 0x12, // LDA #$12
+            0x83, 0x01, // STA $01,S
+            0xC2, 0x20, // REP #$20
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_adjustment_with_other_return_byte_overwritten() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xE2, 0x20, // SEP #$20
+            0xA9, 0x12, // LDA #$12
+            0x83, 0x02, // STA $02,S
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x01, // ADC #$01
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_return_adjustment_after_unmodified_restore() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0x48, // PHA
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn detects_return_adjustment_after_balanced_php_plp() {
+        let rom = rom_at_8000(&[
+            0x08, // PHP
+            0x78, // SEI
+            0x28, // PLP
+            0xC2, 0x30, // REP #$30
+            0xFA, // PLX
+            0xE8, // INX
+            0xDA, // PHX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_plp_state() {
+        let rom = rom_at_8000(&[
+            0x28, // PLP
+            0xC2, 0x30, // REP #$30
+            0xFA, // PLX
+            0xE8, // INX
+            0xDA, // PHX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_plp_after_status_slot_overwrite() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x08, // PHP
+            0xAB, // PLB
+            0x48, // PHA
+            0xAB, // PLB
+            0x28, // PLP
+            0xFA, // PLX
+            0xE8, // INX
+            0xDA, // PHX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_xce_during_inline_argument_scan() {
+        let rom = rom_at_8000(&[
+            0xFB, // XCE
+            0xC2, 0x30, // REP #$30
+            0xFA, // PLX
+            0xE8, // INX
+            0xDA, // PHX
+            0x60, // RTS
         ]);
         assert_eq!(
             detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),

--- a/recompiler/v2/decoder.py
+++ b/recompiler/v2/decoder.py
@@ -1182,7 +1182,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
     ADVANCES the stacked return address by a constant N so its RTS/RTL
     returns PAST the inline data. The game-agnostic 65816 signature:
 
-        LDA $rr,S        ; load the return-address-low slot (rr=1 here)
+        LDA $rr,S        ; load the current return-address-low slot
         ... (A preserved: STA dp/abs, CLC/SEC) ...
         ADC #N           ; advance the return address by N
         STA $rr,S        ; write it back to the SAME slot
@@ -1229,13 +1229,49 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
     }
     pc = addr & 0xFFFF
     m, x = entry_m & 1, entry_x & 1
-    a_slot = None     # stack slot the live A value came from (LDA $nn,S)
-    a_pulled = False  # live A value came from PLA of the return address
-    a_added = 0       # constant added to that value since the load
-    y_slot = None     # stack slot copied through Y via TAY/TYA
+    stack_depth = 0
+    return_valid = 0b11
+    status_slots = {}
+
+    def return_mask(start, size):
+        mask = 0
+        if start <= 1 < start + size:
+            mask |= 0b01
+        if start <= 2 < start + size:
+            mask |= 0b10
+        return mask
+
+    def return_bytes_valid(start, size):
+        if start != 1 or size not in (1, 2):
+            return False
+        mask = (1 << size) - 1
+        return return_valid & mask == mask
+
+    def invalidate_stack_write(start, size):
+        nonlocal return_valid
+        return_valid &= ~return_mask(start, size)
+        for pos in range(start, start + size):
+            status_slots.pop(pos, None)
+
+    def push_bytes(size):
+        nonlocal stack_depth
+        stack_depth -= size
+        start = stack_depth + 1
+        invalidate_stack_write(start, size)
+        return start
+
+    a_slot = None
+    a_slot_size = 0
+    a_pulled = False
+    a_pulled_size = 0
+    a_added = 0
+    y_slot = None
+    y_slot_size = 0
     y_pulled = False
+    y_pulled_size = 0
     y_added = 0
     x_pulled = False
+    x_pulled_size = 0
     x_added = 0
     budget = 0
     while budget < 96:
@@ -1256,92 +1292,245 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
         if mn in _TERMINATORS:
             return None
         if mn == 'REP':
-            if ins.operand & 0x20: m = 0
+            if ins.operand & 0x20:
+                changed = m != 0
+                m = 0
+                if changed:
+                    a_slot = None
+                    a_slot_size = 0
+                    a_pulled = False
+                    a_pulled_size = 0
+                    a_added = 0
             if ins.operand & 0x10:
+                changed = x != 0
                 x = 0
-                x_pulled = False
-                x_added = 0
+                if changed:
+                    y_slot = None
+                    y_slot_size = 0
+                    y_pulled = False
+                    y_pulled_size = 0
+                    y_added = 0
+                    x_pulled = False
+                    x_pulled_size = 0
+                    x_added = 0
         elif mn == 'SEP':
-            if ins.operand & 0x20: m = 1
+            if ins.operand & 0x20:
+                changed = m != 1
+                m = 1
+                if changed:
+                    a_slot = None
+                    a_slot_size = 0
+                    a_pulled = False
+                    a_pulled_size = 0
+                    a_added = 0
             if ins.operand & 0x10:
+                changed = x != 1
                 x = 1
-                x_pulled = False
-                x_added = 0
+                if changed:
+                    y_slot = None
+                    y_slot_size = 0
+                    y_pulled = False
+                    y_pulled_size = 0
+                    y_added = 0
+                    x_pulled = False
+                    x_pulled_size = 0
+                    x_added = 0
         elif mn == 'LDA' and ins.mode == STK:
-            a_slot = ins.operand & 0xFF       # (re)start tracking from this slot
+            slot = ins.operand & 0xFF
+            size = 1 if m else 2
+            tracked = return_bytes_valid(stack_depth + slot, size)
+            a_slot = slot if tracked else None
+            a_slot_size = size if tracked else 0
             a_pulled = False
+            a_pulled_size = 0
             a_added = 0
         elif op == 0x68:                       # PLA
+            size = 1 if m else 2
             a_slot = None
-            a_pulled = True
+            a_slot_size = 0
+            a_pulled = return_bytes_valid(stack_depth + 1, size)
+            a_pulled_size = size if a_pulled else 0
             a_added = 0
+            stack_depth += size
         elif op == 0xA8:                       # TAY
-            if a_slot is not None or a_pulled:
+            if m == x and (a_slot is not None or a_pulled):
                 y_slot = a_slot
+                y_slot_size = a_slot_size
                 y_pulled = a_pulled
+                y_pulled_size = a_pulled_size
                 y_added = a_added
             else:
                 y_slot = None
+                y_slot_size = 0
                 y_pulled = False
+                y_pulled_size = 0
                 y_added = 0
         elif op == 0x98:                       # TYA
-            if y_slot is not None or y_pulled:
+            if m == x and (y_slot is not None or y_pulled):
                 a_slot = y_slot
+                a_slot_size = y_slot_size
                 a_pulled = y_pulled
+                a_pulled_size = y_pulled_size
                 a_added = y_added
             else:
                 a_slot = None
+                a_slot_size = 0
                 a_pulled = False
+                a_pulled_size = 0
                 a_added = 0
         elif op == 0x69 and (a_slot is not None or a_pulled):   # ADC #imm
             a_added = (a_added + ins.operand) & 0xFFFF
         elif op == 0x83 and ins.mode == STK:      # STA $nn,S — return-addr write-back
-            if a_slot is not None and (ins.operand & 0xFF) == a_slot and a_added:
+            slot = ins.operand & 0xFF
+            size = 1 if m else 2
+            start = stack_depth + slot
+            writeback = (a_slot is not None and slot == a_slot and
+                         a_slot_size == size and start == 1)
+            mask = return_mask(start, size)
+            if writeback and a_added and return_valid | mask == 0b11:
                 return a_added & 0xFF             # inline byte count
-            # store-back without an add (or to a different slot): not it
-        elif op == 0x48 and a_pulled:             # PHA
-            if a_added:
-                return a_added & 0xFF
+            invalidate_stack_write(start, size)
+            if writeback and not a_added:
+                return_valid |= mask
+        elif op == 0x48:                          # PHA
+            size = 1 if m else 2
+            start = push_bytes(size)
+            if (a_pulled and a_pulled_size == size and
+                    start == 1):
+                if a_added:
+                    if return_valid | return_mask(start, size) == 0b11:
+                        return a_added & 0xFF
+                else:
+                    return_valid |= return_mask(start, size)
             a_pulled = False
+            a_pulled_size = 0
             a_added = 0
         elif op == 0xFA:                          # PLX
-            x_pulled = True
+            size = 1 if x else 2
+            x_pulled = return_bytes_valid(stack_depth + 1, size)
+            x_pulled_size = size if x_pulled else 0
             x_added = 0
+            stack_depth += size
         elif op == 0xE8 and x_pulled:             # INX
             x_added = (x_added + 1) & 0xFFFF
-        elif op == 0xDA and x_pulled:             # PHX
-            if x_added:
-                return x_added & 0xFF
+        elif op == 0xDA:                          # PHX
+            size = 1 if x else 2
+            start = push_bytes(size)
+            if (x_pulled and x_pulled_size == size and
+                    start == 1):
+                if x_added:
+                    if return_valid | return_mask(start, size) == 0b11:
+                        return x_added & 0xFF
+                else:
+                    return_valid |= return_mask(start, size)
             x_pulled = False
+            x_pulled_size = 0
             x_added = 0
-        elif op in CONTROL_TRANSFER:
+        elif op == 0x5A:                          # PHY
+            push_bytes(1 if x else 2)
+            y_pulled = False
+            y_pulled_size = 0
+            y_added = 0
+        elif op == 0x08:                          # PHP
+            status_slots[push_bytes(1)] = (m, x)
+        elif op in (0x8B, 0x4B):                 # PHB / PHK
+            push_bytes(1)
+        elif op == 0x0B:                          # PHD
+            push_bytes(2)
+        elif op in (0xF4, 0xD4, 0x62):           # PEA / PEI / PER
+            push_bytes(2)
             a_slot = None
+            a_slot_size = 0
             a_pulled = False
+            a_pulled_size = 0
+            a_added = 0
+        elif op == 0x7A:                          # PLY
+            stack_depth += 1 if x else 2
+            a_slot = None
+            a_slot_size = 0
+            a_pulled = False
+            a_pulled_size = 0
             a_added = 0
             y_slot = None
             y_pulled = False
+            y_pulled_size = 0
+            y_added = 0
+        elif op == 0xAB:                          # PLB
+            stack_depth += 1
+            a_slot = None
+            a_slot_size = 0
+            a_pulled = False
+            a_pulled_size = 0
+            a_added = 0
+        elif op == 0x2B:                          # PLD
+            stack_depth += 2
+            a_slot = None
+            a_slot_size = 0
+            a_pulled = False
+            a_pulled_size = 0
+            a_added = 0
+        elif op == 0x28:                          # PLP
+            saved = status_slots.pop(stack_depth + 1, None)
+            if saved is None:
+                return None
+            stack_depth += 1
+            m, x = saved
+            a_slot = None
+            a_slot_size = 0
+            a_pulled = False
+            a_pulled_size = 0
+            a_added = 0
+            y_slot = None
+            y_slot_size = 0
+            y_pulled = False
+            y_pulled_size = 0
             y_added = 0
             x_pulled = False
+            x_pulled_size = 0
+            x_added = 0
+        elif op in (0x9A, 0x1B, 0xFB):           # TXS / TCS / XCE
+            return None
+        elif op in CONTROL_TRANSFER:
+            a_slot = None
+            a_slot_size = 0
+            a_pulled = False
+            a_pulled_size = 0
+            a_added = 0
+            y_slot = None
+            y_slot_size = 0
+            y_pulled = False
+            y_pulled_size = 0
+            y_added = 0
+            x_pulled = False
+            x_pulled_size = 0
             x_added = 0
         elif op in A_PRESERVING:
             if op in Y_MUTATING:
                 y_slot = None
+                y_slot_size = 0
                 y_pulled = False
+                y_pulled_size = 0
                 y_added = 0
             if op in X_MUTATING:
                 x_pulled = False
+                x_pulled_size = 0
                 x_added = 0
             pass                                  # A unchanged; keep tracking
         else:
             a_slot = None                         # A clobbered — reset
+            a_slot_size = 0
             a_pulled = False
+            a_pulled_size = 0
             a_added = 0
             if op in Y_MUTATING:
                 y_slot = None
+                y_slot_size = 0
                 y_pulled = False
+                y_pulled_size = 0
                 y_added = 0
             if op in X_MUTATING:
                 x_pulled = False
+                x_pulled_size = 0
                 x_added = 0
         pc = (pc + ins.length) & 0xFFFF
     return None

--- a/tests/v2/test_inline_arg_detector.py
+++ b/tests/v2/test_inline_arg_detector.py
@@ -129,6 +129,235 @@ def test_x_carrier_is_invalidated_by_subroutine_call():
     assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
 
 
+def test_rejects_x_save_restore_as_return_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x10,        # REP #$10
+            0xDA,              # PHX
+            0x20, 0x00, 0x81,  # JSR $8100
+            0xFA,              # PLX
+            0xE8,              # INX
+            0xDA,              # PHX
+            0x20, 0x00, 0x81,  # JSR $8100
+            0xFA,              # PLX
+            0x60,              # RTS
+        ]),
+        0x8100: bytes([0x60]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_a_save_restore_as_return_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x20,        # REP #$20
+            0x48,              # PHA
+            0x20, 0x00, 0x81,  # JSR $8100
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x20, 0x00, 0x81,  # JSR $8100
+            0x68,              # PLA
+            0x60,              # RTS
+        ]),
+        0x8100: bytes([0x60]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_local_stack_slot_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0xDA,              # PHX
+            0xA3, 0x01,        # LDA $01,S
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x83, 0x01,        # STA $01,S
+            0xFA,              # PLX
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_detects_return_slot_below_saved_register():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0xDA,              # PHX
+            0xA3, 0x03,        # LDA $03,S
+            0x18,              # CLC
+            0x69, 0x03, 0x00,  # ADC #$0003
+            0x83, 0x03,        # STA $03,S
+            0xFA,              # PLX
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 3
+
+
+def test_rejects_return_slot_overwritten_by_push():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0xFA,              # PLX
+            0x48,              # PHA
+            0xA3, 0x01,        # LDA $01,S
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x83, 0x01,        # STA $01,S
+            0x68,              # PLA
+            0xDA,              # PHX
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_return_slot_overwritten_by_stack_store():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0xA9, 0x34, 0x12,  # LDA #$1234
+            0x83, 0x01,        # STA $01,S
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_partially_overwritten_return_slot():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0xE2, 0x20,        # SEP #$20
+            0xA9, 0x12,        # LDA #$12
+            0x83, 0x01,        # STA $01,S
+            0xC2, 0x20,        # REP #$20
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_adjustment_with_other_return_byte_overwritten():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,  # REP #$30
+            0xE2, 0x20,  # SEP #$20
+            0xA9, 0x12,  # LDA #$12
+            0x83, 0x02,  # STA $02,S
+            0x68,        # PLA
+            0x18,        # CLC
+            0x69, 0x01,  # ADC #$01
+            0x48,        # PHA
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_detects_return_adjustment_after_unmodified_restore():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0x48,              # PHA
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 1
+
+
+def test_detects_return_adjustment_after_balanced_php_plp():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0x08,        # PHP
+            0x78,        # SEI
+            0x28,        # PLP
+            0xC2, 0x30,  # REP #$30
+            0xFA,        # PLX
+            0xE8,        # INX
+            0xDA,        # PHX
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 1
+
+
+def test_rejects_unknown_plp_state():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0x28,        # PLP
+            0xC2, 0x30,  # REP #$30
+            0xFA,        # PLX
+            0xE8,        # INX
+            0xDA,        # PHX
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_plp_after_status_slot_overwrite():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,  # REP #$30
+            0x08,        # PHP
+            0xAB,        # PLB
+            0x48,        # PHA
+            0xAB,        # PLB
+            0x28,        # PLP
+            0xFA,        # PLX
+            0xE8,        # INX
+            0xDA,        # PHX
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_xce():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xFB,        # XCE
+            0xC2, 0x30,  # REP #$30
+            0xFA,        # PLX
+            0xE8,        # INX
+            0xDA,        # PHX
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
 def test_y_carrier_is_invalidated_by_y_mutation():
     rom = make_lorom_bank0({
         0x8000: bytes([


### PR DESCRIPTION
PLX and PLA could be treated as return-address loads after local stack data had replaced the original return slots. That allowed ordinary stack manipulation to match the inline-argument heuristic and skip bytes at unrelated call sites.

Track the two entry return bytes alongside stack movement and only keep return-address carriers while their origin is known. Exact unmodified restores and balanced PHP/PLP pairs remain supported; unknown stack or status changes stop the scan.

Tests:
- python tests/v2/run_tests.py (388 passed)
- python tests/run_tests.py (81 passed)
- cargo test in recompiler-rs (70 passed)