### PR TITLE
ppu: widescreen world-mirror bands + elastic anchor bands (GWED)

### DIFF
--- a/docs/WIDESCREEN_PATTERNS.md
+++ b/docs/WIDESCREEN_PATTERNS.md
@@ -106,6 +106,92 @@ and must equal the reflected source column; mid-scroll the margin must equal
 what the tilemap authors there (i.e. must be byte-identical to the natural
 render), which is the assertion that catches a viewport-space fold.
 
+### P2c. A continuous status bar anchors its rigid groups and stretches only elastic material
+
+**Defect:** `PpuSetWidescreenLayerAnchorBand` moves a raster status bar's left
+and right groups out to the widened viewport edges and keeps its middle
+centered. That is the right *placement*, and it is only half an answer whenever
+the bar is **one continuous graphic** with no transparent column to hide the
+seam: anchoring then opens an `extra`-px transparent gap on each side of the
+centre group, through which lower layers and the backdrop show. The two
+existing ways out are both wrong here. `PpuSetWidescreenLayerStretchBand`
+closes the gap but scales the *whole* line, so every glyph on it -- names,
+digits, labels -- is resampled. `PpuSetWidescreenLayerClampBand` avoids both
+problems by giving up: the bar stays native-centered inside a 16:9 frame, with
+the widened world visible past both of its ends.
+
+**Invariant:** decide per *column group*, not per line. Measure which source
+spans are **rigid** (they carry glyphs, markers, or any shape whose proportions
+read as intentional) and which are **elastic** -- a run of columns identical to
+one another (plain chrome), or a gauge's interior. Then map the native 256
+columns onto `[-extraLeft, 256+extraRight)` piecewise: rigid segments copy 1:1
+at a shifted destination, elastic segments resample. Rigid segments are then
+byte-exact wherever they land, which is the property that keeps glyphs
+pixel-perfect while they move, and elastic segments absorb the whole margin.
+
+`PpuSetWidescreenLayerElasticBand(ppu, layer, y0, y1, segs, nseg)` takes the
+explicit segment list `{srcX0, srcX1, dstX0, dstX1}` (ascending and
+non-overlapping in destination space, or the band is rejected outright).
+`PpuSetWidescreenLayerElasticSplitBandSlot(ppu, slot, layer, y0, y1, lx0, lx1,
+rx0, rx1)` builds the symmetric five-segment layout from the two elastic runs
+alone, and with both runs empty installs an identity band -- i.e. a clamp --
+which is how a transitional scanline is expressed in the same vocabulary.
+
+Two properties do the work and both are asserted:
+
+- **the resample is centre-nearest**, `sx = srcX0 + ((2*o+1)*sw)/(2*dw)`. It is
+  exactly 1:1 when `sw == dw`, so a rigid segment needs no special case; it is
+  symmetric under reflection, so a **mirror-image pair of gauges stretches to
+  the same length**, which `floor(o*sw/dw)` does not (measured: 111 of 113 fill
+  levels came out 1px asymmetric with the floor form, 1 of 113 with the centre
+  form);
+- **fill fraction is preserved**: `k` filled of `n` source columns become
+  `round(k*dw/n)` of `dw` destination columns within a pixel, so a full gauge
+  stays full, an empty one stays empty, and 37% stays 37%. This is what makes
+  stretching a *gauge* legitimate at all -- the bar is longer, and it still
+  reads the same health.
+
+Implemented at the merge step of the Mode-1 policy dispatchers, so it covers
+the 4bpp, 2bpp, big-tile and mosaic paths at once, and only source columns
+`[0,256)` -- the picture the game actually authored -- are ever sampled. It
+shares the world band's precedence rule (clamp band, layer mask,
+mirror/repeat/stretch and the BG3-widen gate all win over it) and beats the
+world band where the two overlap, since it is the more specific statement about
+that scanline.
+
+**Case:** GWED (`GundamWingEndlessDuelSNESRecomp`). The fight HUD is BG1 map
+rows 58-63 on scanlines 24-71, mirror-symmetric about px 128, with **no fully
+transparent column anywhere in px 1..254** -- so anchoring alone would have
+opened two 43px holes. Four bands, one per distinct tile-row layout, each with
+its elastic runs measured as spans whose columns are identical in all three HUD
+scenes: row 58 (name plates + the `TIME` label) stretches the plain chrome at
+px [88,112) / [144,168); row 59 stretches the health bar interior [8,120) /
+[136,248); row 60 the boost bar [24,120) / [136,232); rows 61-63 a SINGLE
+column of chrome, px [62,63) / [193,194). Line 72 gets an identity band because
+its hScroll is the arena camera, not the HUD's pinned 0, and lines 22-23 keep a
+plain clamp.
+
+That single column is the sub-lesson worth carrying to the next title:
+**"identical in every scene recon captured" is not the same as "identical in
+every state the game can draw."** Recon measured px 62-67 as six identical
+columns in all three HUD scenes, and stretching those six 6 -> 49 px came out
+as six 8-9 px steps as soon as a multi-hit combo replaced the energy box with a
+wider readout whose right cap, charge arrow and shoulder land exactly there. A
+one-column elastic run can only ever be REPEATED, so it is flat in *every*
+state -- plain plate normally, the readout box's own interior during a combo.
+Prefer the widest run that is flat in every state you can enumerate, and fall
+back to one column rather than to a wider run that is only usually flat.
+Corollary: measure the runs on the layer **in isolation**
+(`SNESRECOMP_LAYER_MASK`), never on the composite, where the bar's transparent
+pixels show whatever is behind them and vary per column and per frame.
+
+**Check:** rigid segments byte-exact against the unpolicied render at their
+shifted destination; the centre group byte-identical to it; no destination
+column left unpainted; a uniform source run stretching to a uniform
+destination run; and the gauge sweep -- every `k` from 0 to `n`, both gauges,
+within 1px of `round(k*dw/n)` of each other and of the ideal.
+`tests/ppu/ppu_elastic_band_test.c`.
+
 ### P3. Periodic layers fold; world-anchored layers use history
 
 **Defect:** treating a horizontally periodic layer (sky, repeating city glow) as

--- a/docs/WIDESCREEN_PATTERNS.md
+++ b/docs/WIDESCREEN_PATTERNS.md
@@ -66,6 +66,46 @@ rolling-map bookkeeping. Read-only with respect to simulation.
 **Check:** enter a room moving left and right; the outermost margin column must be
 correct on the first frame it is visible.
 
