### PR TITLE
Point vendored submodules at RetroPortingToolKit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "lib/recomp-net"]
 	path = lib/recomp-net
-	url = https://github.com/TechnicallyComputers/recomp-net.git
+	url = https://github.com/RetroPortingToolKit/recomp-net.git
 	branch = main
 
 [submodule "lib/retcomm-rbengine"]
 	path = lib/retcomm-rbengine
-	url = https://github.com/TechnicallyComputers/retcomm-rbengine.git
+	url = https://github.com/RetroPortingToolKit/rbengine.git
 	branch = main

--- a/docs/RECOMP_NET.md
+++ b/docs/RECOMP_NET.md
@@ -1,6 +1,6 @@
 # recomp-net (netcode)
 
-snesrecomp vendors [recomp-net](https://github.com/TechnicallyComputers/recomp-net)
+snesrecomp vendors [recomp-net](https://github.com/RetroPortingToolKit/recomp-net)
 as a git submodule at `lib/recomp-net`. Any game that builds with
 `runner/runner.cmake` can link the library and drive delay-sync multiplayer
 from the game main loop.
@@ -460,7 +460,7 @@ recomp-ui policy mirror: `docs/HOST_NETPLAY.md` → “Where to put fixes”.
 | snesrecomp (`lib/recomp-net`, `snes_netplay`, `snes_host_session`, lobby)     | Vendors netcode, pad/admit facade, MotK WS + ICE; guest bind normalize; `try_fill_launch`; rematch SDL ensure + soft-exit + `session_reset` dispatch |
 | [recomp-ui](https://github.com/mstan/recomp-ui)                                | Waiting-room UI, UDP create/join port prep (`guest_bind`), resume-room flags   |
 | Game runtime                                                                   | Thin callbacks → helpers above; `RtlGameInfo` hooks; pad sample / `RtlRunFrame` |
-| [recomp-net-server](https://github.com/TechnicallyComputers/recomp-net-server) | Lobby membership, launch, ICE signal relay                                     |
+| [recomp-net-server](https://github.com/RetroPortingToolKit/recomp-net-server) | Lobby membership, launch, ICE signal relay                                     |
 
 ## Windows MSBuild / `lib/` superbuild
 


### PR DESCRIPTION
`recomp-net` and `retcomm-rbengine` (now **rbengine**) moved from `TechnicallyComputers` to the `RetroPortingToolKit` org.

GitHub still redirects the old URLs, so **nothing is broken today**. But this repo is what every SNES port inherits its `.gitmodules` from, so the old owner keeps propagating into each new clone until it's fixed here. It surfaced through Studio's *Git settings* dialog, which reads those URLs:

```
$ project_studio --platform snes git module-urls --root <a port>
[nested] lib/recomp-net
    .gitmodules https://github.com/TechnicallyComputers/recomp-net.git
[nested] lib/retcomm-rbengine
    .gitmodules https://github.com/TechnicallyComputers/retcomm-rbengine.git
```

## Deliberately unchanged

- Submodule **paths** (`lib/recomp-net`, `lib/retcomm-rbengine`) — every port pins them, and they are not repo slugs.
- `snesrecomp` and `recomp-ui` did **not** move; still `mstan`. Verified against the live repos.

Companion PR for the PSX side: mstan/psxrecomp#340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xfKkiEkh87zL1EpE5Ty55