### PR TITLE
Track moving left-margin OAM sprites

### DIFF
--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -647,6 +647,7 @@ bool RtlLoadSnapshot(const char *filename) {
     return false;
   }
   g_snes->beamMasterLast = g_cpu.master_cycles;
+  PpuResetWidescreenOamHistory(g_snes->ppu);
   /* Post-load reconciliation: host-side execution state (fibers, HLE
    * scheduler bookkeeping) cannot live in the guest snapshot; give the
    * game one hook to rebuild it against the freshly restored WRAM. */
@@ -694,6 +695,7 @@ bool RtlLoadSnapshotFromMemory(const void *data, size_t size) {
   RtlApuUnlock();
   if (memory.error) return false;
   g_snes->beamMasterLast = g_cpu.master_cycles;
+  PpuResetWidescreenOamHistory(g_snes->ppu);
   if (g_rtl_game_info && g_rtl_game_info->on_state_loaded)
     g_rtl_game_info->on_state_loaded(hdr[1]);
   return true;

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -4179,6 +4179,7 @@ static void cmd_load_state(const char *args) {
         send_fmt("{\"error\":\"read failed after %zu bytes\"}", fs.total);
         return;
     }
+    PpuResetWidescreenOamHistory(g_snes->ppu);
     send_fmt("{\"ok\":true,\"bytes\":%zu,\"file\":\"%s\"}", fs.total + 8, filename);
 }
 

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -24,10 +24,13 @@ static void PpuDrawWholeLine(Ppu *ppu, uint y);
 
 static bool ppu_evaluateSprites(Ppu* ppu, int line);
 static uint16_t ppu_getVramRemap(Ppu* ppu);
+static void PpuUpdateWidescreenOamHistory(Ppu *ppu, int line);
 
 
 Ppu* ppu_init(void) {
   Ppu* ppu = calloc(1, sizeof(Ppu));  /* zero padding: saveload/co-sim hash determinism */
+  if (ppu)
+    ppu->wsOamMotionLastLine = -1;
   return ppu;
 }
 
@@ -52,6 +55,7 @@ void ppu_reset(Ppu* ppu) {
     memcpy(ppu->overlayRenderBuffer, overlayBuffer, sizeof(overlayBuffer));
   }
   ppu->vramIncrement = 1;