+### P2b. Bounded arenas reflect about the authored world edge, not the viewport edge
+
+**Defect:** a single-screen arena (a fighter's stage) has a tilemap that is
+authored only over a fixed pixel span, with tile 0 either side, and a camera
+clamped so the native 256 view never leaves that span. Widening the view then
+has two distinct regimes, and the existing policies each get one of them wrong:
+
+- `PpuSetWidescreenLayerMirror`/`RepeatBand` fold the rendered scanline at
+  screen x=0/255, so **mid-scroll** they discard the genuine authored art that
+  the margins are now showing and replace it with a fold of the centre.
+- Natural rendering is right mid-scroll but **at the camera clamps** runs the
+  margins straight off the end of the authored span into tile 0 (or, on a
+  smaller map, into a wrapped copy of the opposite side).
+
+**Invariant:** reflect in *tilemap* space about the authored world's own edges,
+not in screen space about the viewport's. Per pixel, with `x` = this line's
+hScroll + screen x (map pixels, before the map's wrap): `x < left` samples
+`2*left-1-x`, `x >= right` samples `2*right-1-x`, everything else renders
+naturally. Columns the tilemap really authors — margin columns included —
+survive untouched, and synthesis happens only where content ran out.
+`PpuSetWidescreenLayerWorldMirrorBand(ppu, layer, y0, y1, left, right)`.
+
+The band is per-layer and per-scanline because a raster-split status bar
+re-points hScroll for its own lines, where a world bound is meaningless; every
+other per-line policy (clamp band, layer mask, mirror/repeat/stretch, BG3
+widen) therefore wins over this one, so a status band is excluded simply by
+clamping it.
+
+**Case:** GWED (`GundamWingEndlessDuelSNESRecomp`). BG1 is a 64x64 map authored
+only in map px [64,448); the camera X clamp is [64,192], so the native 256 view
+spans exactly [64,448) at the walls and the 43px margins are the only thing
+that can leave the world. Lines 22-72 are a raster-split HUD band pinned to
+hScroll 0 / vScroll 440 and are clamped instead. BG2 is a 256px skyline with
+hScroll pinned to 0, where the map's own wrap already is the right answer.
+
+**Check:** at both camera clamps the outermost margin column must be non-blank
+and must equal the reflected source column; mid-scroll the margin must equal
+what the tilemap authors there (i.e. must be byte-identical to the natural
+render), which is the assertion that catches a viewport-space fold.
+
 ### P3. Periodic layers fold; world-anchored layers use history
 
 **Defect:** treating a horizontally periodic layer (sky, repeating city glow) as

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -4948,7 +4948,12 @@ static void cmd_get_ppu_state(const char *args) {
              "\"widescreen\":{\"budget\":%u,\"left\":%u,\"right\":%u,\"bottom\":%u,"
              "\"layerWiden\":\"0x%02x\",\"layerClamp\":\"0x%02x\","
              "\"layerMirror\":\"0x%02x\",\"layerRepeat\":\"0x%02x\","
-             "\"windowExpandLayers\":\"0x%02x\",\"windowExpandWindows\":\"0x%02x\"},"
+             "\"windowExpandLayers\":\"0x%02x\",\"windowExpandWindows\":\"0x%02x\","
+             "\"worldBands\":["
+               "{\"slot\":0,\"y0\":[%u,%u,%u,%u],\"y1\":[%u,%u,%u,%u],"
+                 "\"left\":[%u,%u,%u,%u],\"right\":[%u,%u,%u,%u]},"
+               "{\"slot\":1,\"y0\":[%u,%u,%u,%u],\"y1\":[%u,%u,%u,%u],"
+                 "\"left\":[%u,%u,%u,%u],\"right\":[%u,%u,%u,%u]}]},"
              "\"evenFrame\":%s}",
              p->inidisp, p->bgmode & 7, p->mosaic, p->obsel,
              p->setini,
@@ -4967,6 +4972,25 @@ static void cmd_get_ppu_state(const char *args) {
              p->extraBottomCur, p->wsLayerWidenMask, p->wsLayerClamp,
              p->wsLayerMirror, p->wsLayerRepeat,
              p->wsWindowExpandLayers, p->wsWindowExpandWindows,
+             /* worldBands: per-layer authored-world spans for the
+              * world-mirror policy (PpuSetWidescreenLayerWorldMirrorBand).
+              * y1<=y0 or right<=left on a layer means that slot is off. */
+             p->wsWorldY0[0][0], p->wsWorldY0[0][1], p->wsWorldY0[0][2],
+             p->wsWorldY0[0][3],
+             p->wsWorldY1[0][0], p->wsWorldY1[0][1], p->wsWorldY1[0][2],
+             p->wsWorldY1[0][3],
+             p->wsWorldLeft[0][0], p->wsWorldLeft[0][1],
+             p->wsWorldLeft[0][2], p->wsWorldLeft[0][3],
+             p->wsWorldRight[0][0], p->wsWorldRight[0][1],
+             p->wsWorldRight[0][2], p->wsWorldRight[0][3],
+             p->wsWorldY0[1][0], p->wsWorldY0[1][1], p->wsWorldY0[1][2],
+             p->wsWorldY0[1][3],
+             p->wsWorldY1[1][0], p->wsWorldY1[1][1], p->wsWorldY1[1][2],
+             p->wsWorldY1[1][3],
+             p->wsWorldLeft[1][0], p->wsWorldLeft[1][1],
+             p->wsWorldLeft[1][2], p->wsWorldLeft[1][3],
+             p->wsWorldRight[1][0], p->wsWorldRight[1][1],
+             p->wsWorldRight[1][2], p->wsWorldRight[1][3],
              p->evenFrame ? "true" : "false");
 }
 

--- a/runner/src/debug_server.c
+++ b/runner/src/debug_server.c
@@ -4933,6 +4933,46 @@ static void cmd_render_inject(const char *args) {
 static void cmd_get_ppu_state(const char *args) {
     if (!g_ppu) { send_fmt("{\"error\":\"ppu not available\"}"); return; }
     Ppu *p = g_ppu;
+    /* elasticBands: only the configured (layer, slot) pairs, since the full
+     * kPpuWsElasticBands x 4 x kPpuWsElasticSegs table would dwarf the rest
+     * of the reply. Each entry carries the band's scanline range and its
+     * piecewise map as [srcX0, srcX1, dstX0, dstX1] quads, which is exactly
+     * what a widescreen verdict needs to reproduce the mapping. */
+    char eb[3072];
+    size_t ebn = 0;
+    eb[ebn++] = '[';
+    for (unsigned slot = 0; slot < kPpuWsElasticBands; slot++) {
+        for (unsigned layer = 0; layer < 4; layer++) {
+            unsigned nseg = p->wsElasticNSeg[slot][layer];
+            if (!nseg || p->wsElasticY1[slot][layer] <= p->wsElasticY0[slot][layer])
+                continue;
+            int n = snprintf(eb + ebn, sizeof(eb) - ebn,
+                             "%s{\"slot\":%u,\"layer\":%u,\"y0\":%u,\"y1\":%u,\"segs\":[",
+                             ebn > 1 ? "," : "", slot, layer,
+                             p->wsElasticY0[slot][layer],
+                             p->wsElasticY1[slot][layer]);
+            if (n < 0 || (size_t)n >= sizeof(eb) - ebn) { ebn = sizeof(eb); break; }
+            ebn += (size_t)n;
+            for (unsigned i = 0; i < nseg; i++) {
+                const PpuWsElasticSeg *s = &p->wsElasticSeg[slot][layer][i];
+                n = snprintf(eb + ebn, sizeof(eb) - ebn, "%s[%d,%d,%d,%d]",
+                             i ? "," : "", s->srcX0, s->srcX1, s->dstX0, s->dstX1);
+                if (n < 0 || (size_t)n >= sizeof(eb) - ebn) { ebn = sizeof(eb); break; }
+                ebn += (size_t)n;
+            }
+            if (ebn >= sizeof(eb) - 4) break;
+            eb[ebn++] = ']';
+            eb[ebn++] = '}';
+        }
+        if (ebn >= sizeof(eb) - 4) break;
+    }
+    if (ebn >= sizeof(eb) - 4) {
+        /* Truncation would emit invalid JSON; report the overflow instead. */
+        snprintf(eb, sizeof(eb), "\"overflow\"");
+    } else {
+        eb[ebn++] = ']';
+        eb[ebn] = '\0';
+    }
     send_fmt("{\"inidisp\":\"0x%02x\",\"bgmode\":%d,\"mosaic\":\"0x%02x\",\"obsel\":\"0x%02x\","
              "\"setini\":\"0x%02x\","
              "\"bgXsc\":[\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],"
@@ -4953,7 +4993,8 @@ static void cmd_get_ppu_state(const char *args) {
                "{\"slot\":0,\"y0\":[%u,%u,%u,%u],\"y1\":[%u,%u,%u,%u],"
                  "\"left\":[%u,%u,%u,%u],\"right\":[%u,%u,%u,%u]},"
                "{\"slot\":1,\"y0\":[%u,%u,%u,%u],\"y1\":[%u,%u,%u,%u],"
-                 "\"left\":[%u,%u,%u,%u],\"right\":[%u,%u,%u,%u]}]},"
+                 "\"left\":[%u,%u,%u,%u],\"right\":[%u,%u,%u,%u]}],"
+             "\"elasticBands\":%s},"
              "\"evenFrame\":%s}",
              p->inidisp, p->bgmode & 7, p->mosaic, p->obsel,
              p->setini,
@@ -4991,6 +5032,7 @@ static void cmd_get_ppu_state(const char *args) {
              p->wsWorldLeft[1][2], p->wsWorldLeft[1][3],
              p->wsWorldRight[1][0], p->wsWorldRight[1][1],
              p->wsWorldRight[1][2], p->wsWorldRight[1][3],
+             eb,
              p->evenFrame ? "true" : "false");
 }
 

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -169,6 +169,10 @@ static inline void PpuResetLayerPolicies(Ppu *ppu) {
   memset(ppu->wsAnchorRightStart, 0, sizeof(ppu->wsAnchorRightStart));
   memset(ppu->wsMarginGapL, 0, sizeof(ppu->wsMarginGapL));
   memset(ppu->wsMarginGapR, 0, sizeof(ppu->wsMarginGapR));
+  memset(ppu->wsWorldY0, 0, sizeof(ppu->wsWorldY0));
+  memset(ppu->wsWorldY1, 0, sizeof(ppu->wsWorldY1));
+  memset(ppu->wsWorldLeft, 0, sizeof(ppu->wsWorldLeft));
+  memset(ppu->wsWorldRight, 0, sizeof(ppu->wsWorldRight));
   memset(ppu->wsViewportInsetL, 0, sizeof(ppu->wsViewportInsetL));
   memset(ppu->wsViewportInsetR, 0, sizeof(ppu->wsViewportInsetR));
   ppu->wsWindowExpandLayers = 0;
@@ -391,6 +395,30 @@ void PpuSetWidescreenLayerViewportInset(Ppu *ppu, uint8_t layer,
     ppu->wsViewportInsetL[layer] = left_px;
     ppu->wsViewportInsetR[layer] = right_px;
   }
+}
+
+void PpuSetWidescreenLayerWorldMirrorBand(Ppu *ppu, uint8_t layer, uint8_t y0,
+                                          uint8_t y1, uint16_t world_left_px,
+                                          uint16_t world_right_px) {
+  PpuSetWidescreenLayerWorldMirrorBandSlot(ppu, 0, layer, y0, y1,
+                                           world_left_px, world_right_px);
+}
+
+void PpuSetWidescreenLayerWorldMirrorBandSlot(
+    Ppu *ppu, uint8_t slot, uint8_t layer, uint8_t y0, uint8_t y1,
+    uint16_t world_left_px, uint16_t world_right_px) {
+  // See ppu.h. An empty band or an empty/inverted world span disables the
+  // slot outright rather than leaving half-configured state behind.
+  if (slot >= kPpuWsWorldBands || layer >= 4)
+    return;
+  if (y1 <= y0 || world_right_px <= world_left_px) {
+    y0 = y1 = 0;
+    world_left_px = world_right_px = 0;
+  }
+  ppu->wsWorldY0[slot][layer] = y0;
+  ppu->wsWorldY1[slot][layer] = y1;
+  ppu->wsWorldLeft[slot][layer] = world_left_px;
+  ppu->wsWorldRight[slot][layer] = world_right_px;
 }
 
 bool ppu_checkOverscan(Ppu* ppu) {
@@ -1382,6 +1410,40 @@ static void PpuMergePaddedBackground(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
   }
 }
 
+// Merge one isolated layer into the live priority buffer, reflecting columns
+// that fall outside the layer's AUTHORED WORLD back inside it. Unlike
+// PpuMergePaddedBackground this keeps every column the tilemap really
+// authors -- including margin columns -- and only synthesizes where the world
+// runs out. See PpuSetWidescreenLayerWorldMirrorBand.
+static void PpuMergeWorldMirroredBackground(Ppu *ppu,
+                                            PpuPixelPrioBufs *dstbuf,
+                                            const PpuPixelPrioBufs *layerbuf,
+                                            int world_left, int world_right,
+                                            int hscroll) {
+  PpuZbufType *dst = dstbuf->data;
+  const PpuZbufType *src = layerbuf->data;
+  const int left_extra = ppu->extraLeftCur;
+  const int right_extra = ppu->extraRightCur;
+  // Screen x of the authored world's left edge, and of the first column past
+  // its right edge, for the scroll THIS line rendered with (P1).
+  const int a = world_left - hscroll;
+  const int b = world_right - hscroll;
+  for (int x = -left_extra; x < kPpuXPixels + right_extra; x++) {
+    int sx = x;
+    if (x < a)
+      sx = 2 * a - 1 - x;
+    else if (x >= b)
+      sx = 2 * b - 1 - x;
+    if (sx < a || sx >= b)
+      continue;  // the reflection lands outside the world as well
+    if (sx < -left_extra || sx >= kPpuXPixels + right_extra)
+      continue;  // that source column was never rendered this line
+    int di = x + kPpuExtraLeftRight, si = sx + kPpuExtraLeftRight;
+    if (src[si] > dst[di])
+      dst[di] = src[si];
+  }
+}
+
 static void PpuMergeStretchedBackground(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
                                         const PpuPixelPrioBufs *layerbuf) {
   PpuZbufType *dst = dstbuf->data;
@@ -1409,7 +1471,9 @@ static void PpuDrawBackground_4bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
   uint8_t padding = ppu->wsLayerMirror | ppu->wsLayerRepeat;
   bool repeat_band = PpuWidescreenLayerRepeatBandActive(ppu, layer, y);
   bool stretch_band = PpuWidescreenLayerStretchBandActive(ppu, layer, y);
-  if (!(padding & (1u << layer)) && !repeat_band && !stretch_band) {
+  int world_band = PpuWidescreenLayerWorldBandAt(ppu, layer, (int)y);
+  if (!(padding & (1u << layer)) && !repeat_band && !stretch_band &&
+      world_band < 0) {
     if (PPU_bigTiles(ppu, layer))
       PpuDrawBackgroundBig(ppu, dstbuf, y, sub, layer, 4, zhi, zlo, mosaic);
     else if (mosaic)
@@ -1429,7 +1493,14 @@ static void PpuDrawBackground_4bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
     PpuDrawBackground_4bpp_mosaic(ppu, &layerbuf, y, sub, layer, zhi, zlo);
   else
     PpuDrawBackground_4bpp(ppu, &layerbuf, y, sub, layer, zhi, zlo);
-  if (stretch_band) {
+  if (world_band >= 0) {
+    // A live world band implies the layer widens on this line, so no clamp,
+    // mirror, repeat or stretch policy can be in force at the same time.
+    PpuMergeWorldMirroredBackground(ppu, dstbuf, &layerbuf,
+                                    ppu->wsWorldLeft[world_band][layer],
+                                    ppu->wsWorldRight[world_band][layer],
+                                    ppu->hScroll[layer]);
+  } else if (stretch_band) {
     PpuMergeStretchedBackground(ppu, dstbuf, &layerbuf);
   } else {
     PpuMergePaddedBackground(ppu, dstbuf, &layerbuf,
@@ -1450,7 +1521,9 @@ static void PpuDrawBackground_2bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
   uint8_t padding = ppu->wsLayerMirror | ppu->wsLayerRepeat;
   bool repeat_band = PpuWidescreenLayerRepeatBandActive(ppu, layer, y);
   bool stretch_band = PpuWidescreenLayerStretchBandActive(ppu, layer, y);
-  if (!(padding & (1u << layer)) && !repeat_band && !stretch_band) {
+  int world_band = PpuWidescreenLayerWorldBandAt(ppu, layer, (int)y);
+  if (!(padding & (1u << layer)) && !repeat_band && !stretch_band &&
+      world_band < 0) {
     if (PPU_bigTiles(ppu, layer))
       PpuDrawBackgroundBig(ppu, dstbuf, y, sub, layer, 2, zhi, zlo, mosaic);
     else if (mosaic)
@@ -1468,7 +1541,14 @@ static void PpuDrawBackground_2bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
     PpuDrawBackground_2bpp_mosaic(ppu, &layerbuf, y, sub, layer, zhi, zlo);
   else
     PpuDrawBackground_2bpp(ppu, &layerbuf, y, sub, layer, zhi, zlo);
-  if (stretch_band) {
+  if (world_band >= 0) {
+    // A live world band implies the layer widens on this line, so no clamp,
+    // mirror, repeat or stretch policy can be in force at the same time.
+    PpuMergeWorldMirroredBackground(ppu, dstbuf, &layerbuf,
+                                    ppu->wsWorldLeft[world_band][layer],
+                                    ppu->wsWorldRight[world_band][layer],
+                                    ppu->hScroll[layer]);
+  } else if (stretch_band) {
     PpuMergeStretchedBackground(ppu, dstbuf, &layerbuf);
   } else {
     PpuMergePaddedBackground(ppu, dstbuf, &layerbuf,

--- a/runner/src/snes/ppu.c
+++ b/runner/src/snes/ppu.c
@@ -173,6 +173,10 @@ static inline void PpuResetLayerPolicies(Ppu *ppu) {
   memset(ppu->wsWorldY1, 0, sizeof(ppu->wsWorldY1));
   memset(ppu->wsWorldLeft, 0, sizeof(ppu->wsWorldLeft));
   memset(ppu->wsWorldRight, 0, sizeof(ppu->wsWorldRight));
+  memset(ppu->wsElasticY0, 0, sizeof(ppu->wsElasticY0));
+  memset(ppu->wsElasticY1, 0, sizeof(ppu->wsElasticY1));
+  memset(ppu->wsElasticNSeg, 0, sizeof(ppu->wsElasticNSeg));
+  memset(ppu->wsElasticSeg, 0, sizeof(ppu->wsElasticSeg));
   memset(ppu->wsViewportInsetL, 0, sizeof(ppu->wsViewportInsetL));
   memset(ppu->wsViewportInsetR, 0, sizeof(ppu->wsViewportInsetR));
   ppu->wsWindowExpandLayers = 0;
@@ -421,6 +425,105 @@ void PpuSetWidescreenLayerWorldMirrorBandSlot(
   ppu->wsWorldRight[slot][layer] = world_right_px;
 }
 
+static void PpuClearElasticBandSlot(Ppu *ppu, uint8_t slot, uint8_t layer) {
+  ppu->wsElasticY0[slot][layer] = 0;
+  ppu->wsElasticY1[slot][layer] = 0;
+  ppu->wsElasticNSeg[slot][layer] = 0;
+  memset(ppu->wsElasticSeg[slot][layer], 0,
+         sizeof(ppu->wsElasticSeg[slot][layer]));
+}
+
+void PpuSetWidescreenLayerElasticBand(Ppu *ppu, uint8_t layer, uint8_t y0,
+                                      uint8_t y1,
+                                      const PpuWsElasticSeg *segs,
+                                      uint8_t nseg) {
+  PpuSetWidescreenLayerElasticBandSlot(ppu, 0, layer, y0, y1, segs, nseg);
+}
+
+void PpuSetWidescreenLayerElasticBandSlot(Ppu *ppu, uint8_t slot,
+                                          uint8_t layer, uint8_t y0,
+                                          uint8_t y1,
+                                          const PpuWsElasticSeg *segs,
+                                          uint8_t nseg) {
+  // See ppu.h. A band that fails validation is cleared outright rather than
+  // left half-applied: a partly-installed remap would tear the very glyphs
+  // this policy exists to protect.
+  if (slot >= kPpuWsElasticBands || layer >= 4)
+    return;
+  if (!segs || nseg == 0 || nseg > kPpuWsElasticSegs || y1 <= y0) {
+    PpuClearElasticBandSlot(ppu, slot, layer);
+    return;
+  }
+  int prev_dst_end = -0x8000;
+  for (uint8_t i = 0; i < nseg; i++) {
+    const PpuWsElasticSeg *s = &segs[i];
+    if (s->srcX1 <= s->srcX0 || s->dstX1 <= s->dstX0 || s->srcX0 < 0 ||
+        s->srcX1 > kPpuXPixels || s->dstX0 < prev_dst_end) {
+      PpuClearElasticBandSlot(ppu, slot, layer);
+      return;
+    }
+    prev_dst_end = s->dstX1;
+  }
+  ppu->wsElasticY0[slot][layer] = y0;
+  ppu->wsElasticY1[slot][layer] = y1;
+  ppu->wsElasticNSeg[slot][layer] = nseg;
+  memset(ppu->wsElasticSeg[slot][layer], 0,
+         sizeof(ppu->wsElasticSeg[slot][layer]));
+  memcpy(ppu->wsElasticSeg[slot][layer], segs,
+         (size_t)nseg * sizeof(PpuWsElasticSeg));
+}
+
+bool PpuSetWidescreenLayerElasticSplitBandSlot(
+    Ppu *ppu, uint8_t slot, uint8_t layer, uint8_t y0, uint8_t y1,
+    uint16_t left_elastic_x0, uint16_t left_elastic_x1,
+    uint16_t right_elastic_x0, uint16_t right_elastic_x1) {
+  if (slot >= kPpuWsElasticBands || layer >= 4)
+    return false;
+  const int lx0 = left_elastic_x0, lx1 = left_elastic_x1;
+  const int rx0 = right_elastic_x0, rx1 = right_elastic_x1;
+  PpuWsElasticSeg segs[kPpuWsElasticSegs];
+  uint8_t n = 0;
+  if (lx1 <= lx0 && rx1 <= rx0) {
+    // No stretchable material named: the band becomes an identity remap, i.e.
+    // the layer renders its authentic 256 columns and contributes nothing to
+    // the margins. This is what a transitional scanline wants.
+    segs[n].srcX0 = 0; segs[n].srcX1 = kPpuXPixels;
+    segs[n].dstX0 = 0; segs[n].dstX1 = kPpuXPixels;
+    n++;
+  } else {
+    if (!(lx0 >= 0 && lx0 < lx1 && lx1 <= rx0 && rx0 < rx1 &&
+          rx1 <= kPpuXPixels)) {
+      PpuClearElasticBandSlot(ppu, slot, layer);
+      return false;
+    }
+    const int L = ppu->extraLeftCur, R = ppu->extraRightCur;
+    if (lx0 > 0) {
+      segs[n].srcX0 = 0;   segs[n].srcX1 = (int16_t)lx0;
+      segs[n].dstX0 = (int16_t)(-L); segs[n].dstX1 = (int16_t)(lx0 - L);
+      n++;
+    }
+    segs[n].srcX0 = (int16_t)lx0; segs[n].srcX1 = (int16_t)lx1;
+    segs[n].dstX0 = (int16_t)(lx0 - L); segs[n].dstX1 = (int16_t)lx1;
+    n++;
+    if (rx0 > lx1) {
+      segs[n].srcX0 = (int16_t)lx1; segs[n].srcX1 = (int16_t)rx0;
+      segs[n].dstX0 = (int16_t)lx1; segs[n].dstX1 = (int16_t)rx0;
+      n++;
+    }
+    segs[n].srcX0 = (int16_t)rx0; segs[n].srcX1 = (int16_t)rx1;
+    segs[n].dstX0 = (int16_t)rx0; segs[n].dstX1 = (int16_t)(rx1 + R);
+    n++;
+    if (rx1 < kPpuXPixels) {
+      segs[n].srcX0 = (int16_t)rx1; segs[n].srcX1 = kPpuXPixels;
+      segs[n].dstX0 = (int16_t)(rx1 + R);
+      segs[n].dstX1 = (int16_t)(kPpuXPixels + R);
+      n++;
+    }
+  }
+  PpuSetWidescreenLayerElasticBandSlot(ppu, slot, layer, y0, y1, segs, n);
+  return ppu->wsElasticNSeg[slot][layer] == n;
+}
+
 bool ppu_checkOverscan(Ppu* ppu) {
   // called at (0,225)
   ppu->frameOverscan = PPU_overscan(ppu); // set if we have a overscan-frame
@@ -645,6 +748,11 @@ static void PpuWindowsSplit(PpuWindows *win, int16 *bias, int xpos) {
 static bool PpuApplyLayerAnchorBand(Ppu *ppu, uint layer, uint y,
                                     PpuWindows *win, int16 *bias) {
   if (win->nr != 1 || win->bits != 0)
+    return false;
+  // An elastic band already carries the anchoring in its rigid segments, and
+  // it remaps the merge rather than the draw. Letting both act on one line
+  // would shift the source twice.
+  if (PpuWidescreenLayerElasticBandAt(ppu, layer, (int)y) >= 0)
     return false;
   int left_end = 0;
   int right_start = 0;
@@ -1444,6 +1552,45 @@ static void PpuMergeWorldMirroredBackground(Ppu *ppu,
   }
 }
 
+// Merge one isolated layer into the live priority buffer through an elastic
+// anchor band's piecewise horizontal map: rigid segments copy 1:1 at their
+// shifted destination, elastic segments resample nearest-neighbour so the
+// margin is absorbed by stretchable material only. Only source columns
+// [0,256) -- the picture the game authored -- are ever sampled. Destination
+// columns no segment covers are left alone, so a band can express a clamp.
+// See PpuSetWidescreenLayerElasticBand.
+static void PpuMergeElasticBackground(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
+                                      const PpuPixelPrioBufs *layerbuf,
+                                      const PpuWsElasticSeg *segs, int nseg) {
+  PpuZbufType *dst = dstbuf->data;
+  const PpuZbufType *src = layerbuf->data;
+  const int xlo = -ppu->extraLeftCur;
+  const int xhi = kPpuXPixels + ppu->extraRightCur;
+  for (int i = 0; i < nseg; i++) {
+    const int src0 = segs[i].srcX0, dst0 = segs[i].dstX0;
+    const int sw = segs[i].srcX1 - src0, dw = segs[i].dstX1 - dst0;
+    if (sw <= 0 || dw <= 0)
+      continue;
+    int d0 = dst0 < xlo ? xlo : dst0;
+    int d1 = segs[i].dstX1 > xhi ? xhi : segs[i].dstX1;
+    for (int x = d0; x < d1; x++) {
+      // Nearest neighbour about each destination pixel's CENTRE:
+      // floor(((o + 1/2) * sw) / dw) in integer arithmetic. x >= dst0, so
+      // every operand is non-negative and the division is a plain floor --
+      // deterministic, no rounding mode, identical on every host. Centre
+      // sampling (rather than the cheaper floor(o*sw/dw)) is what makes the
+      // map symmetric under reflection, so a mirror-image pair of gauges
+      // stretches to the same length; it is still exactly 1:1 when sw == dw.
+      int sx = src0 + ((2 * (x - dst0) + 1) * sw) / (2 * dw);
+      if (sx < 0 || sx >= kPpuXPixels)
+        continue;
+      int di = x + kPpuExtraLeftRight, si = sx + kPpuExtraLeftRight;
+      if (src[si] > dst[di])
+        dst[di] = src[si];
+    }
+  }
+}
+
 static void PpuMergeStretchedBackground(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
                                         const PpuPixelPrioBufs *layerbuf) {
   PpuZbufType *dst = dstbuf->data;
@@ -1472,8 +1619,9 @@ static void PpuDrawBackground_4bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
   bool repeat_band = PpuWidescreenLayerRepeatBandActive(ppu, layer, y);
   bool stretch_band = PpuWidescreenLayerStretchBandActive(ppu, layer, y);
   int world_band = PpuWidescreenLayerWorldBandAt(ppu, layer, (int)y);
+  int elastic_band = PpuWidescreenLayerElasticBandAt(ppu, layer, (int)y);
   if (!(padding & (1u << layer)) && !repeat_band && !stretch_band &&
-      world_band < 0) {
+      world_band < 0 && elastic_band < 0) {
     if (PPU_bigTiles(ppu, layer))
       PpuDrawBackgroundBig(ppu, dstbuf, y, sub, layer, 4, zhi, zlo, mosaic);
     else if (mosaic)
@@ -1493,7 +1641,14 @@ static void PpuDrawBackground_4bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
     PpuDrawBackground_4bpp_mosaic(ppu, &layerbuf, y, sub, layer, zhi, zlo);
   else
     PpuDrawBackground_4bpp(ppu, &layerbuf, y, sub, layer, zhi, zlo);
-  if (world_band >= 0) {
+  if (elastic_band >= 0) {
+    // The most specific per-line statement wins: an elastic band describes
+    // this exact scanline's own horizontal layout, where a world band
+    // describes a scrolling plane whose scroll this line does not share.
+    PpuMergeElasticBackground(ppu, dstbuf, &layerbuf,
+                              ppu->wsElasticSeg[elastic_band][layer],
+                              ppu->wsElasticNSeg[elastic_band][layer]);
+  } else if (world_band >= 0) {
     // A live world band implies the layer widens on this line, so no clamp,
     // mirror, repeat or stretch policy can be in force at the same time.
     PpuMergeWorldMirroredBackground(ppu, dstbuf, &layerbuf,
@@ -1522,8 +1677,9 @@ static void PpuDrawBackground_2bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
   bool repeat_band = PpuWidescreenLayerRepeatBandActive(ppu, layer, y);
   bool stretch_band = PpuWidescreenLayerStretchBandActive(ppu, layer, y);
   int world_band = PpuWidescreenLayerWorldBandAt(ppu, layer, (int)y);
+  int elastic_band = PpuWidescreenLayerElasticBandAt(ppu, layer, (int)y);
   if (!(padding & (1u << layer)) && !repeat_band && !stretch_band &&
-      world_band < 0) {
+      world_band < 0 && elastic_band < 0) {
     if (PPU_bigTiles(ppu, layer))
       PpuDrawBackgroundBig(ppu, dstbuf, y, sub, layer, 2, zhi, zlo, mosaic);
     else if (mosaic)
@@ -1541,7 +1697,14 @@ static void PpuDrawBackground_2bpp_policy(Ppu *ppu, PpuPixelPrioBufs *dstbuf,
     PpuDrawBackground_2bpp_mosaic(ppu, &layerbuf, y, sub, layer, zhi, zlo);
   else
     PpuDrawBackground_2bpp(ppu, &layerbuf, y, sub, layer, zhi, zlo);
-  if (world_band >= 0) {
+  if (elastic_band >= 0) {
+    // The most specific per-line statement wins: an elastic band describes
+    // this exact scanline's own horizontal layout, where a world band
+    // describes a scrolling plane whose scroll this line does not share.
+    PpuMergeElasticBackground(ppu, dstbuf, &layerbuf,
+                              ppu->wsElasticSeg[elastic_band][layer],
+                              ppu->wsElasticNSeg[elastic_band][layer]);
+  } else if (world_band >= 0) {
     // A live world band implies the layer widens on this line, so no clamp,
     // mirror, repeat or stretch policy can be in force at the same time.
     PpuMergeWorldMirroredBackground(ppu, dstbuf, &layerbuf,

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -41,7 +41,25 @@ enum {
   // A layer may need more than one authored-world span per frame (e.g. an
   // arena strip above a status bar and a second one below it).
   kPpuWsWorldBands = 2,
+  // Elastic anchor bands (see PpuSetWidescreenLayerElasticBand). A raster
+  // status bar needs one band per tile row whose horizontal layout differs,
+  // plus one identity band per transitional line: GWED's fight HUD uses five.
+  kPpuWsElasticBands = 6,
+  // Piecewise segments per elastic band. Five is what a symmetric
+  // rigid/elastic/centre/elastic/rigid split costs; the spare room is for
+  // layouts that need more than one stretchable run per side.
+  kPpuWsElasticSegs = 8,
 };
+
+// One piece of an elastic anchor band's horizontal mapping: destination
+// columns [dstX0,dstX1) of the widened line are produced from source columns
+// [srcX0,srcX1) of the native 256-px rendered line. Equal widths copy 1:1 --
+// a RIGID segment, shifted if dstX0 != srcX0. A wider destination resamples
+// (nearest neighbour, integer math) -- an ELASTIC segment.
+typedef struct PpuWsElasticSeg {
+  int16_t srcX0, srcX1;   // source columns, within [0,256]
+  int16_t dstX0, dstX1;   // destination columns, within [-extraLeft,256+extraRight]
+} PpuWsElasticSeg;
 
 typedef uint16_t PpuZbufType;
 
@@ -234,6 +252,12 @@ struct Ppu {
   uint8_t wsWorldY0[kPpuWsWorldBands][4], wsWorldY1[kPpuWsWorldBands][4];
   uint16_t wsWorldLeft[kPpuWsWorldBands][4];
   uint16_t wsWorldRight[kPpuWsWorldBands][4];
+  // Piecewise horizontal remaps for the elastic anchor bands (see
+  // PpuSetWidescreenLayerElasticBand). nseg == 0 or y1 <= y0 = slot off.
+  uint8_t wsElasticY0[kPpuWsElasticBands][4];
+  uint8_t wsElasticY1[kPpuWsElasticBands][4];
+  uint8_t wsElasticNSeg[kPpuWsElasticBands][4];
+  PpuWsElasticSeg wsElasticSeg[kPpuWsElasticBands][4][kPpuWsElasticSegs];
   // Treat [left_px, 256-right_px) as a layer's authentic visible viewport
   // when a host line enhancer supplies the expanded scene. This lets the
   // layer's normally hidden/blank native edge columns reveal lower layers.
@@ -411,6 +435,33 @@ static inline int PpuWidescreenLayerWorldBandAt(
         y >= ppu->wsWorldY0[slot][layer] &&
         y < ppu->wsWorldY1[slot][layer] &&
         ppu->wsWorldRight[slot][layer] > ppu->wsWorldLeft[slot][layer])
+      return (int)slot;
+  }
+  return -1;
+}
+
+// Which elastic anchor band, if any, governs BG(layer+1) on scanline y.
+// Returns the band slot, or -1 for the ordinary (unremapped) merge.
+// Inert unless a side margin is live. Deliberately shares the world band's
+// precedence rule -- clamp band, layer mask, mirror/repeat/stretch and the
+// BG3-widen gate all win over this one -- so a game excludes a line from the
+// remap exactly the way it excludes one from a world band. Where the two do
+// overlap the elastic band wins, because it is the more specific statement
+// about the same scanline: the world band describes a scrolling plane and the
+// elastic band a raster-split status bar pinned to its own scroll.
+static inline int PpuWidescreenLayerElasticBandAt(
+    const Ppu *ppu, unsigned int layer, int y) {
+  if (layer >= 4 || !(ppu->extraLeftCur | ppu->extraRightCur))
+    return -1;
+  int widest = ppu->extraLeftCur > ppu->extraRightCur ? ppu->extraLeftCur
+                                                      : ppu->extraRightCur;
+  if (!PpuWidescreenLayerExtra(ppu, layer, y, widest))
+    return -1;
+  for (unsigned int slot = 0; slot < kPpuWsElasticBands; slot++) {
+    if (ppu->wsElasticNSeg[slot][layer] &&
+        ppu->wsElasticY1[slot][layer] > ppu->wsElasticY0[slot][layer] &&
+        y >= ppu->wsElasticY0[slot][layer] &&
+        y < ppu->wsElasticY1[slot][layer])
       return (int)slot;
   }
   return -1;
@@ -685,5 +736,84 @@ void PpuSetWidescreenLayerWorldMirrorBand(Ppu *ppu, uint8_t layer, uint8_t y0,
 void PpuSetWidescreenLayerWorldMirrorBandSlot(
     Ppu *ppu, uint8_t slot, uint8_t layer, uint8_t y0, uint8_t y1,
     uint16_t world_left_px, uint16_t world_right_px);
+
+// ELASTIC ANCHOR BANDS -- anchor a raster status bar's chrome to the widened
+// viewport edges and bridge the gap that opens by stretching only the
+// material that can survive being stretched.
+//
+// PpuSetWidescreenLayerAnchorBand already moves a status bar's left and right
+// chunks out to the expanded edges. That is only half an answer whenever the
+// bar is ONE continuous graphic with no transparent column to hide the seam:
+// anchoring then opens an `extra`-px hole on each side of the centre group,
+// through which lower layers and the backdrop show. PpuSetWidescreenLayer-
+// StretchBand closes such a hole, but it scales the WHOLE line, which
+// distorts every glyph on it.
+//
+// An elastic band splits the difference per column. On scanlines [y0,y1) of
+// BG(layer+1), destination column x in [-extraLeft, 256+extraRight) is
+// produced from the native 256-px rendered line by an explicit piecewise map:
+//   for the segment whose [dstX0,dstX1) contains x, with o = x - dstX0,
+//   sw = srcX1 - srcX0 and dw = dstX1 - dstX0:
+//       sx = srcX0 + ((2*o + 1) * sw) / (2 * dw)
+// i.e. nearest neighbour about each destination pixel's centre, in integer
+// arithmetic (no rounding mode, no float, identical on every host). Equal
+// source and destination widths make that an exact 1:1 copy, so a RIGID
+// segment is byte-exact wherever it is placed -- that is what keeps names,
+// digits, labels and markers pixel-perfect while they move outward. A wider
+// destination resamples, which is exactly invisible when the source run's
+// columns are identical to each other, and which preserves a gauge's fill
+// FRACTION when the run is a bar: k filled of n source columns become
+// round(k*dw/n) of dw destination columns within a pixel, so full stays full,
+// empty stays empty and 37% stays 37%. Centre sampling rather than
+// floor(o*sw/dw) is what makes the map symmetric under reflection, so a
+// mirror-image pair of gauges stretches to the same length.
+//
+// Segments must be ascending and non-overlapping in destination space; a band
+// that is not is rejected outright rather than half-applied. Destination
+// columns no segment covers stay transparent, so a band can also express a
+// pure clamp (one segment {0,256,0,256}) for a transitional line.
+//
+// Implemented at the merge step of the Mode-1 policy dispatchers, so it covers
+// the 4bpp, 2bpp, big-tile and mosaic draw paths in one place. Only source
+// columns [0,256) are sampled -- the native picture the game authored, never
+// the margin columns the widened render happens to reach. Presentation-only:
+// no emulated register is touched, the fields live outside every savestate
+// span, and the whole policy is inert while the margin is 0. Requires
+// kPpuRenderFlags_NewRenderer. Re-apply per frame like the other widescreen
+// setters (PpuSetExtraSpace* clears them); slot 0 is the band set by the
+// convenience form.
+//
+// A layer must not carry an elastic band and an anchor band on the same line:
+// the anchor band stands down where an elastic band is live, since the
+// elastic band's rigid segments already express the anchoring.
+void PpuSetWidescreenLayerElasticBand(Ppu *ppu, uint8_t layer, uint8_t y0,
+                                      uint8_t y1,
+                                      const PpuWsElasticSeg *segs,
+                                      uint8_t nseg);
+void PpuSetWidescreenLayerElasticBandSlot(Ppu *ppu, uint8_t slot,
+                                          uint8_t layer, uint8_t y0,
+                                          uint8_t y1,
+                                          const PpuWsElasticSeg *segs,
+                                          uint8_t nseg);
+
+// Build and install the symmetric five-segment layout a centred status bar
+// wants, from the two stretchable source runs alone:
+//
+//   [0, left_elastic_x0)             rigid, shifted out to the left edge
+//   [left_elastic_x0, ..._x1)        elastic, absorbs the left margin
+//   [left_elastic_x1, right_..._x0)  rigid, unshifted (holds the centre group)
+//   [right_elastic_x0, ..._x1)       elastic, absorbs the right margin
+//   [right_elastic_x1, 256)          rigid, shifted out to the right edge
+//
+// The elastic runs are what a game measures: pick spans whose columns are
+// identical to one another (plain chrome) or which are a gauge's interior.
+// Empty runs (x1 <= x0 for both sides) install the identity/clamp band.
+// Returns false and leaves the slot cleared if the spans are not ordered
+// 0 <= lx0 < lx1 <= rx0 < rx1 <= 256. Reads the CURRENT margin
+// (extraLeftCur/extraRightCur), so it must be called after PpuSetExtraSpace*.
+bool PpuSetWidescreenLayerElasticSplitBandSlot(
+    Ppu *ppu, uint8_t slot, uint8_t layer, uint8_t y0, uint8_t y1,
+    uint16_t left_elastic_x0, uint16_t left_elastic_x1,
+    uint16_t right_elastic_x0, uint16_t right_elastic_x1);
 
 #endif

--- a/runner/src/snes/ppu.h
+++ b/runner/src/snes/ppu.h
@@ -38,6 +38,9 @@ enum {
   kPpuBufWidth = kPpuXPixels + kPpuExtraLeftRight * 2,
   // Split-screen games can assign distinct anchor layouts to each viewport.
   kPpuWsAnchorBands = 2,
+  // A layer may need more than one authored-world span per frame (e.g. an
+  // arena strip above a status bar and a second one below it).
+  kPpuWsWorldBands = 2,
 };
 
 typedef uint16_t PpuZbufType;
@@ -226,6 +229,11 @@ struct Ppu {
   uint8_t wsAnchorRightStart[kPpuWsAnchorBands][4];
   // Skip offscreen staging columns before sampling a layer's side margins.
   uint8_t wsMarginGapL[4], wsMarginGapR[4];
+  // Authored-world spans, in tilemap pixels, for the world-mirror bands (see
+  // PpuSetWidescreenLayerWorldMirrorBand). y1<=y0 or right<=left = off.
+  uint8_t wsWorldY0[kPpuWsWorldBands][4], wsWorldY1[kPpuWsWorldBands][4];
+  uint16_t wsWorldLeft[kPpuWsWorldBands][4];
+  uint16_t wsWorldRight[kPpuWsWorldBands][4];
   // Treat [left_px, 256-right_px) as a layer's authentic visible viewport
   // when a host line enhancer supplies the expanded scene. This lets the
   // layer's normally hidden/blank native edge columns reveal lower layers.
@@ -381,6 +389,31 @@ static inline int PpuWidescreenLayerExtra(
   if (layer != 2)
     return extra;
   return (ppu->wsBg3WidenY && y >= ppu->wsBg3WidenY) ? extra : 0;
+}
+
+// Which world-mirror band, if any, governs BG(layer+1) on scanline y.
+// Returns the band slot, or -1 for natural (unreflected) tilemap rendering.
+// Deliberately inert unless a side margin is actually live, and every other
+// per-line policy wins over this one: on a line the layer does not widen
+// (layer mask, clamp, mirror, repeat, stretch, BG3-widen) there is no margin
+// to reflect into, and the line's hScroll may not even be the world camera --
+// a raster-split status bar pinned to hScroll 0 is the usual case.
+static inline int PpuWidescreenLayerWorldBandAt(
+    const Ppu *ppu, unsigned int layer, int y) {
+  if (layer >= 4 || !(ppu->extraLeftCur | ppu->extraRightCur))
+    return -1;
+  int widest = ppu->extraLeftCur > ppu->extraRightCur ? ppu->extraLeftCur
+                                                      : ppu->extraRightCur;
+  if (!PpuWidescreenLayerExtra(ppu, layer, y, widest))
+    return -1;
+  for (unsigned int slot = 0; slot < kPpuWsWorldBands; slot++) {
+    if (ppu->wsWorldY1[slot][layer] > ppu->wsWorldY0[slot][layer] &&
+        y >= ppu->wsWorldY0[slot][layer] &&
+        y < ppu->wsWorldY1[slot][layer] &&
+        ppu->wsWorldRight[slot][layer] > ppu->wsWorldLeft[slot][layer])
+      return (int)slot;
+  }
+  return -1;
 }
 
 
@@ -615,5 +648,42 @@ void PpuSetWidescreenLayerMarginGap(Ppu *ppu, uint8_t layer, uint8_t left_px,
 // framebuffer padding that was hidden on the original display.
 void PpuSetWidescreenLayerViewportInset(Ppu *ppu, uint8_t layer,
                                         uint8_t left_px, uint8_t right_px);
+
+// Reflect BG(layer+1) about the edges of its AUTHORED WORLD rather than about
+// the viewport edge, on scanlines [y0,y1).
+//
+// PpuSetWidescreenLayerMirror/RepeatBand fold the rendered native scanline
+// back at screen x=0/255. That is right for a layer whose content ends where
+// the original screen ends, and wrong for a bounded arena: mid-scroll the
+// margins of such a layer hold genuine authored tilemap art, and folding at
+// the viewport edge throws it away.
+//
+// This policy leaves those columns alone and only intervenes where the
+// tilemap runs out of authored content. Per pixel, with `x` the tilemap X
+// this line renders at (the line's own hScroll + screen x, in map pixels and
+// before the map's own wrap):
+//   x <  world_left_px   ->  sample 2*world_left_px  - 1 - x
+//   x >= world_right_px  ->  sample 2*world_right_px - 1 - x
+//   otherwise            ->  render naturally
+// A pixel whose reflection also lands outside [left,right) is left
+// transparent, so lower layers and the backdrop still fill it.
+//
+// The rule is applied uniformly to margin and authentic columns; in practice a
+// game clamps the camera so only margins can leave the world. Phase comes from
+// the scroll the PPU rendered the line with, never from a WRAM camera mirror
+// (WIDESCREEN_PATTERNS P1). Presentation-only: no emulated register is
+// touched, the fields live outside every savestate span, and the policy is
+// inert while the widescreen margin is 0.
+//
+// Applies to the Mode-1 policy-dispatched 4bpp/2bpp paths, including their
+// big-tile and mosaic variants. Requires kPpuRenderFlags_NewRenderer.
+// Re-apply per frame like the other widescreen setters; slot 0 is the band set
+// by the convenience function.
+void PpuSetWidescreenLayerWorldMirrorBand(Ppu *ppu, uint8_t layer, uint8_t y0,
+                                          uint8_t y1, uint16_t world_left_px,
+                                          uint16_t world_right_px);
+void PpuSetWidescreenLayerWorldMirrorBandSlot(
+    Ppu *ppu, uint8_t slot, uint8_t layer, uint8_t y0, uint8_t y1,
+    uint16_t world_left_px, uint16_t world_right_px);
 
 #endif

--- a/tests/ppu/ppu_elastic_band_test.c
+++ b/tests/ppu/ppu_elastic_band_test.c
@@ -1,0 +1,485 @@
+/* Synthetic regression for PpuSetWidescreenLayerElasticBand /
+ * ...ElasticSplitBandSlot (WIDESCREEN_PATTERNS P2c: a continuous status bar
+ * anchors its rigid groups to the widened edges and bridges the gap that
+ * opens by stretching only material that can survive being stretched).
+ *
+ * The scene is a GWED-shaped Mode 1 BG1 status row: one tile row whose 256
+ * native columns each carry a UNIQUE colour, so a rendered pixel names the
+ * source column it came from and no mapping error can hide. A second variant
+ * paints a pair of mirror-image GAUGES -- k filled of n, depleting from the
+ * outer end, exactly like GWED's health and boost bars -- so the fill
+ * fraction can be measured after the remap.
+ *
+ * The load-bearing assertions:
+ *   1. rigid segments are BYTE-EXACT at their shifted destination (this is
+ *      what keeps names, digits, labels and markers pixel-perfect while they
+ *      move to the 16:9 edges, and what a whole-line stretch band destroys);
+ *   2. the centre group is byte-identical to the unpolicied native render;
+ *   3. every destination column equals the documented mapping's source
+ *      column, and elastic segments preserve their endpoints;
+ *   4. a run of identical source columns stretches to identical output
+ *      columns, so a plain-chrome bridge is exactly invisible;
+ *   5. a gauge's fill FRACTION survives -- k of n becomes within 1px of
+ *      round(k*(n+extra)/n) of n+extra, for EVERY k, and the mirror-image
+ *      gauge agrees within a pixel;
+ *   6. no destination column in [-extra, 256+extra) is left unpainted, i.e.
+ *      the anchoring opens no transparent gap;
+ *   7. precedence and inertness: unbanded output is unchanged, the band is
+ *      inert at authentic 256 width, clamp/mirror win over it, it wins over
+ *      an overlapping world band, the degenerate form renders exactly like a
+ *      clamp band, and invalid input clears the slot instead of half-applying.
+ */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "snes/ppu.h"
+#include "snes/snes.h"
+
+Snes *g_snes;
+
+/* ppu.c reaches runtime globals defined in snes.c / common_rtl.c and the
+ * ws_shadow streaming-tilemap helpers. This harness links ppu.c on its own;
+ * none of them participate in the elastic band policy. */
+int snes_frame_counter;
+unsigned char g_snesrecomp_last_hdmaen;
+
+uint16_t WsShadowTile(int layer, int screen_x, uint32_t wrapped_y,
+                      uint16_t hscroll, uint16_t map_word_offset,
+                      uint16_t real_tile) {
+    (void)layer; (void)screen_x; (void)wrapped_y; (void)hscroll;
+    (void)map_word_offset;
+    return real_tile;
+}
+bool WsShadowLayerActive(int layer) { (void)layer; return false; }
+uint32_t WsShadowWorldX(int layer) { (void)layer; return 0; }
+uint32_t WsShadowPresentWorldY(int layer, int screen_x) {
+    (void)layer; (void)screen_x; return 0;
+}
+uint32_t WsShadowScrollY(int layer) { (void)layer; return 0; }
+void WsShadowOnVramWrite(uint16_t word_adr, uint16_t value) {
+    (void)word_adr; (void)value;
+}
+
+enum {
+    kExtra = 43,                 /* GWED's 16:9 margin, per side */
+    kWide = kPpuXPixels + kExtra * 2,
+    kLine = 1,                   /* ppu_runLine(1) renders framebuffer row 0 */
+    kMapBaseWords = 0x0000,
+    kCharBaseWords = 0x1000,
+    /* GWED's measured fight-HUD gauge row: the frame cap is rigid, the bar
+     * interior is elastic, and the TIME pod stays centred. */
+    kBarL0 = 8, kBarL1 = 120, kBarR0 = 136, kBarR1 = 248,
+    kBarLen = kBarL1 - kBarL0,
+};
+
+static int failures;
+
+static void check(bool condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message);
+        failures++;
+    }
+}
+
+/* Write one 4bpp tile row. Pixel 0 is leftmost (plane bit 7). */
+static void put_tile_row(Ppu *ppu, int tile, int row, const int *px) {
+    uint16_t w0 = 0, w1 = 0;
+    for (int p = 0; p < 8; p++) {
+        int v = px[p] & 0xf;
+        int bit = 7 - p;
+        w0 |= (uint16_t)(((v >> 0) & 1) << bit);
+        w0 |= (uint16_t)(((v >> 1) & 1) << (bit + 8));
+        w1 |= (uint16_t)(((v >> 2) & 1) << bit);
+        w1 |= (uint16_t)(((v >> 3) & 1) << (bit + 8));
+    }
+    ppu->vram[(kCharBaseWords + tile * 16 + row) & 0x7fff] = w0;
+    ppu->vram[(kCharBaseWords + tile * 16 + 8 + row) & 0x7fff] = w1;
+}
+
+/* `column_value(x)` supplies the 4bpp pixel index for native column x; the
+ * tile column's palette supplies the high nibble of the CGRAM entry, so a
+ * column's final colour is cgram[palette*16 + index]. */
+typedef int (*ColumnFn)(int x);
+
+/* Column labelling. A 4bpp layer can show at most 15 indices x 8 palettes and
+ * the palette is a per-TILE attribute, so at most 8 tile columns -- 64 native
+ * columns -- can be labelled uniquely; 256 unique labels are impossible here.
+ * The labelling below is therefore exactly period 64 (index = x mod 8 within
+ * the tile, palette = tile column mod 8), which is the widest window a Mode 1
+ * BG can distinguish. Consequence, stated plainly: a mapping error of exactly
+ * 64, 128 or 192 columns would alias; every smaller error shows. */
+static int col_distinct(int x) { return (x % 8) + 1; }
+
+/* Gauge state, set by the caller before rendering. `g_filled` of the left
+ * bar's kBarLen columns are filled from the INNER end, so the empty part is
+ * at the outer end; the right bar is its mirror image. */
+static int g_filled;
+static int col_gauge(int x) {
+    if (x >= kBarL0 && x < kBarL1)
+        return (x >= kBarL1 - g_filled) ? 5 : 1;
+    if (x >= kBarR0 && x < kBarR1)
+        return (x < kBarR0 + g_filled) ? 5 : 1;
+    return 9;   /* rigid chrome and the centre pod: uniform but distinct */
+}
+
+/* The documented mapping, restated so the render can be checked against it. */
+static int map_src(const PpuWsElasticSeg *s, int x) {
+    int sw = s->srcX1 - s->srcX0, dw = s->dstX1 - s->dstX0;
+    return s->srcX0 + ((2 * (x - s->dstX0) + 1) * sw) / (2 * dw);
+}
+
+static void setup_status_bg1(Ppu *ppu, ColumnFn fn, bool uniform_palette) {
+    ppu->inidisp = 0x0f;
+    ppu->bgmode = 1;
+    ppu->screenEnabled[0] = 0x01;   /* BG1 on the main screen only */
+    ppu->screenEnabled[1] = 0x00;
+    ppu->screenWindowed[0] = 0x00;  /* GWED disables window clipping here */
+    ppu->screenWindowed[1] = 0x00;
+    ppu->bgXsc[0] = 0x03;           /* map at word 0, 64x64 */
+    ppu->bgTileAdr = 0x0001;        /* BG1 char base = word 0x1000 */
+    ppu->vScroll[0] = 0;
+
+    memset(ppu->vram, 0, sizeof ppu->vram);
+    memset(ppu->cgram, 0, sizeof ppu->cgram);
+    for (int i = 1; i < 256; i++)
+        ppu->cgram[i] = (uint16_t)(0x0139 * i + 1);   /* all distinct, non-zero */
+
+    /* 32 tiles, one per native tile column, each painted from `fn`. */
+    for (int t = 0; t < 32; t++) {
+        for (int row = 0; row < 8; row++) {
+            int px[8];
+            for (int p = 0; p < 8; p++)
+                px[p] = fn(t * 8 + p);
+            put_tile_row(ppu, t + 1, row, px);
+        }
+    }
+    for (int scr = 0; scr < 2; scr++)
+        for (int row = 0; row < 32; row++)
+            for (int col = 0; col < 32; col++) {
+                int pal = uniform_palette ? 0 : (col & 7);
+                ppu->vram[kMapBaseWords + scr * 0x400 + row * 32 + col] =
+                    (uint16_t)((col + 1) | (pal << 10));
+            }
+}
+
+enum PolicyKind {
+    kNoPolicy = 0,
+    kSplitBand,        /* the GWED gauge-row split */
+    kClampOnly,
+    kClampAndSplit,
+    kMirrorOnly,
+    kMirrorAndSplit,
+    kWorldAndSplit,
+    kIdentityBand,     /* the degenerate "clamp" form of the split builder */
+};
+
+static void render_wide(Ppu *ppu, uint32_t *out, ColumnFn fn,
+                        enum PolicyKind kind) {
+    const bool uniform_palette = (fn == col_gauge);
+    memset(out, 0, sizeof(uint32_t) * kWide);
+    ppu_reset(ppu);
+    PpuBeginDrawing(ppu, (uint8_t *)out, sizeof(uint32_t) * kWide,
+                    kPpuRenderFlags_NewRenderer);
+    setup_status_bg1(ppu, fn, uniform_palette);
+    PpuSetExtraSpace(ppu, kExtra);   /* resets layer policies: must come first */
+    if (kind == kClampOnly || kind == kClampAndSplit)
+        PpuSetWidescreenLayerClampBand(ppu, 0, 0, 225);
+    if (kind == kMirrorOnly || kind == kMirrorAndSplit)
+        PpuSetWidescreenLayerMirror(ppu, 0x01);
+    if (kind == kWorldAndSplit)
+        PpuSetWidescreenLayerWorldMirrorBand(ppu, 0, 0, 225, 0, kPpuXPixels);
+    if (kind == kIdentityBand) {
+        check(PpuSetWidescreenLayerElasticSplitBandSlot(ppu, 0, 0, 0, 225,
+                                                        0, 0, 0, 0),
+              "identity split band accepted");
+    } else if (kind == kSplitBand || kind == kClampAndSplit ||
+               kind == kMirrorAndSplit || kind == kWorldAndSplit) {
+        check(PpuSetWidescreenLayerElasticSplitBandSlot(ppu, 0, 0, 0, 225,
+                                                        kBarL0, kBarL1,
+                                                        kBarR0, kBarR1),
+              "gauge split band accepted");
+    }
+    ppu->hScroll[0] = 0;             /* the raster HUD pins hScroll to 0 */
+    ppu_runLine(ppu, 0);
+    ppu->hScroll[0] = 0;
+    ppu_runLine(ppu, kLine);
+}
+
+/* Count columns of one gauge that hold the filled colour. `lo`/`hi` bound it
+ * in destination space. */
+static int count_filled(const uint32_t *buf, int lo, int hi, uint32_t filled) {
+    int n = 0;
+    for (int x = lo; x < hi; x++)
+        if (buf[x + kExtra] == filled)
+            n++;
+    return n;
+}
+
+int main(void) {
+    Ppu *ppu = ppu_init();
+    if (!ppu) return 2;
+
+    uint32_t *base = malloc(sizeof(uint32_t) * kWide);
+    uint32_t *out = malloc(sizeof(uint32_t) * kWide);
+    uint32_t *ref = malloc(sizeof(uint32_t) * kWide);
+    if (!base || !out || !ref) { fprintf(stderr, "FAIL: oom\n"); return 2; }
+
+    /* The five segments the split builder must produce for GWED's gauge row. */
+    const PpuWsElasticSeg expect[5] = {
+        { 0,       kBarL0,      -kExtra,           kBarL0 - kExtra },
+        { kBarL0,  kBarL1,      kBarL0 - kExtra,   kBarL1 },
+        { kBarL1,  kBarR0,      kBarL1,            kBarR0 },
+        { kBarR0,  kBarR1,      kBarR0,            kBarR1 + kExtra },
+        { kBarR1,  kPpuXPixels, kBarR1 + kExtra,   kPpuXPixels + kExtra },
+    };
+
+    render_wide(ppu, base, col_distinct, kNoPolicy);
+    render_wide(ppu, out, col_distinct, kSplitBand);
+
+    check(ppu->wsElasticNSeg[0][0] == 5,
+          "the split builder emits five segments");
+    check(memcmp(ppu->wsElasticSeg[0][0], expect, sizeof expect) == 0,
+          "the split builder's segments are the documented layout");
+    check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) == 0,
+          "a configured elastic band is reported for its scanlines");
+
+    /* Sanity: the synthetic line really does label its columns, or every
+     * mapping assertion below would be vacuous. Uniqueness is asserted over
+     * the widest window a 4bpp layer can express (see col_distinct). */
+    {
+        int dupes = 0;
+        for (int i = 0; i < kPpuXPixels; i++)
+            for (int j = i + 1; j < kPpuXPixels && j - i < 64; j++)
+                if (base[i + kExtra] == base[j + kExtra])
+                    dupes++;
+        check(dupes == 0,
+              "native columns are uniquely coloured within any 64-px window");
+    }
+
+    {
+        /* 1. Rigid segments byte-exact at their shifted destination. */
+        int rigid_mismatch = 0, rigid_cols = 0;
+        for (int i = 0; i < 5; i++) {
+            if (expect[i].srcX1 - expect[i].srcX0 !=
+                expect[i].dstX1 - expect[i].dstX0)
+                continue;   /* elastic */
+            for (int x = expect[i].dstX0; x < expect[i].dstX1; x++) {
+                int sx = expect[i].srcX0 + (x - expect[i].dstX0);
+                rigid_cols++;
+                if (out[x + kExtra] != base[sx + kExtra])
+                    rigid_mismatch++;
+            }
+        }
+        check(rigid_cols == kBarL0 + (kBarR0 - kBarL1) +
+                            (kPpuXPixels - kBarR1),
+              "the rigid segments cover the caps and the centre group");
+        check(rigid_mismatch == 0,
+              "rigid segments are byte-exact at their shifted destination");
+
+        /* 2. The centre group does not move at all. */
+        check(memcmp(out + kBarL1 + kExtra, base + kBarL1 + kExtra,
+                     sizeof(uint32_t) * (kBarR0 - kBarL1)) == 0,
+              "the centre group is byte-identical to the native render");
+
+        /* The anchored groups really did move outward. */
+        check(out[0] == base[0 + kExtra],
+              "the left frame cap is anchored to the widened left edge");
+        check(out[kWide - 1] == base[kPpuXPixels - 1 + kExtra],
+              "the right frame cap is anchored to the widened right edge");
+        check(out[kExtra] != base[kExtra],
+              "native column 0 no longer shows column 0 (the group shifted)");
+
+        /* 3. Every destination column equals the documented mapping, and the
+         *    elastic segments preserve their endpoints. */
+        int map_mismatch = 0;
+        for (int i = 0; i < 5; i++) {
+            for (int x = expect[i].dstX0; x < expect[i].dstX1; x++) {
+                int sx = map_src(&expect[i], x);
+                if (sx < 0 || sx >= kPpuXPixels)
+                    continue;
+                if (out[x + kExtra] != base[sx + kExtra])
+                    map_mismatch++;
+            }
+            int sw = expect[i].srcX1 - expect[i].srcX0;
+            int dw = expect[i].dstX1 - expect[i].dstX0;
+            if (sw == dw)
+                continue;
+            check(out[expect[i].dstX0 + kExtra] ==
+                      base[expect[i].srcX0 + kExtra],
+                  "an elastic segment starts on its first source column");
+            check(out[expect[i].dstX1 - 1 + kExtra] ==
+                      base[expect[i].srcX1 - 1 + kExtra],
+                  "an elastic segment ends on its last source column");
+        }
+        check(map_mismatch == 0,
+              "every destination column samples the documented source column");
+
+        /* 6. Nothing left transparent: the anchoring opened no gap. */
+        int blank = 0;
+        for (int x = 0; x < kWide; x++)
+            if (out[x] == 0)
+                blank++;
+        check(blank == 0, "no destination column is left unpainted");
+    }
+
+    /* 4. A run of identical source columns stretches to identical output
+     *    columns -- the property that makes a plain-chrome bridge invisible. */
+    {
+        g_filled = kBarLen;              /* both gauges completely full */
+        render_wide(ppu, out, col_gauge, kSplitBand);
+        int nonuniform = 0;
+        for (int x = kBarL0 - kExtra; x < kBarL1 - 1; x++)
+            if (out[x + kExtra] != out[x + 1 + kExtra])
+                nonuniform++;
+        check(nonuniform == 0,
+              "a uniform source run stretches to a uniform destination run");
+    }
+
+    /* 5. Fill fraction survives the stretch, for every k. */
+    {
+        g_filled = kBarLen;
+        render_wide(ppu, base, col_gauge, kNoPolicy);
+        const uint32_t filled_rgb = base[(kBarL1 - 1) + kExtra];
+        const uint32_t empty_rgb = base[(kBarL0 - 1) + kExtra];
+        check(filled_rgb != empty_rgb, "gauge fill and chrome differ");
+        const int dw = kBarLen + kExtra;
+        int worst = 0, worst_k = -1, worst_asym = 0;
+        for (int k = 0; k <= kBarLen; k++) {
+            g_filled = k;
+            render_wide(ppu, out, col_gauge, kSplitBand);
+            int got = count_filled(out, kBarL0 - kExtra, kBarL1, filled_rgb);
+            int got_r = count_filled(out, kBarR0, kBarR1 + kExtra, filled_rgb);
+            int want = (k * dw + kBarLen / 2) / kBarLen;  /* round(k*dw/n) */
+            int err = got > want ? got - want : want - got;
+            if (err > worst) { worst = err; worst_k = k; }
+            int asym = got > got_r ? got - got_r : got_r - got;
+            if (asym > worst_asym) worst_asym = asym;
+            if (k == 0)
+                check(got == 0 && got_r == 0, "an empty gauge stays empty");
+            if (k == kBarLen)
+                check(got == dw && got_r == dw, "a full gauge stays full");
+        }
+        if (worst > 1)
+            fprintf(stderr, "  worst fill error %d px at k=%d\n", worst, worst_k);
+        check(worst <= 1, "gauge fill fraction is preserved within 1 px");
+        check(worst_asym <= 1,
+              "the mirror-image gauge stretches to the same length within 1 px");
+    }
+
+    /* 7. Precedence, inertness and rejection. */
+    {
+        render_wide(ppu, base, col_distinct, kClampOnly);
+        render_wide(ppu, out, col_distinct, kIdentityBand);
+        check(memcmp(base, out, sizeof(uint32_t) * kWide) == 0,
+              "an identity split band renders exactly like a clamp band");
+
+        render_wide(ppu, out, col_distinct, kClampAndSplit);
+        check(memcmp(base, out, sizeof(uint32_t) * kWide) == 0,
+              "clamp band wins over an overlapping elastic band");
+
+        render_wide(ppu, ref, col_distinct, kMirrorOnly);
+        render_wide(ppu, out, col_distinct, kMirrorAndSplit);
+        check(memcmp(ref, out, sizeof(uint32_t) * kWide) == 0,
+              "layer mirror wins over an overlapping elastic band");
+
+        /* But an elastic band wins over an overlapping WORLD band: it is the
+         * more specific statement about this scanline's own layout. */
+        render_wide(ppu, ref, col_distinct, kSplitBand);
+        render_wide(ppu, out, col_distinct, kWorldAndSplit);
+        check(memcmp(ref, out, sizeof(uint32_t) * kWide) == 0,
+              "an elastic band wins over an overlapping world band");
+    }
+
+    /* Inert at authentic width. */
+    {
+        uint32_t native[kPpuXPixels], banded[kPpuXPixels];
+        for (int pass = 0; pass < 2; pass++) {
+            uint32_t *dst = pass ? banded : native;
+            memset(dst, 0, sizeof native);
+            ppu_reset(ppu);
+            PpuBeginDrawing(ppu, (uint8_t *)dst,
+                            sizeof(uint32_t) * kPpuXPixels,
+                            kPpuRenderFlags_NewRenderer);
+            setup_status_bg1(ppu, col_distinct, false);
+            if (pass) {
+                PpuWsElasticSeg s[2] = {
+                    { 0, kBarL1, -kExtra, kBarL1 },
+                    { kBarL1, kPpuXPixels, kBarL1, kPpuXPixels + kExtra },
+                };
+                PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, s, 2);
+            }
+            ppu->hScroll[0] = 0;
+            ppu_runLine(ppu, 0);
+            ppu->hScroll[0] = 0;
+            ppu_runLine(ppu, kLine);
+        }
+        check(memcmp(native, banded, sizeof native) == 0,
+              "an elastic band is inert at authentic 256 width");
+    }
+
+    /* Validation: bad input clears the slot rather than half-applying it. */
+    {
+        PpuWsElasticSeg good[2] = {
+            { 0, kBarL1, -kExtra, kBarL1 },
+            { kBarL1, kPpuXPixels, kBarL1, kPpuXPixels + kExtra },
+        };
+        ppu_reset(ppu);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, good, 2);
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) == 0,
+              "a valid explicit band is installed");
+
+        PpuWsElasticSeg overlap[2] = {
+            { 0, kBarL1, -kExtra, kBarL1 },
+            { kBarL1, kPpuXPixels, kBarL1 - 4, kPpuXPixels + kExtra },
+        };
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, overlap, 2);
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) < 0,
+              "destination-overlapping segments are rejected outright");
+
+        PpuWsElasticSeg oob[1] = { { 0, kPpuXPixels + 1, 0, kPpuXPixels } };
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, good, 2);
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, oob, 1);
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) < 0,
+              "a source range past 256 is rejected outright");
+
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, good, 2);
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 0, good, 2);
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) < 0,
+              "an empty scanline range disables the slot");
+
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, good, 2);
+        PpuSetWidescreenLayerElasticBand(ppu, 0, 0, 225, good, 0);
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) < 0,
+              "a zero-segment band disables the slot");
+
+        check(!PpuSetWidescreenLayerElasticSplitBandSlot(ppu, 1, 0, 0, 225,
+                                                         120, 8, 136, 248),
+              "an inverted left elastic run is refused");
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, kLine) < 0,
+              "a refused split band leaves no slot configured");
+        check(!PpuSetWidescreenLayerElasticSplitBandSlot(ppu, 1, 0, 0, 225,
+                                                         8, 200, 136, 248),
+              "overlapping left/right elastic runs are refused");
+
+        /* Slots are independently addressable and per-scanline. */
+        check(PpuSetWidescreenLayerElasticSplitBandSlot(ppu, 2, 0, 100, 200,
+                                                        kBarL0, kBarL1,
+                                                        kBarR0, kBarR1),
+              "slot 2 accepts a band");
+        check(PpuWidescreenLayerElasticBandAt(ppu, 0, 150) == 2 &&
+              PpuWidescreenLayerElasticBandAt(ppu, 0, 50) < 0,
+              "slot 2 is independently addressable");
+        check(kPpuWsElasticBands >= 5,
+              "there are enough slots for GWED's per-tile-row HUD layout");
+    }
+
+    free(base);
+    free(out);
+    free(ref);
+    ppu_free(ppu);
+    printf("ppu_elastic_band_test: %s\n", failures ? "FAIL" : "PASS");
+    return failures ? 1 : 0;
+}

--- a/tests/ppu/ppu_world_mirror_test.c
+++ b/tests/ppu/ppu_world_mirror_test.c
@@ -1,0 +1,308 @@
+/* Synthetic regression for PpuSetWidescreenLayerWorldMirrorBand
+ * (WIDESCREEN_PATTERNS P2b: bounded arenas reflect about the authored world
+ * edge, not the viewport edge).
+ *
+ * The scene is a GWED-shaped Mode 1 BG1: a 64x64 tilemap authored only over
+ * map px [64, 448), tile 0 either side, with the camera clamped so that the
+ * authentic 256 columns never leave the authored span and only the widescreen
+ * margins can. No game ROM, generated code, or platform frontend is needed.
+ *
+ * The load-bearing assertions:
+ *   1. every pixel whose tilemap X is inside the authored world renders
+ *      byte-identically to the no-policy render (this is what a viewport-space
+ *      mirror gets wrong mid-scroll: it discards real authored margin art);
+ *   2. every pixel outside it equals the reflected source column;
+ *   3. at the camera walls the outermost margin column is non-blank, and
+ *      differs from what a viewport-space fold would have produced;
+ *   4. with no band configured the wide output is unchanged, and clamp /
+ *      mirror bands still win over a world band that overlaps them.
+ */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "snes/ppu.h"
+#include "snes/snes.h"
+
+Snes *g_snes;
+
+/* ppu.c reaches runtime globals defined in snes.c / common_rtl.c and the
+ * ws_shadow streaming-tilemap helpers. This harness links ppu.c on its own;
+ * none of them participate in the world-mirror policy. */
+int snes_frame_counter;
+unsigned char g_snesrecomp_last_hdmaen;
+
+uint16_t WsShadowTile(int layer, int screen_x, uint32_t wrapped_y,
+                      uint16_t hscroll, uint16_t map_word_offset,
+                      uint16_t real_tile) {
+    (void)layer; (void)screen_x; (void)wrapped_y; (void)hscroll;
+    (void)map_word_offset;
+    return real_tile;
+}
+bool WsShadowLayerActive(int layer) { (void)layer; return false; }
+uint32_t WsShadowWorldX(int layer) { (void)layer; return 0; }
+uint32_t WsShadowPresentWorldY(int layer, int screen_x) {
+    (void)layer; (void)screen_x; return 0;
+}
+uint32_t WsShadowScrollY(int layer) { (void)layer; return 0; }
+void WsShadowOnVramWrite(uint16_t word_adr, uint16_t value) {
+    (void)word_adr; (void)value;
+}
+
+enum {
+    kExtra = 43,                 /* GWED's 16:9 margin, per side */
+    kWide = kPpuXPixels + kExtra * 2,
+    kWorldLeft = 64,             /* first authored map pixel */
+    kWorldRight = 448,           /* one past the last authored map pixel */
+    kLine = 1,                   /* ppu_runLine(1) renders framebuffer row 0 */
+    kMapBaseWords = 0x0000,
+    kCharBaseWords = 0x1000,
+};
+
+static int failures;
+
+static void check(bool condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", message);
+        failures++;
+    }
+}
+
+/* Write one 4bpp tile row. Pixel 0 is leftmost (plane bit 7), matching the
+ * hardware bit order the renderer decodes. */
+static void put_tile_row(Ppu *ppu, int tile, int row, const int *px) {
+    uint16_t w0 = 0, w1 = 0;
+    for (int p = 0; p < 8; p++) {
+        int v = px[p] & 0xf;
+        int bit = 7 - p;
+        w0 |= (uint16_t)(((v >> 0) & 1) << bit);
+        w0 |= (uint16_t)(((v >> 1) & 1) << (bit + 8));
+        w1 |= (uint16_t)(((v >> 2) & 1) << bit);
+        w1 |= (uint16_t)(((v >> 3) & 1) << (bit + 8));
+    }
+    ppu->vram[(kCharBaseWords + tile * 16 + row) & 0x7fff] = w0;
+    ppu->vram[(kCharBaseWords + tile * 16 + 8 + row) & 0x7fff] = w1;
+}
+
+/* A 64x64 Mode 1 BG1 whose tilemap holds art only in map px [64,448). Every
+ * authored 8px column gets its own tile, so a pixel identifies its source
+ * column and a reflection cannot be confused with a fold. */
+static void setup_arena_bg1(Ppu *ppu) {
+    ppu->inidisp = 0x0f;
+    ppu->bgmode = 1;
+    ppu->screenEnabled[0] = 0x01;   /* BG1 on the main screen only */
+    ppu->screenEnabled[1] = 0x00;
+    ppu->screenWindowed[0] = 0x00;
+    ppu->screenWindowed[1] = 0x00;
+    ppu->bgXsc[0] = 0x03;           /* map at word 0, 64x64 */
+    ppu->bgTileAdr = 0x0001;        /* BG1 char base = word 0x1000 */
+    ppu->vScroll[0] = 0;
+
+    memset(ppu->vram, 0, sizeof ppu->vram);
+    ppu->cgram[0] = 0x0000;
+    for (int i = 1; i < 16; i++)
+        ppu->cgram[i] = (uint16_t)(0x0421 * i);
+
+    /* 48 authored tile columns, tiles 1..48. Tile n's rows are a shifted ramp
+     * so both the tile index and the pixel position are recoverable. */
+    for (int t = 1; t <= 48; t++) {
+        for (int row = 0; row < 8; row++) {
+            int px[8];
+            for (int p = 0; p < 8; p++)
+                px[p] = ((t * 3 + p * 5 + row) % 15) + 1;
+            put_tile_row(ppu, t, row, px);
+        }
+    }
+    /* Tile 0 stays all-zero: transparent, exactly like GWED's unauthored
+     * tilemap columns. */
+    for (int scr = 0; scr < 2; scr++) {
+        for (int row = 0; row < 32; row++) {
+            for (int col = 0; col < 32; col++) {
+                int tx = scr * 32 + col;         /* 0..63 */
+                int tile = 0;
+                if (tx >= kWorldLeft / 8 && tx < kWorldRight / 8)
+                    tile = tx - kWorldLeft / 8 + 1;
+                ppu->vram[kMapBaseWords + scr * 0x400 + row * 32 + col] =
+                    (uint16_t)tile;
+            }
+        }
+    }
+}
+
+static void render_wide(Ppu *ppu, uint32_t *out, int hscroll,
+                        bool world_band, bool clamp_band, bool mirror_band) {
+    memset(out, 0, sizeof(uint32_t) * kWide);
+    ppu_reset(ppu);
+    PpuBeginDrawing(ppu, (uint8_t *)out, sizeof(uint32_t) * kWide,
+                    kPpuRenderFlags_NewRenderer);
+    setup_arena_bg1(ppu);
+    PpuSetExtraSpace(ppu, kExtra);   /* resets layer policies: must come first */
+    if (clamp_band)
+        PpuSetWidescreenLayerClampBand(ppu, 0, 0, 225);
+    if (mirror_band)
+        PpuSetWidescreenLayerMirror(ppu, 0x01);
+    if (world_band)
+        PpuSetWidescreenLayerWorldMirrorBand(ppu, 0, 0, 225, kWorldLeft,
+                                             kWorldRight);
+    ppu->hScroll[0] = (uint16_t)hscroll;
+    ppu_runLine(ppu, 0);
+    ppu->hScroll[0] = (uint16_t)hscroll;
+    ppu_runLine(ppu, kLine);
+}
+
+/* One camera position: compare the world-mirrored render against the
+ * unpolicied one, pixel by pixel, using the reflection rule as the oracle. */
+static void check_camera(Ppu *ppu, int hscroll, const char *label,
+                         bool expect_out_of_world) {
+    uint32_t *base = malloc(sizeof(uint32_t) * kWide);
+    uint32_t *out = malloc(sizeof(uint32_t) * kWide);
+    if (!base || !out) { fprintf(stderr, "FAIL: oom\n"); failures++; return; }
+
+    render_wide(ppu, base, hscroll, false, false, false);
+    render_wide(ppu, out, hscroll, true, false, false);
+
+    const int a = kWorldLeft - hscroll;    /* screen x of the world's left edge */
+    const int b = kWorldRight - hscroll;   /* screen x one past its right edge */
+    int inside_mismatch = 0, reflected_mismatch = 0, reflected_pixels = 0;
+    int viewport_fold_differs = 0;
+    char msg[160];
+
+    for (int x = -kExtra; x < kPpuXPixels + kExtra; x++) {
+        uint32_t got = out[x + kExtra];
+        if (x >= a && x < b) {
+            if (got != base[x + kExtra])
+                inside_mismatch++;
+            continue;
+        }
+        int sx = (x < a) ? 2 * a - 1 - x : 2 * b - 1 - x;
+        if (sx < a || sx >= b || sx < -kExtra || sx >= kPpuXPixels + kExtra) {
+            if (got != 0)
+                reflected_mismatch++;   /* nothing to sample: stays backdrop */
+            continue;
+        }
+        reflected_pixels++;
+        if (got != base[sx + kExtra])
+            reflected_mismatch++;
+        /* What PpuSetWidescreenLayerMirror would have shown here. */
+        int fold = (x < 0) ? -x : (2 * kPpuXPixels - 2 - x);
+        if (fold >= -kExtra && fold < kPpuXPixels + kExtra &&
+            base[fold + kExtra] != got)
+            viewport_fold_differs++;
+    }
+
+    snprintf(msg, sizeof msg,
+             "%s: in-world columns render naturally (byte-identical)", label);
+    check(inside_mismatch == 0, msg);
+    snprintf(msg, sizeof msg,
+             "%s: out-of-world columns equal the reflected source", label);
+    check(reflected_mismatch == 0, msg);
+    if (expect_out_of_world) {
+        snprintf(msg, sizeof msg, "%s: some columns leave the world", label);
+        check(reflected_pixels > 0, msg);
+        snprintf(msg, sizeof msg,
+                 "%s: outermost margin column is non-blank", label);
+        check(a > -kExtra ? out[0] != 0 : out[kWide - 1] != 0, msg);
+        snprintf(msg, sizeof msg,
+                 "%s: world reflection differs from a viewport fold", label);
+        check(viewport_fold_differs > 0, msg);
+    } else {
+        snprintf(msg, sizeof msg,
+                 "%s: nothing leaves the world, so nothing is synthesized",
+                 label);
+        check(reflected_pixels == 0, msg);
+        snprintf(msg, sizeof msg, "%s: output identical to no policy at all",
+                 label);
+        check(memcmp(base, out, sizeof(uint32_t) * kWide) == 0, msg);
+    }
+    free(base);
+    free(out);
+}
+
+int main(void) {
+    Ppu *ppu = ppu_init();
+    if (!ppu) return 2;
+
+    /* Left wall: the camera cannot scroll further left, so the whole left
+     * margin is off the end of the authored tilemap. */
+    check_camera(ppu, 64, "left wall (hScroll 64)", true);
+    /* Right wall: mirror image of the above. */
+    check_camera(ppu, 192, "right wall (hScroll 192)", true);
+    /* Mid-scroll: both margins hold genuine authored art. This is the case a
+     * viewport-space mirror or repeat band destroys. */
+    check_camera(ppu, 128, "mid-scroll (hScroll 128)", false);
+
+    /* Precedence: a clamp band and a layer mirror each keep the layer out of
+     * the margins, so a world band overlapping them must be inert -- the
+     * output has to match the clamp/mirror configuration on its own. */
+    {
+        uint32_t *a = malloc(sizeof(uint32_t) * kWide);
+        uint32_t *b = malloc(sizeof(uint32_t) * kWide);
+        if (a && b) {
+            render_wide(ppu, a, 64, false, true, false);
+            render_wide(ppu, b, 64, true, true, false);
+            check(memcmp(a, b, sizeof(uint32_t) * kWide) == 0,
+                  "clamp band wins over an overlapping world band");
+            render_wide(ppu, a, 64, false, false, true);
+            render_wide(ppu, b, 64, true, false, true);
+            check(memcmp(a, b, sizeof(uint32_t) * kWide) == 0,
+                  "layer mirror wins over an overlapping world band");
+        } else {
+            fprintf(stderr, "FAIL: oom\n");
+            failures++;
+        }
+        free(a);
+        free(b);
+    }
+
+    /* Inert at authentic width: configuring a world band with no margin must
+     * not change the 256-wide picture. */
+    {
+        uint32_t native[kPpuXPixels], banded[kPpuXPixels];
+        for (int pass = 0; pass < 2; pass++) {
+            uint32_t *dst = pass ? banded : native;
+            memset(dst, 0, sizeof native);
+            ppu_reset(ppu);
+            PpuBeginDrawing(ppu, (uint8_t *)dst,
+                            sizeof(uint32_t) * kPpuXPixels,
+                            kPpuRenderFlags_NewRenderer);
+            setup_arena_bg1(ppu);
+            if (pass)
+                PpuSetWidescreenLayerWorldMirrorBand(ppu, 0, 0, 225,
+                                                     kWorldLeft, kWorldRight);
+            ppu->hScroll[0] = 64;
+            ppu_runLine(ppu, 0);
+            ppu->hScroll[0] = 64;
+            ppu_runLine(ppu, kLine);
+        }
+        check(memcmp(native, banded, sizeof native) == 0,
+              "world band is inert at authentic 256 width");
+    }
+
+    /* The disable form must clear the slot rather than leave it half set. */
+    {
+        ppu_reset(ppu);
+        PpuSetExtraSpace(ppu, kExtra);
+        PpuSetWidescreenLayerWorldMirrorBand(ppu, 0, 0, 225, kWorldLeft,
+                                             kWorldRight);
+        check(PpuWidescreenLayerWorldBandAt(ppu, 0, kLine) == 0,
+              "a configured band is reported for its scanlines");
+        PpuSetWidescreenLayerWorldMirrorBand(ppu, 0, 0, 0, kWorldLeft,
+                                             kWorldRight);
+        check(PpuWidescreenLayerWorldBandAt(ppu, 0, kLine) < 0,
+              "an empty band disables the slot");
+        PpuSetWidescreenLayerWorldMirrorBandSlot(ppu, 1, 0, 0, 225,
+                                                 kWorldRight, kWorldLeft);
+        check(PpuWidescreenLayerWorldBandAt(ppu, 0, kLine) < 0,
+              "an inverted world span disables the slot");
+        PpuSetWidescreenLayerWorldMirrorBandSlot(ppu, 1, 0, 100, 200,
+                                                 kWorldLeft, kWorldRight);
+        check(PpuWidescreenLayerWorldBandAt(ppu, 0, 150) == 1 &&
+              PpuWidescreenLayerWorldBandAt(ppu, 0, 50) < 0,
+              "slot 1 is independently addressable");
+    }
+
+    ppu_free(ppu);
+    printf("ppu_world_mirror_test: %s\n", failures ? "FAIL" : "PASS");
+    return failures ? 1 : 0;
+}

--- a/tests/ppu/run.ps1
+++ b/tests/ppu/run.ps1
@@ -1,24 +1,31 @@
 $ErrorActionPreference = "Stop"
 $root = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
-$out = Join-Path $root "build\ppu_sprite_limit_test.exe"
 $gcc = (Get-Command gcc).Source
-$args = @(
-    "-std=c11", "-Wall", "-Wextra", "-O1",
-    "-DSNESRECOMP_REVERSE_DEBUG=0",
-    "-I$root\runner\src", "-I$root\runner\src\snes",
-    "$root\tests\ppu\ppu_sprite_limit_test.c",
-    "$root\runner\src\snes\ppu.c",
-    "$root\runner\src\snes\ppu_legacy.c",
-    "-o", $out
-)
+$tests = @("ppu_sprite_limit_test", "ppu_world_mirror_test")
+$failed = @()
 
-New-Item -ItemType Directory -Force (Split-Path $out) | Out-Null
-Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue
-$proc = Start-Process -FilePath $gcc -ArgumentList $args -PassThru -NoNewWindow
-$proc.PriorityClass = "BelowNormal"
-$proc.WaitForExit()
-if (-not (Test-Path -LiteralPath $out)) {
-    throw "gcc did not produce the sprite-limit test executable"
+foreach ($test in $tests) {
+    $out = Join-Path $root "build\$test.exe"
+    $args = @(
+        "-std=c11", "-Wall", "-Wextra", "-O1",
+        "-DSNESRECOMP_REVERSE_DEBUG=0",
+        "-I$root\runner\src", "-I$root\runner\src\snes",
+        "$root\tests\ppu\$test.c",
+        "$root\runner\src\snes\ppu.c",
+        "$root\runner\src\snes\ppu_legacy.c",
+        "-o", $out
+    )
+
+    New-Item -ItemType Directory -Force (Split-Path $out) | Out-Null
+    Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue
+    $proc = Start-Process -FilePath $gcc -ArgumentList $args -PassThru -NoNewWindow
+    $proc.PriorityClass = "BelowNormal"
+    $proc.WaitForExit()
+    if (-not (Test-Path -LiteralPath $out)) {
+        throw "gcc did not produce $test.exe"
+    }
+    & $out
+    if ($LASTEXITCODE -ne 0) { $failed += $test }
 }
-& $out
-if ($LASTEXITCODE -ne 0) { throw "sprite-limit test failed" }
+
+if ($failed.Count -gt 0) { throw ("PPU tests failed: " + ($failed -join ", ")) }

--- a/tests/ppu/run.ps1
+++ b/tests/ppu/run.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 $root = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 $gcc = (Get-Command gcc).Source
-$tests = @("ppu_sprite_limit_test", "ppu_world_mirror_test")
+$tests = @("ppu_sprite_limit_test", "ppu_world_mirror_test", "ppu_elastic_band_test")
 $failed = @()
 
 foreach ($test in $tests) {

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -37,6 +37,10 @@ echo "=== PPU sprite limits ==="
     -o "$OUT/ppu_sprite_limit_test"
 "$OUT/ppu_sprite_limit_test"
 
+echo "=== PPU widescreen world-mirror band ==="
+"$CC" -std=c11 -Wall -Wextra -O1     -DSNESRECOMP_REVERSE_DEBUG=0     -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes"     "$ROOT/tests/ppu/ppu_world_mirror_test.c"     "$ROOT/runner/src/snes/ppu.c"     "$ROOT/runner/src/snes/ppu_legacy.c"     -o "$OUT/ppu_world_mirror_test"
+"$OUT/ppu_world_mirror_test"
+
 echo "=== DMA / HDMA ==="
 "$CC" -std=c11 -Wall -Wextra -Werror -O1 \
     -DSNESRECOMP_REVERSE_DEBUG=0 \

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -41,6 +41,10 @@ echo "=== PPU widescreen world-mirror band ==="
 "$CC" -std=c11 -Wall -Wextra -O1     -DSNESRECOMP_REVERSE_DEBUG=0     -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes"     "$ROOT/tests/ppu/ppu_world_mirror_test.c"     "$ROOT/runner/src/snes/ppu.c"     "$ROOT/runner/src/snes/ppu_legacy.c"     -o "$OUT/ppu_world_mirror_test"
 "$OUT/ppu_world_mirror_test"
 
+echo "=== PPU widescreen elastic anchor band ==="
+"$CC" -std=c11 -Wall -Wextra -O1     -DSNESRECOMP_REVERSE_DEBUG=0     -I "$ROOT/runner/src" -I "$ROOT/runner/src/snes"     "$ROOT/tests/ppu/ppu_elastic_band_test.c"     "$ROOT/runner/src/snes/ppu.c"     "$ROOT/runner/src/snes/ppu_legacy.c"     -o "$OUT/ppu_elastic_band_test"
+"$OUT/ppu_elastic_band_test"
+
 echo "=== DMA / HDMA ==="
 "$CC" -std=c11 -Wall -Wextra -Werror -O1 \
     -DSNESRECOMP_REVERSE_DEBUG=0 \


### PR DESCRIPTION
## PPU: widescreen world-mirror bands and elastic anchor bands (draft)

Two additive, default-off widescreen policies needed by the Gundam Wing: Endless Duel port (companion PR on TechnicallyComputers/GundamWingEndlessDuelSNESRecomp, branch `feature/gwed-widescreen`). Both are inert at `extra == 0`, live outside every savestate span, reset in `PpuResetLayerPolicies`, and are exported in `get_ppu_state.widescreen`. Doctrine entries P2b and P2c added to `docs/WIDESCREEN_PATTERNS.md`.

- `PpuSetWidescreenLayerWorldMirrorBand{,Slot}` — for bounded arenas: render the tilemap naturally and reflect only pixels whose map X falls outside the authored world `[left,right)` about that edge. The existing `LayerMirror` reflects about the *viewport* edge, which discards real art whenever the camera is not exactly at a wall. Implemented at the merge step (covers 4bpp/2bpp/big-tile/mosaic); the layer is drawn across the full padded width first so reflected sources that are themselves margin columns exist.
- `PpuSetWidescreenLayerElasticBand{,Slot}` + `ElasticSplitBandSlot` — piecewise horizontal remap per scanline band: rigid segments copy 1:1 at shifted destinations (glyphs byte-exact), elastic segments resample centre-nearest (`sx = s0 + ((2*o+1)*sw)/(2*dw)`; the floor form left a 1 px asymmetry on 111/113 gauge fill levels). Fail-closed validation: a malformed band is cleared, never half-applied.

Tests: `tests/ppu/ppu_world_mirror_test.c`, `tests/ppu/ppu_elastic_band_test.c` (both adversarially checked with mutants); `tests/ppu/run.ps1` / `tests/run_c_tests.sh` updated. All three PPU tests pass.

Not done here: other SNES titles were not rebuilt against this branch (change is additive and default-off). Beads: `beads-8wg.2.25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
