### PR TITLE
Follow recomp-ui to the RetroPortingToolKit org

### DIFF
--- a/docs/LAUNCHER_DESIGN.md
+++ b/docs/LAUNCHER_DESIGN.md
@@ -4,7 +4,7 @@ Status: **SHIPPED via recomp-ui** · 2026-07-23
 
 The pre-boot launcher is not part of the snesrecomp engine tree. Games that
 need the shared Dear ImGui launcher vendor
-[mstan/recomp-ui](https://github.com/mstan/recomp-ui) as a **repo-root**
+[RetroPortingToolKit/recomp-ui](https://github.com/RetroPortingToolKit/recomp-ui) as a **repo-root**
 submodule and wire it themselves. snesrecomp keeps only recomp-net (and the
 lobby / netplay host facades that recomp-ui drives through callbacks).
 
@@ -12,7 +12,7 @@ lobby / netplay host facades that recomp-ui drives through callbacks).
 
 ```cmake
 # In the game repo (not snesrecomp):
-#   git submodule add https://github.com/mstan/recomp-ui.git recomp-ui
+#   git submodule add https://github.com/RetroPortingToolKit/recomp-ui.git recomp-ui
 
 include(${SNESRECOMP_ROOT}/runner/runner.cmake)
 add_executable(MyGame ...)

--- a/docs/RECOMP_NET.md
+++ b/docs/RECOMP_NET.md
@@ -428,7 +428,7 @@ games — that lives in `snes_host_lobby.c`.
 
 **Default:** put networking optimizations and launcher/netplay UX fixes in
 **snesrecomp** (`snes_netplay_*`, `snes_lobby_*`, `snes_host_*`) or
-**[recomp-ui](https://github.com/mstan/recomp-ui)** (presentation, UDP port
+**[recomp-ui](https://github.com/RetroPortingToolKit/recomp-ui)** (presentation, UDP port
 prep, waiting-room flow) — **not** as one-off patches in each game’s
 `main.c` / RTL. New titles then inherit the fix when they bump submodules.
 
@@ -458,7 +458,7 @@ recomp-ui policy mirror: `docs/HOST_NETPLAY.md` → “Where to put fixes”.
 | Layer                                                                          | Responsibility                                                                 |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | snesrecomp (`lib/recomp-net`, `snes_netplay`, `snes_host_session`, lobby)     | Vendors netcode, pad/admit facade, MotK WS + ICE; guest bind normalize; `try_fill_launch`; rematch SDL ensure + soft-exit + `session_reset` dispatch |
-| [recomp-ui](https://github.com/mstan/recomp-ui)                                | Waiting-room UI, UDP create/join port prep (`guest_bind`), resume-room flags   |
+| [recomp-ui](https://github.com/RetroPortingToolKit/recomp-ui)                                | Waiting-room UI, UDP create/join port prep (`guest_bind`), resume-room flags   |
 | Game runtime                                                                   | Thin callbacks → helpers above; `RtlGameInfo` hooks; pad sample / `RtlRunFrame` |
 | [recomp-net-server](https://github.com/RetroPortingToolKit/recomp-net-server) | Lobby membership, launch, ICE signal relay                                     |
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # lib/CMakeLists.txt — optional Windows-oriented superbuild helpers.
 #
 # The Dear ImGui launcher is not vendored here — games that need it add
-# mstan/recomp-ui at their own repo root (see docs/LAUNCHER_DESIGN.md).
+# RetroPortingToolKit/recomp-ui at their own repo root (see docs/LAUNCHER_DESIGN.md).
 #
 # This file optionally builds recomp-net for MSBuild-era consumers that still
 # want a packaged static library from lib/:

--- a/runner/runner.cmake
+++ b/runner/runner.cmake
@@ -467,5 +467,5 @@ endfunction()
 include(${SNESRECOMP_RUNNER_ROOT}/recomp_net.cmake)
 
 # Dear ImGui pre-boot launcher is NOT vendored here. Games that need it add
-# mstan/recomp-ui as a repo-root submodule and call recomp_target_launcher_ui()
+# RetroPortingToolKit/recomp-ui as a repo-root submodule and call recomp_target_launcher_ui()
 # themselves (see docs/LAUNCHER_DESIGN.md).


### PR DESCRIPTION
Follow-on to #67, which moved the submodule URLs. `recomp-ui` has since moved too: `mstan/recomp-ui` → `RetroPortingToolKit/recomp-ui`.

GitHub redirects the old URL, so **nothing is broken today**. But this repo is what every SNES port inherits its module URLs from, so the old owner keeps propagating into each new clone until it is fixed here — the same reason #67 existed.

Four files: `docs/LAUNCHER_DESIGN.md`, `docs/RECOMP_NET.md`, `lib/CMakeLists.txt`, `runner/runner.cmake`.

`snesrecomp` itself has **not** moved and is untouched. Unlike the PSX side there is no product-name rename here — `main` carries no `RetComM` strings at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DpaQqVguHFpBuCmdoFYWY