### PR TITLE
Harden inline argument carrier tracking

### DIFF
--- a/recompiler-rs/src/decoder.rs
+++ b/recompiler-rs/src/decoder.rs
@@ -2867,14 +2867,25 @@ pub fn detect_inline_arg_bytes(
     fn mutates_y(opcode: u8) -> bool {
         matches!(
             opcode,
-            0xA0 | 0xA4 | 0xB4 | 0xAC | 0xBC | 0xC8 | 0x88 | 0x7A | 0xA8 | 0x9B
+            0x44 | 0x54 | 0xA0 | 0xA4 | 0xB4 | 0xAC | 0xBC | 0xC8 | 0x88 | 0x7A | 0xA8 | 0x9B
         )
     }
 
     fn mutates_x(opcode: u8) -> bool {
         matches!(
             opcode,
-            0xA2 | 0xA6 | 0xB6 | 0xAE | 0xBE | 0xE8 | 0xCA | 0xFA | 0xAA | 0xBA | 0xBB
+            0x44 | 0x54
+                | 0xA2
+                | 0xA6
+                | 0xB6
+                | 0xAE
+                | 0xBE
+                | 0xE8
+                | 0xCA
+                | 0xFA
+                | 0xAA
+                | 0xBA
+                | 0xBB
         )
     }
 
@@ -2927,7 +2938,7 @@ pub fn detect_inline_arg_bytes(
 
     fn invalidate_stack_write(
         valid: &mut u8,
-        status_slots: &mut HashMap<i32, (u8, u8)>,
+        status_slots: &mut HashMap<i32, (u8, u8, Option<u8>)>,
         start: i32,
         size: u8,
     ) {
@@ -2940,7 +2951,7 @@ pub fn detect_inline_arg_bytes(
     fn push_bytes(
         depth: &mut i32,
         valid: &mut u8,
-        status_slots: &mut HashMap<i32, (u8, u8)>,
+        status_slots: &mut HashMap<i32, (u8, u8, Option<u8>)>,
         size: u8,
     ) -> i32 {
         *depth -= i32::from(size);
@@ -2954,12 +2965,16 @@ pub fn detect_inline_arg_bytes(
     let mut x = entry_x & 1;
     let mut stack_depth = 0i32;
     let mut return_valid = 0b11u8;
-    let mut status_slots: HashMap<i32, (u8, u8)> = HashMap::new();
+    let mut status_slots: HashMap<i32, (u8, u8, Option<u8>)> = HashMap::new();
     let mut a_slot: Option<u8> = None;
     let mut a_slot_size = 0u8;
     let mut a_pulled = false;
     let mut a_pulled_size = 0u8;
     let mut a_added = 0u32;
+    let mut a_carry: Option<u8> = None;
+    // Decimal flag: Some(0) binary, Some(1) BCD, None unknown. ADC #imm only
+    // yields a usable constant in binary mode, so anything else stops the match.
+    let mut decimal: Option<u8> = Some(0);
     let mut y_slot: Option<u8> = None;
     let mut y_slot_size = 0u8;
     let mut y_pulled = false;
@@ -2990,6 +3005,7 @@ pub fn detect_inline_arg_bytes(
                         a_pulled = false;
                         a_pulled_size = 0;
                         a_added = 0;
+                        a_carry = None;
                     }
                 }
                 if ins.operand & 0x10 != 0 {
@@ -3006,6 +3022,12 @@ pub fn detect_inline_arg_bytes(
                         x_added = 0;
                     }
                 }
+                if ins.operand & 0x01 != 0 && (a_slot.is_some() || a_pulled) {
+                    a_carry = Some(0);
+                }
+                if ins.operand & 0x08 != 0 {
+                    decimal = Some(0);
+                }
             }
             "SEP" => {
                 if ins.operand & 0x20 != 0 {
@@ -3017,6 +3039,7 @@ pub fn detect_inline_arg_bytes(
                         a_pulled = false;
                         a_pulled_size = 0;
                         a_added = 0;
+                        a_carry = None;
                     }
                 }
                 if ins.operand & 0x10 != 0 {
@@ -3033,6 +3056,12 @@ pub fn detect_inline_arg_bytes(
                         x_added = 0;
                     }
                 }
+                if ins.operand & 0x01 != 0 && (a_slot.is_some() || a_pulled) {
+                    a_carry = Some(1);
+                }
+                if ins.operand & 0x08 != 0 {
+                    decimal = Some(1);
+                }
             }
             "LDA" if ins.mode == Mode::Stk => {
                 let slot = (ins.operand & 0xFF) as u8;
@@ -3043,6 +3072,7 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
             }
             "PLA" => {
                 let size = if m != 0 { 1 } else { 2 };
@@ -3051,6 +3081,7 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = return_bytes_valid(return_valid, stack_depth + 1, size);
                 a_pulled_size = if a_pulled { size } else { 0 };
                 a_added = 0;
+                a_carry = None;
                 stack_depth += i32::from(size);
             }
             "TAY" => {
@@ -3068,9 +3099,30 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = tracked && y_pulled;
                 a_pulled_size = if a_pulled { y_pulled_size } else { 0 };
                 a_added = if tracked { y_added } else { 0 };
+                a_carry = None;
+            }
+            "CLC" => {
+                if a_slot.is_some() || a_pulled {
+                    a_carry = Some(0);
+                }
+            }
+            "SEC" => {
+                if a_slot.is_some() || a_pulled {
+                    a_carry = Some(1);
+                }
             }
             "ADC" if ins.opcode == 0x69 && (a_slot.is_some() || a_pulled) => {
-                a_added = (a_added + ins.operand) & 0xFFFF;
+                if let (Some(carry), Some(0)) = (a_carry, decimal) {
+                    let width_mask = if m != 0 { 0xFF } else { 0xFFFF };
+                    a_added = (a_added + ins.operand + u32::from(carry)) & width_mask;
+                } else {
+                    a_slot = None;
+                    a_slot_size = 0;
+                    a_pulled = false;
+                    a_pulled_size = 0;
+                    a_added = 0;
+                }
+                a_carry = None;
             }
             "STA" if ins.opcode == 0x83 && ins.mode == Mode::Stk => {
                 let slot = (ins.operand & 0xFF) as u8;
@@ -3078,8 +3130,8 @@ pub fn detect_inline_arg_bytes(
                 let start = stack_depth + i32::from(slot);
                 let writeback = a_slot == Some(slot) && a_slot_size == size && start == 1;
                 let mask = return_mask(start, size);
-                if writeback && a_added != 0 && return_valid | mask == 0b11 {
-                    return Some((a_added & 0xFF) as u8);
+                if writeback && a_added != 0 && (return_valid | mask) == 0b11 {
+                    return u8::try_from(a_added).ok();
                 }
                 invalidate_stack_write(&mut return_valid, &mut status_slots, start, size);
                 if writeback && a_added == 0 {
@@ -3092,16 +3144,13 @@ pub fn detect_inline_arg_bytes(
                     push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, size);
                 if a_pulled && a_pulled_size == size && start == 1 {
                     if a_added != 0 {
-                        if return_valid | return_mask(start, size) == 0b11 {
-                            return Some((a_added & 0xFF) as u8);
+                        if (return_valid | return_mask(start, size)) == 0b11 {
+                            return u8::try_from(a_added).ok();
                         }
                     } else {
                         return_valid |= return_mask(start, size);
                     }
                 }
-                a_pulled = false;
-                a_pulled_size = 0;
-                a_added = 0;
             }
             "PLX" => {
                 let size = if x != 0 { 1 } else { 2 };
@@ -3111,7 +3160,7 @@ pub fn detect_inline_arg_bytes(
                 stack_depth += i32::from(size);
             }
             "INX" if x_pulled => {
-                x_added = x_added.wrapping_add(1);
+                x_added = (x_added + 1) & 0xFFFF;
             }
             "PHX" => {
                 let size = if x != 0 { 1 } else { 2 };
@@ -3119,16 +3168,13 @@ pub fn detect_inline_arg_bytes(
                     push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, size);
                 if x_pulled && x_pulled_size == size && start == 1 {
                     if x_added != 0 {
-                        if return_valid | return_mask(start, size) == 0b11 {
+                        if (return_valid | return_mask(start, size)) == 0b11 {
                             return Some((x_added & 0xFF) as u8);
                         }
                     } else {
                         return_valid |= return_mask(start, size);
                     }
                 }
-                x_pulled = false;
-                x_pulled_size = 0;
-                x_added = 0;
             }
             "PHY" => {
                 push_bytes(
@@ -3137,13 +3183,10 @@ pub fn detect_inline_arg_bytes(
                     &mut status_slots,
                     if x != 0 { 1 } else { 2 },
                 );
-                y_pulled = false;
-                y_pulled_size = 0;
-                y_added = 0;
             }
             "PHP" => {
                 let start = push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, 1);
-                status_slots.insert(start, (m, x));
+                status_slots.insert(start, (m, x, decimal));
             }
             "PHB" | "PHK" => {
                 push_bytes(&mut stack_depth, &mut return_valid, &mut status_slots, 1);
@@ -3158,6 +3201,7 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
             }
             "PLY" => {
                 stack_depth += if x != 0 { 1 } else { 2 };
@@ -3166,7 +3210,9 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
                 y_slot = None;
+                y_slot_size = 0;
                 y_pulled = false;
                 y_pulled_size = 0;
                 y_added = 0;
@@ -3178,6 +3224,7 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
             }
             "PLD" => {
                 stack_depth += 2;
@@ -3186,16 +3233,20 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
             }
             "PLP" => {
                 let saved = status_slots.remove(&(stack_depth + 1))?;
                 stack_depth += 1;
-                (m, x) = saved;
+                // The pulled status byte carries D as well as M/X, so the
+                // matching PHP records all three.
+                (m, x, decimal) = saved;
                 a_slot = None;
                 a_slot_size = 0;
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
                 y_slot = None;
                 y_slot_size = 0;
                 y_pulled = false;
@@ -3212,6 +3263,7 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
                 y_slot = None;
                 y_slot_size = 0;
                 y_pulled = false;
@@ -3222,6 +3274,13 @@ pub fn detect_inline_arg_bytes(
                 x_added = 0;
             }
             _ if preserves_a(ins.opcode) => {
+                if matches!(ins.opcode, 0xE0 | 0xE4 | 0xEC | 0xC0 | 0xC4 | 0xCC) {
+                    a_carry = None;
+                } else if ins.opcode == 0xD8 {
+                    decimal = Some(0);
+                } else if ins.opcode == 0xF8 {
+                    decimal = Some(1);
+                }
                 if mutates_y(ins.opcode) {
                     y_slot = None;
                     y_slot_size = 0;
@@ -3241,6 +3300,7 @@ pub fn detect_inline_arg_bytes(
                 a_pulled = false;
                 a_pulled_size = 0;
                 a_added = 0;
+                a_carry = None;
                 if mutates_y(ins.opcode) {
                     y_slot = None;
                     y_slot_size = 0;
@@ -3920,6 +3980,77 @@ mod tests {
     }
 
     #[test]
+    fn rejects_adc_in_decimal_mode_after_sed() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0xF8, // SED
+            0x18, // CLC
+            0x69, 0x09, 0x00, // ADC #$0009 - BCD, not a byte count
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_adc_in_decimal_mode_after_sep_08() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0xE2, 0x08, // SEP #$08 - sets D
+            0x18, // CLC
+            0x69, 0x09, 0x00, // ADC #$0009
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn php_plp_restores_the_decimal_flag() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x08, // PHP - records binary mode
+            0xF8, // SED
+            0x28, // PLP - back to binary
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x03, 0x00, // ADC #$0003
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn accepts_adc_after_decimal_mode_is_cleared_again() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0xF8, // SED
+            0xD8, // CLD - back to binary before the add
+            0x18, // CLC
+            0x69, 0x09, 0x00, // ADC #$0009
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(9)
+        );
+    }
+
+    #[test]
     fn rejects_xce_during_inline_argument_scan() {
         let rom = rom_at_8000(&[
             0xFB, // XCE
@@ -3951,6 +4082,187 @@ mod tests {
         assert_eq!(
             detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
             None
+        );
+    }
+
+    #[test]
+    fn rejects_x_carrier_after_block_move() {
+        for opcode in [0x44, 0x54] {
+            let rom = rom_at_8000(&[
+                0xC2, 0x10, // REP #$10
+                0xFA, // PLX
+                opcode, 0x00, 0x00, // MVP / MVN
+                0xE8, // INX
+                0xDA, // PHX
+                0x60, // RTS
+            ]);
+            assert_eq!(
+                detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_y_carrier_after_block_move() {
+        for opcode in [0x44, 0x54] {
+            let rom = rom_at_8000(&[
+                0xC2, 0x30, // REP #$30
+                0xA3, 0x01, // LDA $01,S
+                0xA8, // TAY
+                opcode, 0x00, 0x00, // MVP / MVN
+                0x98, // TYA
+                0x18, // CLC
+                0x69, 0x01, 0x00, // ADC #$0001
+                0x83, 0x01, // STA $01,S
+                0x60, // RTS
+            ]);
+            assert_eq!(
+                detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn detects_sec_adc_return_adjustment() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0x38, // SEC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn rejects_adc_with_unknown_carry() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_adjustment_after_known_zero_delta_restore() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x00, 0x00, // ADC #$0000
+            0x48, // PHA
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x01, 0x00, // ADC #$0001
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn eight_bit_adc_wrap_is_not_an_adjustment() {
+        let rom = rom_at_8000(&[
+            0xE2, 0x20, // SEP #$20
+            0x68, // PLA
+            0x38, // SEC
+            0x69, 0xFF, // ADC #$FF
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_adjustment_larger_than_result_type() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0x18, // CLC
+            0x69, 0x00, 0x01, // ADC #$0100
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn a_carrier_survives_local_push() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xA3, 0x01, // LDA $01,S
+            0x18, // CLC
+            0x69, 0x03, 0x00, // ADC #$0003
+            0x48, // PHA
+            0xFA, // PLX
+            0x83, 0x01, // STA $01,S
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn x_carrier_survives_local_push() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0xFA, // PLX
+            0xE8, // INX
+            0x48, // PHA
+            0xDA, // PHX
+            0x7A, // PLY
+            0x68, // PLA
+            0xDA, // PHX
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn y_carrier_survives_local_push() {
+        let rom = rom_at_8000(&[
+            0xC2, 0x30, // REP #$30
+            0x68, // PLA
+            0xA8, // TAY
+            0x48, // PHA
+            0x5A, // PHY
+            0xFA, // PLX
+            0x2B, // PLD
+            0x98, // TYA
+            0x18, // CLC
+            0x69, 0x03, 0x00, // ADC #$0003
+            0x48, // PHA
+            0x60, // RTS
+        ]);
+        assert_eq!(
+            detect_inline_arg_bytes(&rom, RomMapping::LoRom, 0, 0x8000, 1, 1),
+            Some(3)
         );
     }
 

--- a/recompiler/v2/decoder.py
+++ b/recompiler/v2/decoder.py
@@ -1199,7 +1199,12 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
     resets the match — so a routine that merely reads its return address
     (e.g. a JSL dispatch helper) without adding a constant and storing it
     back is NOT flagged. Returns None on the first terminator or after a
-    short instruction budget."""
+    short instruction budget.
+
+    The routine is assumed to be entered in binary mode. SED and SEP #$08
+    set the decimal flag, CLD and REP #$08 clear it, and PHP/PLP carry it the
+    same way they carry M/X. ADC #imm in decimal mode is BCD and does not
+    yield a usable byte count, so it stops the match."""
     from snes65816 import decode_insn, lorom_offset, STK
     # Opcodes that PRESERVE A (may appear between the load and the
     # add/store-back): stores, flag set/clear, register transfers that
@@ -1218,10 +1223,11 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
         0xEA, 0x42,                                   # NOP / WDM
     }
     Y_MUTATING = {
-        0xA0, 0xA4, 0xB4, 0xAC, 0xBC, 0xC8, 0x88, 0x7A, 0xA8, 0x9B,
+        0x44, 0x54, 0xA0, 0xA4, 0xB4, 0xAC, 0xBC, 0xC8, 0x88, 0x7A, 0xA8, 0x9B,
     }
     X_MUTATING = {
-        0xA2, 0xA6, 0xB6, 0xAE, 0xBE, 0xE8, 0xCA, 0xFA, 0xAA, 0xBA, 0xBB,
+        0x44, 0x54, 0xA2, 0xA6, 0xB6, 0xAE, 0xBE, 0xE8, 0xCA, 0xFA, 0xAA, 0xBA,
+        0xBB,
     }
     CONTROL_TRANSFER = {
         0x00, 0x02, 0x10, 0x20, 0x22, 0x30, 0x40, 0x4C, 0x50, 0x5C, 0x60, 0x6B,
@@ -1265,6 +1271,10 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
     a_pulled = False
     a_pulled_size = 0
     a_added = 0
+    a_carry = None
+    # Decimal flag: 0 binary, 1 BCD, None unknown. ADC #imm only yields a
+    # usable constant in binary mode, so anything else stops the match.
+    decimal = 0
     y_slot = None
     y_slot_size = 0
     y_pulled = False
@@ -1301,6 +1311,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
                     a_pulled = False
                     a_pulled_size = 0
                     a_added = 0
+                    a_carry = None
             if ins.operand & 0x10:
                 changed = x != 0
                 x = 0
@@ -1313,6 +1324,10 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
                     x_pulled = False
                     x_pulled_size = 0
                     x_added = 0
+            if ins.operand & 0x01 and (a_slot is not None or a_pulled):
+                a_carry = 0
+            if ins.operand & 0x08:
+                decimal = 0
         elif mn == 'SEP':
             if ins.operand & 0x20:
                 changed = m != 1
@@ -1323,6 +1338,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
                     a_pulled = False
                     a_pulled_size = 0
                     a_added = 0
+                    a_carry = None
             if ins.operand & 0x10:
                 changed = x != 1
                 x = 1
@@ -1335,6 +1351,10 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
                     x_pulled = False
                     x_pulled_size = 0
                     x_added = 0
+            if ins.operand & 0x01 and (a_slot is not None or a_pulled):
+                a_carry = 1
+            if ins.operand & 0x08:
+                decimal = 1
         elif mn == 'LDA' and ins.mode == STK:
             slot = ins.operand & 0xFF
             size = 1 if m else 2
@@ -1344,6 +1364,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
         elif op == 0x68:                       # PLA
             size = 1 if m else 2
             a_slot = None
@@ -1351,6 +1372,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = return_bytes_valid(stack_depth + 1, size)
             a_pulled_size = size if a_pulled else 0
             a_added = 0
+            a_carry = None
             stack_depth += size
         elif op == 0xA8:                       # TAY
             if m == x and (a_slot is not None or a_pulled):
@@ -1372,14 +1394,31 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
                 a_pulled = y_pulled
                 a_pulled_size = y_pulled_size
                 a_added = y_added
+                a_carry = None
             else:
                 a_slot = None
                 a_slot_size = 0
                 a_pulled = False
                 a_pulled_size = 0
                 a_added = 0
+                a_carry = None
+        elif op == 0x18:                       # CLC
+            if a_slot is not None or a_pulled:
+                a_carry = 0
+        elif op == 0x38:                       # SEC
+            if a_slot is not None or a_pulled:
+                a_carry = 1
         elif op == 0x69 and (a_slot is not None or a_pulled):   # ADC #imm
-            a_added = (a_added + ins.operand) & 0xFFFF
+            if a_carry is None or decimal != 0:
+                a_slot = None
+                a_slot_size = 0
+                a_pulled = False
+                a_pulled_size = 0
+                a_added = 0
+            else:
+                width_mask = 0xFF if m else 0xFFFF
+                a_added = (a_added + ins.operand + a_carry) & width_mask
+            a_carry = None
         elif op == 0x83 and ins.mode == STK:      # STA $nn,S — return-addr write-back
             slot = ins.operand & 0xFF
             size = 1 if m else 2
@@ -1387,8 +1426,8 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             writeback = (a_slot is not None and slot == a_slot and
                          a_slot_size == size and start == 1)
             mask = return_mask(start, size)
-            if writeback and a_added and return_valid | mask == 0b11:
-                return a_added & 0xFF             # inline byte count
+            if writeback and a_added and (return_valid | mask) == 0b11:
+                return a_added if a_added <= 0xFF else None
             invalidate_stack_write(start, size)
             if writeback and not a_added:
                 return_valid |= mask
@@ -1398,13 +1437,10 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             if (a_pulled and a_pulled_size == size and
                     start == 1):
                 if a_added:
-                    if return_valid | return_mask(start, size) == 0b11:
-                        return a_added & 0xFF
+                    if (return_valid | return_mask(start, size)) == 0b11:
+                        return a_added if a_added <= 0xFF else None
                 else:
                     return_valid |= return_mask(start, size)
-            a_pulled = False
-            a_pulled_size = 0
-            a_added = 0
         elif op == 0xFA:                          # PLX
             size = 1 if x else 2
             x_pulled = return_bytes_valid(stack_depth + 1, size)
@@ -1419,20 +1455,14 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             if (x_pulled and x_pulled_size == size and
                     start == 1):
                 if x_added:
-                    if return_valid | return_mask(start, size) == 0b11:
+                    if (return_valid | return_mask(start, size)) == 0b11:
                         return x_added & 0xFF
                 else:
                     return_valid |= return_mask(start, size)
-            x_pulled = False
-            x_pulled_size = 0
-            x_added = 0
         elif op == 0x5A:                          # PHY
             push_bytes(1 if x else 2)
-            y_pulled = False
-            y_pulled_size = 0
-            y_added = 0
         elif op == 0x08:                          # PHP
-            status_slots[push_bytes(1)] = (m, x)
+            status_slots[push_bytes(1)] = (m, x, decimal)
         elif op in (0x8B, 0x4B):                 # PHB / PHK
             push_bytes(1)
         elif op == 0x0B:                          # PHD
@@ -1444,6 +1474,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
         elif op == 0x7A:                          # PLY
             stack_depth += 1 if x else 2
             a_slot = None
@@ -1451,7 +1482,9 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
             y_slot = None
+            y_slot_size = 0
             y_pulled = False
             y_pulled_size = 0
             y_added = 0
@@ -1462,6 +1495,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
         elif op == 0x2B:                          # PLD
             stack_depth += 2
             a_slot = None
@@ -1469,17 +1503,21 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
         elif op == 0x28:                          # PLP
             saved = status_slots.pop(stack_depth + 1, None)
             if saved is None:
                 return None
             stack_depth += 1
-            m, x = saved
+            # The pulled status byte carries D as well as M/X, so the matching
+            # PHP records all three.
+            m, x, decimal = saved
             a_slot = None
             a_slot_size = 0
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
             y_slot = None
             y_slot_size = 0
             y_pulled = False
@@ -1496,6 +1534,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
             y_slot = None
             y_slot_size = 0
             y_pulled = False
@@ -1505,6 +1544,12 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             x_pulled_size = 0
             x_added = 0
         elif op in A_PRESERVING:
+            if op in (0xE0, 0xE4, 0xEC, 0xC0, 0xC4, 0xCC):
+                a_carry = None
+            elif op == 0xD8:                      # CLD
+                decimal = 0
+            elif op == 0xF8:                      # SED
+                decimal = 1
             if op in Y_MUTATING:
                 y_slot = None
                 y_slot_size = 0
@@ -1522,6 +1567,7 @@ def _detect_inline_arg_bytes_stack_slot(rom: bytes, bank: int, addr: int,
             a_pulled = False
             a_pulled_size = 0
             a_added = 0
+            a_carry = None
             if op in Y_MUTATING:
                 y_slot = None
                 y_slot_size = 0

--- a/tests/v2/test_inline_arg_detector.py
+++ b/tests/v2/test_inline_arg_detector.py
@@ -374,3 +374,241 @@ def test_y_carrier_is_invalidated_by_y_mutation():
     })
 
     assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_x_carrier_is_invalidated_by_block_move():
+    for opcode in (0x44, 0x54):  # MVP / MVN
+        rom = make_lorom_bank0({
+            0x8000: bytes([
+                0xC2, 0x10,       # REP #$10
+                0xFA,             # PLX
+                opcode, 0x00, 0x00,
+                0xE8,             # INX
+                0xDA,             # PHX
+                0x60,             # RTS
+            ]),
+        })
+
+        assert detect_inline_arg_bytes(
+            rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_y_carrier_is_invalidated_by_block_move():
+    for opcode in (0x44, 0x54):  # MVP / MVN
+        rom = make_lorom_bank0({
+            0x8000: bytes([
+                0xC2, 0x30,        # REP #$30
+                0xA3, 0x01,        # LDA $01,S
+                0xA8,              # TAY
+                opcode, 0x00, 0x00,
+                0x98,              # TYA
+                0x18,              # CLC
+                0x69, 0x01, 0x00,  # ADC #$0001
+                0x83, 0x01,        # STA $01,S
+                0x60,              # RTS
+            ]),
+        })
+
+        assert detect_inline_arg_bytes(
+            rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_detects_sec_adc_return_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0x38,              # SEC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 2
+
+
+def test_rejects_adc_with_unknown_carry():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_detects_adjustment_after_known_zero_delta_restore():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x00, 0x00,  # ADC #$0000
+            0x48,              # PHA
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x01, 0x00,  # ADC #$0001
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 1
+
+
+def test_8bit_adc_wrap_is_not_an_adjustment():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xE2, 0x20,  # SEP #$20
+            0x68,        # PLA
+            0x38,        # SEC
+            0x69, 0xFF,  # ADC #$FF
+            0x48,        # PHA
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_adjustment_larger_than_result_type():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x00, 0x01,  # ADC #$0100
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_a_carrier_survives_local_push():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0xA3, 0x01,        # LDA $01,S
+            0x18,              # CLC
+            0x69, 0x03, 0x00,  # ADC #$0003
+            0x48,              # PHA
+            0xFA,              # PLX
+            0x83, 0x01,        # STA $01,S
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 3
+
+
+def test_x_carrier_survives_local_push():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,  # REP #$30
+            0xFA,        # PLX
+            0xE8,        # INX
+            0x48,        # PHA
+            0xDA,        # PHX
+            0x7A,        # PLY
+            0x68,        # PLA
+            0xDA,        # PHX
+            0x60,        # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 1
+
+
+def test_y_carrier_survives_local_push():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0xA8,              # TAY
+            0x48,              # PHA
+            0x5A,              # PHY
+            0xFA,              # PLX
+            0x2B,              # PLD
+            0x98,              # TYA
+            0x18,              # CLC
+            0x69, 0x03, 0x00,  # ADC #$0003
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 3
+
+
+def test_rejects_adc_in_decimal_mode_after_sed():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0xF8,              # SED
+            0x18,              # CLC
+            0x69, 0x09, 0x00,  # ADC #$0009 - BCD, not a byte count
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_rejects_adc_in_decimal_mode_after_sep_08():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0xE2, 0x08,        # SEP #$08 - sets D
+            0x18,              # CLC
+            0x69, 0x09, 0x00,  # ADC #$0009
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) is None
+
+
+def test_php_plp_restores_the_decimal_flag():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x08,              # PHP - records binary mode
+            0xF8,              # SED
+            0x28,              # PLP - back to binary
+            0x68,              # PLA
+            0x18,              # CLC
+            0x69, 0x03, 0x00,  # ADC #$0003
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 3
+
+
+def test_accepts_adc_after_decimal_mode_is_cleared_again():
+    rom = make_lorom_bank0({
+        0x8000: bytes([
+            0xC2, 0x30,        # REP #$30
+            0x68,              # PLA
+            0xF8,              # SED
+            0xD8,              # CLD - back to binary before the add
+            0x18,              # CLC
+            0x69, 0x09, 0x00,  # ADC #$0009
+            0x48,              # PHA
+            0x60,              # RTS
+        ]),
+    })
+
+    assert detect_inline_arg_bytes(rom, 0, 0x8000, entry_m=1, entry_x=1) == 9


### PR DESCRIPTION
The inline-argument detector treated any ADC #imm after a return-address load
as a byte count, without knowing what the carry or the decimal flag were. An
ADC with unknown carry was read as +0, and an ADC under SED was read as binary
when the hardware does BCD. MVN and MVP also left stale X/Y carriers behind.

Track carry and decimal alongside M/X, CLC/SEC, REP/SEP bits 0 and 3, carried
through PHP/PLP, and stop the scan when either is unknown. Invalidate X and Y
across MVN/MVP, wrap the accumulated constant at the accumulator width, and
reject an adjustment that does not fit the u8 result instead of truncating it.
Detections can only be withdrawn this way, never added.

Tests:
- python tests/v2/run_tests.py (402 passed)
- python tests/run_tests.py (81 passed)
- cargo test in recompiler-rs (all passed)
- Lufia II regenerated against this branch instead of main: emitted C is
  byte-identical, same sha256 across all 16 banks