+  ppu->wsOamMotionLastLine = -1;
 }
 
 void ppu_saveload(Ppu *ppu, SaveLoadInfo *sli) {
@@ -61,6 +65,16 @@ void ppu_saveload(Ppu *ppu, SaveLoadInfo *sli) {
   sli->func(sli, version, 8);
   sli->func(sli, &ppu->inidisp, PPU_SAVESTATE_REGS_SIZE);
   sli->func(sli, &ppu->cgram, PPU_SAVESTATE_MEM_SIZE);
+}
+
+void PpuResetWidescreenOamHistory(Ppu *ppu) {
+  if (!ppu)
+    return;
+  ppu->wsOamMotionLastLine = -1;
+  memset(ppu->wsOamMotionX, 0, sizeof(ppu->wsOamMotionX));
+  memset(ppu->wsOamMotionSig, 0, sizeof(ppu->wsOamMotionSig));
+  memset(ppu->wsOamMotionSeen, 0, sizeof(ppu->wsOamMotionSeen));
+  memset(ppu->wsOamMotionGrace, 0, sizeof(ppu->wsOamMotionGrace));
 }
 
 // Debug layer isolation: SNESRECOMP_LAYER_MASK is a bitmask of layers to keep
@@ -445,6 +459,7 @@ void ppu_runLine(Ppu* ppu, int line) {
     s_oam_snap_frame = snes_frame_counter;
     debug_server_on_oam_render();
   }
+  PpuUpdateWidescreenOamHistory(ppu, line);
   if(line == 0) {
     if (PPU_mosaicSize(ppu) != ppu->lastMosaicModulo) {
       int mod = PPU_mosaicSize(ppu);
@@ -2060,6 +2075,49 @@ static int PpuDecodeOamX(Ppu *ppu, uint8_t index) {
   return x;
 }
 
+static uint32_t PpuOamMotionSignature(Ppu *ppu, uint8_t index) {
+  uint8_t slot = index >> 1;
+  uint32_t high_pair =
+      (ppu->highOam[slot >> 2] >> ((slot & 3) * 2)) & 0x3u;
+  return ((uint32_t)(ppu->oam[index] >> 8)) |
+         ((uint32_t)ppu->oam[index + 1] << 8) |
+         ((high_pair & 0x2u) << 23);
+}
+
+static bool PpuWsOamHistorySeen(Ppu *ppu, uint8_t slot) {
+  return (ppu->wsOamMotionSeen[slot >> 3] & (1u << (slot & 7))) != 0;
+}
+
+static void PpuWsOamHistoryMarkSeen(Ppu *ppu, uint8_t slot) {
+  ppu->wsOamMotionSeen[slot >> 3] |= (uint8_t)(1u << (slot & 7));
+}
+
+static void PpuUpdateWidescreenOamHistory(Ppu *ppu, int line) {
+  if (ppu->wsOamMotionLastLine >= 0 && line > ppu->wsOamMotionLastLine) {
+    ppu->wsOamMotionLastLine = (int16_t)line;
+    return;
+  }
+  ppu->wsOamMotionLastLine = (int16_t)line;
+  for (uint8_t slot = 0; slot < 128; slot++) {
+    uint8_t index = (uint8_t)(slot * 2);
+    int16_t x = (int16_t)PpuDecodeOamX(ppu, index);
+    uint32_t sig = PpuOamMotionSignature(ppu, index);
+    if (PpuWsOamHistorySeen(ppu, slot) &&
+        sig == ppu->wsOamMotionSig[slot]) {
+      if (x != ppu->wsOamMotionX[slot]) {
+        ppu->wsOamMotionGrace[slot] = kPpuWsOamMovingGraceFrames;
+      } else if (ppu->wsOamMotionGrace[slot]) {
+        ppu->wsOamMotionGrace[slot]--;
+      }
+    } else {
+      ppu->wsOamMotionGrace[slot] = 0;
+      PpuWsOamHistoryMarkSeen(ppu, slot);
+    }
+    ppu->wsOamMotionX[slot] = x;
+    ppu->wsOamMotionSig[slot] = sig;
+  }
+}
+
 static bool PpuWidescreenOamLeftHintAllows(Ppu *ppu, uint8_t index, int x,
                                            int sprite_size,
                                            int left_extra) {
@@ -2067,7 +2125,9 @@ static bool PpuWidescreenOamLeftHintAllows(Ppu *ppu, uint8_t index, int x,
       x + sprite_size <= -left_extra)
     return true;
   int slot = index >> 1;
-  return (ppu->wsOamLeftHint[slot >> 3] & (1u << (slot & 7))) != 0;
+  if (ppu->wsOamLeftHint[slot >> 3] & (1u << (slot & 7)))
+    return true;
+  return ppu->wsOamMotionGrace[slot] != 0;
 }
 
 static bool ppu_evaluateSprites(Ppu* ppu, int line) {

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -38,6 +38,9 @@ enum {
   kPpuBufWidth = kPpuXPixels + kPpuExtraLeftRight * 2,
   // Split-screen games can assign distinct anchor layouts to each viewport.
   kPpuWsAnchorBands = 2,
+  // Number of stopped frames tolerated after a moving unhinted OBJ reaches the
+  // left widened margin.
+  kPpuWsOamMovingGraceFrames = 4,
 };
 
 typedef uint16_t PpuZbufType;
@@ -251,6 +254,14 @@ struct Ppu {
   uint8_t wsOamLeftHint[16];
   uint8_t wsOamRightHintStrict;
   uint8_t wsOamRightHint[16];
+  /* Host-only temporal classifier for unhinted left-margin OBJ. It lets a
+   * game-authored sprite keep moving through the widened margin, then parks it
+   * again after its X stops changing for a few frames. */
+  int16_t wsOamMotionLastLine;
+  int16_t wsOamMotionX[128];
+  uint32_t wsOamMotionSig[128];
+  uint8_t wsOamMotionSeen[16];
+  uint8_t wsOamMotionGrace[128];
   uint8_t lastMosaicModulo;
   uint8_t lastBrightnessMult;
   bool lineHasSprites;
@@ -414,6 +425,7 @@ void ppu_rasterApplyLine(Ppu *ppu, int line);
 int  ppu_rasterDebugDump(char *out, int cap);
 void ppu_saveload(Ppu *ppu, SaveLoadInfo *sli);
 void PpuBeginDrawing(Ppu *ppu, uint8_t *pixels, size_t pitch, uint32_t render_flags);
+void PpuResetWidescreenOamHistory(Ppu *ppu);
 
 // Replace stale BG1 tilemap pixels in widened side margins before final
 // composition. The callback is host-only and runs independently for main and

--- a/tests/ppu/ppu_sprite_limit_test.c
+++ b/tests/ppu/ppu_sprite_limit_test.c
@@ -115,6 +115,17 @@ static void render_one_line(Ppu *ppu) {
     ppu_runLine(ppu, 1);
 }
 
+static void render_strict_left_oam_frame(Ppu *ppu, uint32_t *pixels,
+                                         size_t pixel_count, int raw_x,
+                                         const uint8_t *hints) {
+    memset(pixels, 0, pixel_count * sizeof(pixels[0]));
+    PpuWsSetOamLeftHints(ppu, hints);
+    setup_one_sprite_line(ppu, raw_x);
+    ppu_runLine(ppu, 0);
+    ppu_runLine(ppu, 1);
+    snes_frame_counter++;
+}
+
 static unsigned count_argb_pixels(const uint32_t *pixels, size_t count) {
     unsigned nonzero = 0;
     for (size_t i = 0; i < count; i++) {
@@ -566,6 +577,53 @@ int main(void) {
         ppu_runLine(ppu, 1);
         failures += check(wide_pixels[kExtra - 1] != 0,
                           "NULL left hints restore legacy margin behavior");
+    }
+
+    /* Strict left hints only describe host-owned slots. For game-owned slots,
+     * a negative-X sprite that is moving frame-to-frame should continue through
+     * the widened margin, but a parked off-screen sprite should still clip. */
+    {
+        enum { kExtra = 16, kWidePixels = kPpuXPixels + kExtra * 2 };
+        uint32_t wide_pixels[kWidePixels];
+        uint8_t no_hints[16] = {0};
+
+        ppu_reset(ppu);
+        snes_frame_counter = 1000;
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+
+        render_strict_left_oam_frame(ppu, wide_pixels, kWidePixels,
+                                     0x1f9, no_hints);
+        failures += check(wide_pixels[kExtra] != 0,
+                          "partially visible negative OAM stays visible");
+
+        render_strict_left_oam_frame(ppu, wide_pixels, kWidePixels,
+                                     0x1f8, no_hints);
+        failures += check(wide_pixels[kExtra - 1] != 0 &&
+                              wide_pixels[kExtra - 8] != 0,
+                          "moving unhinted OAM exits through left margin");
+
+        for (int i = 0; i < kPpuWsOamMovingGraceFrames; i++) {
+            render_strict_left_oam_frame(ppu, wide_pixels, kWidePixels,
+                                         0x1f8, no_hints);
+        }
+        failures += check(wide_pixels[kExtra - 1] == 0 &&
+                              wide_pixels[kExtra - 8] == 0,
+                          "stopped unhinted OAM parks outside left edge");
+
+        ppu_reset(ppu);
+        snes_frame_counter = 2000;
+        PpuBeginDrawing(ppu, (uint8_t *)wide_pixels,
+                        sizeof(uint32_t) * kWidePixels,
+                        kPpuRenderFlags_NewRenderer);
+        PpuSetExtraSpace(ppu, kExtra);
+        render_strict_left_oam_frame(ppu, wide_pixels, kWidePixels,
+                                     0x1f8, no_hints);
+        failures += check(wide_pixels[kExtra - 1] == 0 &&
+                              wide_pixels[kExtra - 8] == 0,
+                          "initial parked unhinted OAM remains clipped");
     }
 
     ppu_free(ppu);


### PR DESCRIPTION
## Summary
- track per-slot OAM X/signature history so strict left-margin OAM can distinguish a sprite moving off the native edge from one parked off-screen
- keep explicit left hints authoritative and reset the host-only history on PPU reset/savestate loads
- add a PPU regression for moving unhinted left-margin OBJ parking after a short grace period

Fixes #56.

## Validation
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File tests\ppu\run.ps1`
- `bash tests/run_c_tests.sh`
- `python tests/run_tests.py`
- `python tests/v2/run_tests.py`
- SimCity widescreen/mod branch built against this runner and launched with `SC_WIDESCREEN=96 SC_WS_OBJ_CLIP=1 SC_WS_OAM=1 SC_WS_TITLE=1 SC_WS_LIGHTS=1 SC_NEW_RENDERER=1`; manual visual pass did not show parked sprites leaking/overlapping across margins
- SMW rebuilt and benchmark-smoked; manual visual pass OK
- LTTP rebuilt and manual visual pass OK for the runner change; separate stale adaptive-margin artifact also reproduces on `origin/main`, so it is not caused by this patch
- Super Metroid rebuilt; `ppu_window_test`/`sm_widescreen_test` passed earlier, build passes with this runner
- Mega Man X rebuilt, display/widescreen policy tests passed, and manual recomp-ui widescreen pass OK