### PR TITLE
netplay: automatch, server-granted cosmetic mods, chat reports and fork reporting (2/2)

### DIFF
--- a/runner/src/desktop/mmx_config.c
+++ b/runner/src/desktop/mmx_config.c
@@ -307,6 +307,14 @@ static int GetIniSection(const char *s) {
    * one would otherwise print "Invalid .ini section" on every start. */
   if (StringStartsWithNoCase(s, "[Controller."))
     return 8;
+  /* HOST-owned sections, for the same reason as [Controller.<guid>] above:
+   * the runner does not read them, but a per-game host does (its own
+   * config reader opens the same file), and every one of them printed
+   * "Invalid .ini section" on every start. A section this core has no
+   * business parsing is not a malformed file. */
+  if (StringEqualsNoCase(s, "[Video]") ||
+      StringEqualsNoCase(s, "[Emulation]"))
+    return 9;
   return -1;
 }
 
@@ -350,6 +358,8 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
     return true;
   } else if (section == 8) {
     return true;                 /* saved profile; launcher-owned */
+  } else if (section == 9) {
+    return true;                 /* host-owned; this core does not read it */
   } else if (section == 1) {
     if (StringEqualsNoCase(key, "WindowSize")) {
       char *s;

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -3053,13 +3053,48 @@ int snes_lobby_list_get(int index, SnesLobbyRow *out)
     return 1;
 }
 
+/*
+ * Serialise caps for an outbound op, or publish none at all.
+ *
+ * append_match_caps_json returns 0 when the object would not fit (or would
+ * exceed the 4096 the lobby server silently discards) -- but snprintf has
+ * already left a TRUNCATED, NUL-terminated string in `dst` by then. Every
+ * caller ignored that return and pasted the result straight into its message,
+ * so an oversized caps object did not drop out, it went in as a fragment cut
+ * mid-token. The op was then malformed JSON, the server dropped it, and the
+ * caller reported success.
+ *
+ * That is what made "Create Lobby" close its modal and create nothing. The
+ * same two lines existed in set_match_caps and in start, which would have
+ * failed the same silent way once the caps grew past their buffers -- so this
+ * is one function rather than three fixed copies.
+ *
+ * Caps are dropped rather than the op refused: widescreen and delay matter,
+ * but a lobby that exists without published caps is recoverable and a lobby
+ * that never exists is not. The log line is the part that must not be
+ * missing.
+ */
+static void caps_json_build(char *dst, size_t cap,
+                            const SnesLobbyMatchCaps *caps, const char *op)
+{
+    dst[0] = '\0';
+    if (!caps || !caps->valid) return;
+    if (append_match_caps_json(dst, cap, caps) > 0) return;
+    dst[0] = '\0';
+    fprintf(stderr, "snes_lobby: match caps would not serialise for `%s` -- "
+                    "sending it without them\n", op ? op : "?");
+}
+
 int snes_lobby_create(const char *name, const char *game_name,
                      const char *game_version, const char *password,
                      const char *host_bind, const SnesLobbyMatchCaps *match_caps,
                      int max_slots)
 {
-    char msg[2304];
-    char caps_json[512];
+    /* Sized against what append_match_caps_json will actually emit -- it caps
+     * itself at 4000 bytes -- rather than a round number that a mod plan, a
+     * mod_set and a digest-pinned allowlist grew past. */
+    char msg[5120];
+    char caps_json[4160];
     char name_esc[JSON_ESC_CAP(128)];
     char gn_esc[JSON_ESC_CAP(SNES_LOBBY_NAME_LEN)];
     char gv_esc[JSON_ESC_CAP(SNES_LOBBY_VERSION_LEN)];
@@ -3086,11 +3121,8 @@ int snes_lobby_create(const char *name, const char *game_name,
     strncpy(g_lc.my_bind, host_bind && host_bind[0] ? host_bind : "0.0.0.0:7777",
             sizeof(g_lc.my_bind) - 1);
     g_lc.join.last_error[0] = '\0';
-    caps_json[0] = '\0';
-    if (match_caps && match_caps->valid) {
-        g_lc.match_caps = *match_caps;
-        append_match_caps_json(caps_json, sizeof(caps_json), match_caps);
-    }
+    if (match_caps && match_caps->valid) g_lc.match_caps = *match_caps;
+    caps_json_build(caps_json, sizeof(caps_json), match_caps, "create");
     json_escape(name && name[0] ? name : "Lobby", name_esc, sizeof(name_esc));
     json_escape(gn, gn_esc, sizeof(gn_esc));
     json_escape(gv, gv_esc, sizeof(gv_esc));
@@ -3293,14 +3325,13 @@ const SnesLobbyMatchCaps *snes_lobby_match_caps(void)
 
 int snes_lobby_set_match_caps(const SnesLobbyMatchCaps *caps)
 {
-    char msg[768];
-    char caps_json[512];
+    char msg[4352];
+    char caps_json[4160];
     int n;
     if (!snes_lobby_connected() || !g_lc.in_lobby || !g_lc.is_host || !caps || !caps->valid)
         return -1;
     g_lc.match_caps = *caps;
-    caps_json[0] = '\0';
-    append_match_caps_json(caps_json, sizeof(caps_json), caps);
+    caps_json_build(caps_json, sizeof(caps_json), caps, "set_match_caps");
     n = snprintf(msg, sizeof(msg), "{\"op\":\"set_match_caps\"%s}", caps_json);
     if (n < 0 || (size_t)n >= sizeof(msg)) return -1;
     queue_send(msg);
@@ -3766,11 +3797,8 @@ int snes_lobby_request_start(const SnesLobbyMatchCaps *match_caps)
                 who[0] ? who : "a player", what[0] ? what : "a required mod");
         return -1;
     }
-    caps_json[0] = '\0';
-    if (match_caps && match_caps->valid) {
-        g_lc.match_caps = *match_caps;
-        append_match_caps_json(caps_json, sizeof(caps_json), match_caps);
-    }
+    if (match_caps && match_caps->valid) g_lc.match_caps = *match_caps;
+    caps_json_build(caps_json, sizeof(caps_json), match_caps, "start");
     n = snprintf(msg, sizeof(msg), "{\"op\":\"start\"%s}", caps_json);
     if (n < 0 || (size_t)n >= sizeof(msg)) return -1;
     queue_send(msg);

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -106,7 +106,8 @@ int  snes_lobby_automatch_available(void) { return 0; }
 int  snes_lobby_automatch_ruleset_count(void) { return 0; }
 int  snes_lobby_automatch_ruleset_get(int i, SnesLobbyRuleset *out)
 { (void)i; (void)out; return 0; }
-int  snes_lobby_automatch_queue(const char *r, int m) { (void)r; (void)m; return -1; }
+int  snes_lobby_automatch_queue(const char *r, int m, const char *e)
+{ (void)r; (void)m; (void)e; return -1; }
 int  snes_lobby_automatch_cancel(void) { return -1; }
 int  snes_lobby_automatch_state(void) { return SNES_LOBBY_AUTOMATCH_IDLE; }
 int  snes_lobby_automatch_queued_secs(void) { return 0; }
@@ -151,6 +152,8 @@ int  snes_lobby_member_is_host(const SnesLobbyMember *member)
 int  snes_lobby_local_ready(void) { return 0; }
 int  snes_lobby_all_ready(void) { return 0; }
 int  snes_lobby_set_ready(int ready) { (void)ready; return -1; }
+int  snes_lobby_report_desync(const SnesLobbyDesyncReport *r)
+{ (void)r; return -1; }
 int  snes_lobby_request_start(const SnesLobbyMatchCaps *c) { (void)c; return -1; }
 int  snes_lobby_launch_pending(void) { return 0; }
 void snes_lobby_clear_launch_pending(void) {}
@@ -723,9 +726,11 @@ int snes_lobby_automatch_ruleset_get(int index, SnesLobbyRuleset *out)
     return 1;
 }
 
-int snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled)
+int snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled,
+                               const char *mod_exempt)
 {
-    char msg[1024];
+    char msg[2048];
+    char exempt_json[768];
     char gn_esc[SNES_LOBBY_NAME_LEN * 2 + 4];
     char gv_esc[SNES_LOBBY_VERSION_LEN * 2 + 4];
     char rid_esc[SNES_LOBBY_RULESET_ID_LEN * 2 + 4];
@@ -752,6 +757,52 @@ int snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled)
     json_escape(effective_game_version(NULL), gv_esc, sizeof(gv_esc));
     json_escape(rid, rid_esc, sizeof(rid_esc));
 
+    /* The exemption evidence, as a JSON ARRAY of strings.
+     *
+     * An array rather than one ';'-joined string, and for a reason this
+     * codebase has already paid for once: match_caps.mod_plan shipped as a
+     * ';'-separated STRING, which is valid JSON that every reader using
+     * as_array() saw as empty -- so a host with a full plan read as a host
+     * requiring nothing, failing open and silently. A list of things the
+     * server must check is exactly the shape where that direction of failure
+     * is worst, so it goes on the wire as a list. */
+    {
+        size_t o = 0;
+        const char *p = mod_exempt;
+        int first = 1;
+        exempt_json[o++] = '[';
+        while (p && *p) {
+            const char *end = p;
+            char entry[160];
+            char esc[sizeof(entry) * 2 + 4];
+            size_t len;
+            while (*end && *end != ';' && *end != '\n') ++end;
+            len = (size_t)(end - p);
+            if (len && len < sizeof(entry)) {
+                memcpy(entry, p, len);
+                entry[len] = '\0';
+                json_escape(entry, esc, sizeof(esc));
+                if (o + strlen(esc) + 4 < sizeof(exempt_json)) {
+                    if (!first) exempt_json[o++] = ',';
+                    exempt_json[o++] = '"';
+                    memcpy(exempt_json + o, esc, strlen(esc));
+                    o += strlen(esc);
+                    exempt_json[o++] = '"';
+                    first = 0;
+                } else {
+                    /* Refuse rather than send a SHORT list: a truncated list
+                     * of exemptions is a list the server approves in full
+                     * while the client relies on more than it declared. */
+                    automatch_fail("too many mod exemptions to declare");
+                    return -1;
+                }
+            }
+            p = *end ? end + 1 : end;
+        }
+        exempt_json[o++] = ']';
+        exempt_json[o] = '\0';
+    }
+
     /* Measure before queueing when we can: a client that probes first never
      * waits out the server's probe grace at all. */
     if (g_am.rtt_ms < 0) automatch_probe_send();
@@ -765,9 +816,9 @@ int snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled)
              "{\"op\":\"automatch_queue\",\"titles\":[{"
              "\"game_name\":\"%s\",\"game_version\":\"%s\","
              "\"disc_fp\":\"%s\",\"ruleset_id\":\"%s\",\"max_slots\":2}],"
-             "\"mods_enabled\":%s%s}",
+             "\"mods_enabled\":%s,\"mod_exempt\":%s%s}",
              gn_esc, gv_esc, disc_fp, rid_esc,
-             mods_enabled ? "true" : "false", rtt);
+             mods_enabled ? "true" : "false", exempt_json, rtt);
     queue_send(msg);
     g_am.error[0] = '\0';
     g_am.queue_in_flight = 1;
@@ -1512,6 +1563,11 @@ static void parse_match_caps_object(const char *obj, SnesLobbyMatchCaps *out)
     out->mod_count = parse_mod_pkg_array(obj, "mod_plan", out->mods,
                                          SNES_LOBBY_MAX_MODS);
     json_get_str(obj, "mod_set", out->mod_set, sizeof(out->mod_set));
+    /* Absent => empty => nothing is exempt. The default has to be the strict
+     * one: a server or host that has never heard of cosmetic mods has granted
+     * nothing, and reading its silence as permission is the whole hole. */
+    json_get_str(obj, "mod_cosmetic_allow", out->mod_cosmetic_allow,
+                 sizeof(out->mod_cosmetic_allow));
     out->ignore_aspect = json_get_bool(obj, "ignore_aspect", 0);
     out->input_delay = json_get_int(obj, "input_delay", 6);
     if (out->input_delay < 2) out->input_delay = 2;
@@ -1538,6 +1594,7 @@ static int append_match_caps_json(char *dst, size_t dst_cap, const SnesLobbyMatc
 {
     char mods[SNES_LOBBY_MAX_MODS * 256 + 16];
     char set_esc[sizeof(caps->mod_set) * 2 + 4];
+    char allow_esc[sizeof(caps->mod_cosmetic_allow) * 2 + 4];
     int n;
 
     if (!dst || dst_cap < 8 || !caps || !caps->valid) return 0;
@@ -1548,11 +1605,13 @@ static int append_match_caps_json(char *dst, size_t dst_cap, const SnesLobbyMatc
                               caps->mod_count))
         return 0;
     json_escape(caps->mod_set, set_esc, sizeof(set_esc));
+    json_escape(caps->mod_cosmetic_allow, allow_esc, sizeof(allow_esc));
     n = snprintf(dst, dst_cap,
                  ",\"match_caps\":{\"v\":1,\"widescreen\":%s,\"widescreen_hud\":%s,"
                  "\"ignore_aspect\":%s,\"input_delay\":%d,\"ws_extra\":%d,"
                  "\"force_turn\":%s,\"force_input_relay\":%s,"
-                 "\"rollback\":%s,%s,\"mod_set\":\"%s\"}",
+                 "\"rollback\":%s,%s,\"mod_set\":\"%s\","
+                 "\"mod_cosmetic_allow\":\"%s\"}",
                  caps->widescreen ? "true" : "false",
                  caps->widescreen_hud ? "true" : "false",
                  caps->ignore_aspect ? "true" : "false",
@@ -1560,7 +1619,7 @@ static int append_match_caps_json(char *dst, size_t dst_cap, const SnesLobbyMatc
                  caps->force_turn ? "true" : "false",
                  caps->force_input_relay ? "true" : "false",
                  caps->rollback ? "true" : "false",
-                 mods, set_esc);
+                 mods, set_esc, allow_esc);
     if (n < 0 || (size_t)n >= dst_cap) return 0;
     /* The lobby server drops a match_caps object over 4096 bytes ENTIRELY
      * (sanitize_match_caps returns None), which would take widescreen,
@@ -3518,6 +3577,74 @@ int snes_lobby_set_ready(int ready)
         return -1;
     }
     send_set_ready(ready);
+    flush_pending();
+    return 0;
+}
+
+/*
+ * Report a simulation-state fork to the server.
+ *
+ * WHAT THIS IS FOR, and what it is NOT.
+ *
+ * In rollback both peers digest the same simulation every tick, so any state
+ * divergence is visible by construction -- the entire class of cheats that
+ * alters the simulation cannot hide from it. Until now that signal was
+ * computed, named down to the subsystem, printed to a local log, and thrown
+ * away. Reporting it is what turns a detection nobody sees into evidence
+ * somebody can act on.
+ *
+ * A fork is NOT an accusation and this call must never be written as though
+ * it were. It says two peers disagreed. Version skew says that. A genuine
+ * emulation bug says that -- this project has found several, and each one
+ * would have produced these reports from two entirely honest players. Which
+ * side MOVED is unknowable from either end of a two-peer disagreement, and is
+ * only ever answerable by looking at many matches against many opponents,
+ * which is a thing a server with accounts can do and a client cannot. So both
+ * digests go on the wire, both peers report independently, and the server
+ * stores rather than judges.
+ *
+ * Best-effort: a report that cannot be sent is dropped rather than retried or
+ * queued. A desync usually ends the match, the connection often goes with it,
+ * and making a diagnostic hold a teardown open would be a worse bug than the
+ * missing row.
+ */
+int snes_lobby_report_desync(const SnesLobbyDesyncReport *r)
+{
+    char msg[1024];
+    char part_esc[96];
+    char exempt_esc[512];
+    char gv_esc[SNES_LOBBY_VERSION_LEN * 2 + 4];
+    const char *lid;
+    int n;
+
+    if (!r || !snes_lobby_connected())
+        return -1;
+    lid = g_lc.join.lobby_id[0] ? g_lc.join.lobby_id : "";
+
+    json_escape(r->partition ? r->partition : "?", part_esc, sizeof(part_esc));
+    json_escape(r->mod_exempt ? r->mod_exempt : "", exempt_esc,
+                sizeof(exempt_esc));
+    json_escape(effective_game_version(NULL), gv_esc, sizeof(gv_esc));
+
+    /* Digests as hex STRINGS, not numbers. They are 32-bit and JSON numbers
+     * are doubles in most readers; a value above 2^53 would be safe but a
+     * reader that decides to print one as 4.29497e+09 has silently destroyed
+     * the only field the row exists to compare. */
+    n = snprintf(msg, sizeof(msg),
+                 "{\"op\":\"desync_report\",\"v\":1,"
+                 "\"lobby_id\":\"%s\",\"game_version\":\"%s\","
+                 "\"tick\":%u,\"partition\":\"%s\","
+                 "\"mine\":\"%08x\",\"theirs\":\"%08x\","
+                 "\"role\":\"%s\",\"disc_fp\":\"%s\","
+                 "\"mod_exempt\":\"%s\"}",
+                 lid, gv_esc, (unsigned)r->tick, part_esc,
+                 (unsigned)r->mine, (unsigned)r->theirs,
+                 r->is_host ? "host" : "guest",
+                 snes_lobby_disc_fp() ? snes_lobby_disc_fp() : "",
+                 exempt_esc);
+    if (n < 0 || (size_t)n >= sizeof(msg))
+        return -1;
+    queue_send(msg);
     flush_pending();
     return 0;
 }

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -32,6 +32,7 @@ int  snes_lobby_online_count(void) { return 0; }
 int  snes_lobby_online_get(int index, SnesLobbyOnlinePlayer *out) { (void)index; (void)out; return 0; }
 void snes_lobby_set_game_identity(const char *a, const char *b) { (void)a; (void)b; }
 const char *snes_lobby_game_version(void) { return SNES_GAME_VERSION; }
+int  snes_lobby_version_filter_strict(void) { return 0; }
 int  snes_lobby_create(const char *a, const char *b, const char *c, const char *d,
                        const char *e, const SnesLobbyMatchCaps *f, int max_slots)
 { (void)a; (void)b; (void)c; (void)d; (void)e; (void)f; (void)max_slots; return -1; }
@@ -3031,6 +3032,11 @@ void snes_lobby_set_game_identity(const char *game_name,
 const char *snes_lobby_game_version(void)
 {
     return effective_game_version(NULL);
+}
+
+int snes_lobby_version_filter_strict(void)
+{
+    return list_filter_version_strict();
 }
 
 void snes_lobby_request_list(void)

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -103,6 +103,7 @@ void snes_lobby_set_disc_fp(const char *hex) { (void)hex; }
 const char *snes_lobby_disc_fp(void) { return ""; }
 /* Automatch: absent without a lobby, and IDLE is the resting state that
  * means exactly that -- a build that never queues sits in it forever. */
+int  snes_lobby_set_blocks(const char *a) { (void)a; return -1; }
 int  snes_lobby_automatch_request_rulesets(void) { return -1; }
 int  snes_lobby_automatch_available(void) { return 0; }
 int  snes_lobby_automatch_ruleset_count(void) { return 0; }
@@ -480,6 +481,7 @@ static void automatch_fail(const char *why)
 static int set_nonblock(int fd);   /* defined with the WS socket helpers */
 static const char *effective_game_version(const char *override_ver);
 static void queue_send(const char *json);
+static void flush_pending(void);
 static const char *json_get_str(const char *json, const char *key, char *out, size_t cap);
 static int json_get_int(const char *json, const char *key, int def);
 static int json_extract_object(const char *json, const char *key, char *out, size_t out_cap);
@@ -697,6 +699,42 @@ static void automatch_send_rtt(void)
              "{\"op\":\"automatch_rtt\",\"rtt_ms\":%d}", g_am.rtt_ms);
     queue_send(msg);
     g_am.rtt_reported = 1;
+}
+
+int snes_lobby_set_blocks(const char *accounts)
+{
+    /* Room for the server's cap (256 ids) at 40 characters each, plus the
+     * separators and the envelope. A list that would not fit is truncated at
+     * a separator rather than sent malformed -- a half-written id at the end
+     * would name nobody, and a malformed op would leave the server enforcing
+     * nothing at all. */
+    static char msg[256 * 41 + 64];
+    char list[256 * 41];
+    size_t n = 0;
+    int first = 1;
+    const char *p = accounts ? accounts : "";
+
+    if (!g_lc.connected) return -1;
+    list[0] = '\0';
+    while (*p) {
+        const char *sep = strchr(p, ';');
+        size_t len = sep ? (size_t)(sep - p) : strlen(p);
+        if (len && len < 40 && n + len + 8 < sizeof(list)) {
+            if (!first) { list[n++] = ','; }
+            list[n++] = '"';
+            memcpy(list + n, p, len);
+            n += len;
+            list[n++] = '"';
+            list[n] = '\0';
+            first = 0;
+        }
+        if (!sep) break;
+        p = sep + 1;
+    }
+    snprintf(msg, sizeof(msg), "{\"op\":\"set_blocks\",\"accounts\":[%s]}", list);
+    queue_send(msg);
+    flush_pending();
+    return 0;
 }
 
 int snes_lobby_automatch_request_rulesets(void)

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -2504,7 +2504,20 @@ static void handle_server_json(const char *json)
         return;
     }
     if (strcmp(op, "automatch_accept_ok") == 0) {
-        g_am.state = SNES_LOBBY_AUTOMATCH_ACCEPTED;
+        /* The echo carries WHICH answer was acknowledged, and honouring it is
+         * not optional: this used to set ACCEPTED unconditionally, so a player
+         * who clicked Decline went to IDLE, received the server's ack a
+         * moment later, and had the accept gate reopen on them reading
+         * "Waiting for <opponent> to accept..." -- the dialog for the choice
+         * they had just refused, over a match that was already finished.
+         *
+         * A declined ack ends the ticket here. The server's automatch_cancelled
+         * follows and is idempotent with this. */
+        if (json_get_bool(json, "accept", 1)) {
+            g_am.state = SNES_LOBBY_AUTOMATCH_ACCEPTED;
+        } else {
+            automatch_reset_queue_state();
+        }
         return;
     }
     if (strcmp(op, "automatch_requeue") == 0) {

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -3,6 +3,7 @@
 
 #include "recomp_net/ice_xfer.h"
 #include "recomp_net/chat_filter.h"
+#include "recomp_net/chat_report.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -155,6 +156,9 @@ int  snes_lobby_all_ready(void) { return 0; }
 int  snes_lobby_set_ready(int ready) { (void)ready; return -1; }
 int  snes_lobby_report_desync(const SnesLobbyDesyncReport *r)
 { (void)r; return -1; }
+int  snes_lobby_report_chat(const char *const *m, int c, const char *r,
+                            const char *n)
+{ (void)m; (void)c; (void)r; (void)n; return -1; }
 int  snes_lobby_request_start(const SnesLobbyMatchCaps *c) { (void)c; return -1; }
 int  snes_lobby_launch_pending(void) { return 0; }
 void snes_lobby_clear_launch_pending(void) {}
@@ -1841,7 +1845,8 @@ static int parse_seat_array(const char *json, const char *key, int is_spectator,
 }
 
 static void chat_push(const char *player_id, const char *account,
-                      const char *from, const char *text, int is_system)
+                      const char *from, const char *text, const char *mid,
+                      int is_system)
 {
     SnesLobbyChatMsg *m;
     int idx;
@@ -1859,6 +1864,7 @@ static void chat_push(const char *player_id, const char *account,
     snprintf(m->account, sizeof(m->account), "%s", account ? account : "");
     snprintf(m->from, sizeof(m->from), "%s", from ? from : "");
     snprintf(m->text, sizeof(m->text), "%s", text);
+    snprintf(m->mid, sizeof(m->mid), "%s", (mid && !is_system) ? mid : "");
     /* Masked on arrival, whatever relayed it: the server already did this,
      * an older server did not, and the rule is that nothing unmasked is
      * ever shown. */
@@ -1873,7 +1879,7 @@ static void chat_push(const char *player_id, const char *account,
 }
 
 static void schat_push(const char *player_id, const char *account,
-                       const char *from, const char *text)
+                       const char *from, const char *text, const char *mid)
 {
     SnesLobbyChatMsg *m;
     int idx;
@@ -1891,6 +1897,7 @@ static void schat_push(const char *player_id, const char *account,
     snprintf(m->account, sizeof(m->account), "%s", account ? account : "");
     snprintf(m->from, sizeof(m->from), "%s", from ? from : "");
     snprintf(m->text, sizeof(m->text), "%s", text);
+    snprintf(m->mid, sizeof(m->mid), "%s", mid ? mid : "");
     (void)rnet_chat_filter_apply(m->text, sizeof(m->text));
     m->is_local = (g_lc.player_id[0] && player_id &&
                    strcmp(player_id, g_lc.player_id) == 0) ? 1 : 0;
@@ -2335,15 +2342,18 @@ static void handle_server_json(const char *json)
         char from_id[SNES_LOBBY_ID_LEN];
         char from_acct[SNES_LOBBY_ID_LEN];
         char from[SNES_LOBBY_NAME_LEN];
+        char mid[40];
         text[0] = '\0';
         from_id[0] = '\0';
         from_acct[0] = '\0';
         from[0] = '\0';
+        mid[0] = '\0';
         json_get_str(json, "text", text, sizeof(text));
         json_get_str(json, "from_player_id", from_id, sizeof(from_id));
         json_get_str(json, "from_account", from_acct, sizeof(from_acct));
         json_get_str(json, "from", from, sizeof(from));
-        schat_push(from_id, from_acct, from, text);
+        json_get_str(json, "mid", mid, sizeof(mid));
+        schat_push(from_id, from_acct, from, text, mid);
         return;
     }
     if (strcmp(op, "chat") == 0) {
@@ -2351,15 +2361,19 @@ static void handle_server_json(const char *json)
         char from_id[SNES_LOBBY_ID_LEN];
         char from_acct[SNES_LOBBY_ID_LEN];
         char from[SNES_LOBBY_NAME_LEN];
+        char mid[40];
         text[0] = '\0';
         from_id[0] = '\0';
         from_acct[0] = '\0';
         from[0] = '\0';
+        mid[0] = '\0';
         json_get_str(json, "text", text, sizeof(text));
         json_get_str(json, "from_player_id", from_id, sizeof(from_id));
         json_get_str(json, "from_account", from_acct, sizeof(from_acct));
         json_get_str(json, "from", from, sizeof(from));
-        chat_push(from_id, from_acct, from, text, json_get_bool(json, "system", 0));
+        json_get_str(json, "mid", mid, sizeof(mid));
+        chat_push(from_id, from_acct, from, text, mid,
+                  json_get_bool(json, "system", 0));
         return;
     }
     if (strcmp(op, "signal") == 0) {
@@ -3418,6 +3432,41 @@ int snes_lobby_seat_swap_outgoing(void)
 void snes_lobby_seat_swap_clear(void)
 {
     if (g_lc.swap_out != 1) g_lc.swap_out = 0;
+}
+
+int snes_lobby_report_chat(const char *const *mids, int mid_count,
+                           const char *reason, const char *note)
+{
+    /* Thin on purpose. What a report CONTAINS is console-agnostic and lives in
+     * recomp-net (recomp_net/chat_report.h); this function's whole job is to
+     * say where this particular client is and hand the frame to the socket.
+     * The PSX lobby client's copy of this is the same eight lines. */
+    RNetChatReportMeta meta;
+    char msg[2048];
+    size_t n;
+
+    if (!snes_lobby_connected())
+        return -1;
+
+    memset(&meta, 0, sizeof(meta));
+    meta.game = g_lc.filter_game_name;
+    meta.game_version = effective_game_version(NULL);
+    /* Metadata only. Nothing downstream may name a file or a directory after
+     * it -- see the header: one queue, read by one person, and splitting the
+     * evidence by console fragments a moderation record along a line that has
+     * nothing to do with moderation. */
+    meta.platform = "snes";
+    meta.server = snes_lobby_url();
+    meta.lobby = g_lc.join.lobby_id[0] ? g_lc.join.lobby_id : "";
+    meta.scope = g_lc.in_lobby ? "lobby" : "server";
+
+    n = rnet_chat_report_build(msg, sizeof(msg), mids, mid_count,
+                               reason, note, &meta);
+    if (n == 0)
+        return -1;
+    queue_send(msg);
+    flush_pending();
+    return 0;
 }
 
 int snes_lobby_send_chat(const char *text)

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -1289,6 +1289,8 @@ static void lobby_list_parse_players(const char *json)
                      sizeof(g_lc.online[n].lobby_name));
         g_lc.online[n].hosting = json_get_bool(chunk, "hosting", 0);
         json_get_str(chunk, "tag", g_lc.online[n].tag, sizeof(g_lc.online[n].tag));
+        json_get_str(chunk, "account", g_lc.online[n].account,
+                     sizeof(g_lc.online[n].account));
         json_get_str(chunk, "game_name", g_lc.online[n].game_name,
                      sizeof(g_lc.online[n].game_name));
         /* Players of another title are not "online" for this one. A row
@@ -1838,8 +1840,8 @@ static int parse_seat_array(const char *json, const char *key, int is_spectator,
     return n;
 }
 
-static void chat_push(const char *player_id, const char *from, const char *text,
-                      int is_system)
+static void chat_push(const char *player_id, const char *account,
+                      const char *from, const char *text, int is_system)
 {
     SnesLobbyChatMsg *m;
     int idx;
@@ -1854,6 +1856,7 @@ static void chat_push(const char *player_id, const char *from, const char *text,
     m = &g_lc.chat[idx];
     memset(m, 0, sizeof(*m));
     snprintf(m->player_id, sizeof(m->player_id), "%s", player_id ? player_id : "");
+    snprintf(m->account, sizeof(m->account), "%s", account ? account : "");
     snprintf(m->from, sizeof(m->from), "%s", from ? from : "");
     snprintf(m->text, sizeof(m->text), "%s", text);
     /* Masked on arrival, whatever relayed it: the server already did this,
@@ -1869,7 +1872,8 @@ static void chat_push(const char *player_id, const char *from, const char *text,
     m->seq = ++g_lc.chat_seq;
 }
 
-static void schat_push(const char *player_id, const char *from, const char *text)
+static void schat_push(const char *player_id, const char *account,
+                       const char *from, const char *text)
 {
     SnesLobbyChatMsg *m;
     int idx;
@@ -1884,6 +1888,7 @@ static void schat_push(const char *player_id, const char *from, const char *text
     m = &g_lc.schat[idx];
     memset(m, 0, sizeof(*m));
     snprintf(m->player_id, sizeof(m->player_id), "%s", player_id ? player_id : "");
+    snprintf(m->account, sizeof(m->account), "%s", account ? account : "");
     snprintf(m->from, sizeof(m->from), "%s", from ? from : "");
     snprintf(m->text, sizeof(m->text), "%s", text);
     (void)rnet_chat_filter_apply(m->text, sizeof(m->text));
@@ -2328,27 +2333,33 @@ static void handle_server_json(const char *json)
     if (strcmp(op, "server_chat") == 0) {
         char text[SNES_LOBBY_CHAT_TEXT_LEN];
         char from_id[SNES_LOBBY_ID_LEN];
+        char from_acct[SNES_LOBBY_ID_LEN];
         char from[SNES_LOBBY_NAME_LEN];
         text[0] = '\0';
         from_id[0] = '\0';
+        from_acct[0] = '\0';
         from[0] = '\0';
         json_get_str(json, "text", text, sizeof(text));
         json_get_str(json, "from_player_id", from_id, sizeof(from_id));
+        json_get_str(json, "from_account", from_acct, sizeof(from_acct));
         json_get_str(json, "from", from, sizeof(from));
-        schat_push(from_id, from, text);
+        schat_push(from_id, from_acct, from, text);
         return;
     }
     if (strcmp(op, "chat") == 0) {
         char text[SNES_LOBBY_CHAT_TEXT_LEN];
         char from_id[SNES_LOBBY_ID_LEN];
+        char from_acct[SNES_LOBBY_ID_LEN];
         char from[SNES_LOBBY_NAME_LEN];
         text[0] = '\0';
         from_id[0] = '\0';
+        from_acct[0] = '\0';
         from[0] = '\0';
         json_get_str(json, "text", text, sizeof(text));
         json_get_str(json, "from_player_id", from_id, sizeof(from_id));
+        json_get_str(json, "from_account", from_acct, sizeof(from_acct));
         json_get_str(json, "from", from, sizeof(from));
-        chat_push(from_id, from, text, json_get_bool(json, "system", 0));
+        chat_push(from_id, from_acct, from, text, json_get_bool(json, "system", 0));
         return;
     }
     if (strcmp(op, "signal") == 0) {

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -114,6 +114,7 @@ int  snes_lobby_automatch_pool(void) { return 0; }
 int  snes_lobby_automatch_found_get(SnesLobbyAutomatchFound *out)
 { (void)out; return 0; }
 int  snes_lobby_automatch_accept(int a) { (void)a; return -1; }
+int  snes_lobby_automatch_room(void) { return 0; }
 void snes_lobby_automatch_refuse_local(const char *w) { (void)w; }
 const char *snes_lobby_automatch_error(void) { return ""; }
 int  snes_lobby_send_chat(const char *text) { (void)text; return -1; }
@@ -399,6 +400,13 @@ typedef struct {
     char error[160];
 
     SnesLobbyAutomatchFound found;
+    /* When the offer lapses, as a monotonic timestamp rather than the count
+     * the server sent. The server states the deadline once; a client that
+     * stored the number and showed it unchanged would display "15s" for the
+     * whole fifteen seconds, which reads as a frozen dialog rather than a
+     * deadline. Counting locally also means the display ticks smoothly
+     * instead of jumping with a 1 Hz push. */
+    uint64_t found_deadline_ms;
 
     /* Where to send the latency probe, published on rulesets_ok and again on
      * automatch_queued. Kept from whichever arrived last. */
@@ -417,6 +425,8 @@ typedef struct {
      * (need_account is the common one) would arrive while state is still
      * IDLE and be filed as somebody else's error. */
     int      queue_in_flight;
+    /* This seat came from a pairing, not from a room somebody hosts. */
+    int      in_automatch_room;
 } LobbyAutomatch;
 
 static LobbyAutomatch g_am = { .rtt_ms = -1, .probe_socket = -1 };
@@ -780,6 +790,15 @@ int snes_lobby_automatch_found_get(SnesLobbyAutomatchFound *out)
 {
     if (!out || g_am.state != SNES_LOBBY_AUTOMATCH_FOUND) return 0;
     *out = g_am.found;
+    /* Recomputed on every read, so the caller can poll it each frame and get
+     * a live count. Never below 0: the offer is about to lapse, and a
+     * negative would draw as one. */
+    if (g_am.found_deadline_ms) {
+        uint64_t now = lobby_mono_ms();
+        out->accept_secs = now >= g_am.found_deadline_ms
+                               ? 0
+                               : (int)((g_am.found_deadline_ms - now + 999ull) / 1000ull);
+    }
     return 1;
 }
 
@@ -804,6 +823,8 @@ int snes_lobby_automatch_accept(int accept)
     }
     return 0;
 }
+
+int snes_lobby_automatch_room(void) { return g_am.in_automatch_room; }
 
 void snes_lobby_automatch_refuse_local(const char *why)
 {
@@ -2126,6 +2147,13 @@ static void handle_server_json(const char *json)
          * Not an automatch special case -- the server refuses to queue an
          * account that is already in a lobby (`already_in_lobby`), so holding
          * a ticket and being seated are mutually exclusive either way. */
+        /* Recorded before the reset below, which is what erases the evidence:
+         * ACCEPTED (or FOUND, if the pair resolved in the same breath) is the
+         * only signal that this seat came from a queue rather than from
+         * somebody's room. */
+        g_am.in_automatch_room =
+            (g_am.state == SNES_LOBBY_AUTOMATCH_ACCEPTED ||
+             g_am.state == SNES_LOBBY_AUTOMATCH_FOUND);
         automatch_reset_queue_state();
         g_lc.in_lobby = 1;
         g_lc.is_host = 0;
@@ -2465,6 +2493,9 @@ static void handle_server_json(const char *json)
                      sizeof(g_am.found.ruleset_label));
         g_am.found.est_rtt_ms = json_get_int(json, "est_rtt_ms", 0);
         g_am.found.accept_secs = json_get_int(json, "accept_secs", 15);
+        g_am.found_deadline_ms =
+            lobby_mono_ms() + (uint64_t)(g_am.found.accept_secs > 0
+                                             ? g_am.found.accept_secs : 0) * 1000ull;
         g_am.state = SNES_LOBBY_AUTOMATCH_FOUND;
         fprintf(stderr, "snes_lobby: automatch found opponent=\"%s\" "
                         "est_rtt=%d ms, %d s to answer\n",
@@ -2520,9 +2551,9 @@ static void handle_server_json(const char *json)
                 int retry = json_get_int(json, "retry_secs", 0);
                 if (retry > 0)
                     snprintf(line, sizeof(line),
-                             "Declining put you on a %d s cooldown", retry);
+                             "%d Second Cooldown For Declining", retry);
                 else
-                    snprintf(line, sizeof(line), "You are on a queue cooldown");
+                    snprintf(line, sizeof(line), "Cooldown For Declining");
                 why = line;
             }
             if (why) {
@@ -2544,6 +2575,7 @@ static void handle_server_json(const char *json)
          * reset on `joined` above should already have done this; repeating it
          * here means a missed or reordered `joined` cannot strand the gate. */
         automatch_reset_queue_state();
+        g_am.in_automatch_room = 0;   /* no longer seated anywhere */
         g_lc.swap_in_valid = 0;
         g_lc.swap_out = 0;
         g_lc.in_lobby = 0;
@@ -3084,6 +3116,7 @@ int snes_lobby_leave(void)
     queue_send("{\"op\":\"leave\"}");
     flush_pending();
     g_lc.in_lobby = 0;
+    g_am.in_automatch_room = 0;
     g_lc.is_host = 0;
     g_lc.host_player_id[0] = '\0';
     g_lc.member_count = 0;

--- a/runner/src/lobby/snes_lobby_client.c
+++ b/runner/src/lobby/snes_lobby_client.c
@@ -97,6 +97,25 @@ int  snes_lobby_match_blocked_by_mods(char *w, size_t wc, char *t, size_t tc)
 int  snes_lobby_local_missing_mods(void) { return 0; }
 int  snes_lobby_set_match_caps(const SnesLobbyMatchCaps *c) { (void)c; return -1; }
 int  snes_lobby_member_count(void) { return 0; }
+void snes_lobby_set_disc_fp(const char *hex) { (void)hex; }
+const char *snes_lobby_disc_fp(void) { return ""; }
+/* Automatch: absent without a lobby, and IDLE is the resting state that
+ * means exactly that -- a build that never queues sits in it forever. */
+int  snes_lobby_automatch_request_rulesets(void) { return -1; }
+int  snes_lobby_automatch_available(void) { return 0; }
+int  snes_lobby_automatch_ruleset_count(void) { return 0; }
+int  snes_lobby_automatch_ruleset_get(int i, SnesLobbyRuleset *out)
+{ (void)i; (void)out; return 0; }
+int  snes_lobby_automatch_queue(const char *r, int m) { (void)r; (void)m; return -1; }
+int  snes_lobby_automatch_cancel(void) { return -1; }
+int  snes_lobby_automatch_state(void) { return SNES_LOBBY_AUTOMATCH_IDLE; }
+int  snes_lobby_automatch_queued_secs(void) { return 0; }
+int  snes_lobby_automatch_pool(void) { return 0; }
+int  snes_lobby_automatch_found_get(SnesLobbyAutomatchFound *out)
+{ (void)out; return 0; }
+int  snes_lobby_automatch_accept(int a) { (void)a; return -1; }
+void snes_lobby_automatch_refuse_local(const char *w) { (void)w; }
+const char *snes_lobby_automatch_error(void) { return ""; }
 int  snes_lobby_send_chat(const char *text) { (void)text; return -1; }
 int  snes_lobby_send_server_chat(const char *text) { (void)text; return -1; }
 int  snes_lobby_server_chat_count(void) { return 0; }
@@ -350,10 +369,448 @@ static uint64_t lobby_mono_ms(void)
 /* Defined later; used by waiting-room RTT signal handling. */
 int snes_lobby_send_signal(int type, int flag, const char *text);
 
+
 static LobbyClient g_lc = {
     .fd = -1,
     .filter_game_version = SNES_GAME_VERSION,
 };
+
+/* ── Automatch state ────────────────────────────────────────────────────────
+ *
+ * Deliberately its own struct rather than more fields on LobbyClient: none of
+ * it is lobby membership, its lifetime is the queue rather than the room, and
+ * a `joined` arriving from a pairing must clear it without disturbing the room
+ * state that the same message is setting up.
+ */
+typedef struct {
+    int  have_rulesets;          /* a rulesets_ok has been seen at all */
+    /* A rulesets query is out. The launcher polls availability EVERY
+     * FRAME while the netplay page is up, so without this the gap
+     * before the first reply becomes a request per frame -- measured
+     * as seven answers to one question. */
+    int  rulesets_in_flight;
+    int  ruleset_count;
+    SnesLobbyRuleset rulesets[SNES_LOBBY_MAX_RULESETS];
+
+    int  state;                  /* SNES_LOBBY_AUTOMATCH_* */
+    char ticket_id[SNES_LOBBY_ID_LEN];
+    int  queued_secs;
+    int  pool;
+    char error[160];
+
+    SnesLobbyAutomatchFound found;
+
+    /* Where to send the latency probe, published on rulesets_ok and again on
+     * automatch_queued. Kept from whichever arrived last. */
+    char probe_host[128];
+    int  probe_port;
+    unsigned probe_magic;
+    int  probe_type;
+    /* The measurement, and the nonce that identifies our outstanding probe. */
+    int      rtt_ms;             /* <0 = not measured yet */
+    uint32_t probe_nonce;
+    uint64_t probe_sent_ms;      /* 0 = none outstanding */
+    int      probe_socket;       /* -1 = not open */
+    int      rtt_reported;       /* the server has our number */
+    /* A queue op is out and its answer -- automatch_queued, or an error --
+     * has not arrived. Without it a refusal of the FIRST queue attempt
+     * (need_account is the common one) would arrive while state is still
+     * IDLE and be filed as somebody else's error. */
+    int      queue_in_flight;
+} LobbyAutomatch;
+
+static LobbyAutomatch g_am = { .rtt_ms = -1, .probe_socket = -1 };
+
+static void automatch_reset_queue_state(void)
+{
+    g_am.state = SNES_LOBBY_AUTOMATCH_IDLE;
+    g_am.queue_in_flight = 0;
+    g_am.ticket_id[0] = '\0';
+    g_am.queued_secs = 0;
+    g_am.pool = 0;
+    g_am.rtt_reported = 0;
+    memset(&g_am.found, 0, sizeof(g_am.found));
+}
+
+static void automatch_fail(const char *why)
+{
+    g_am.state = SNES_LOBBY_AUTOMATCH_FAILED;
+    snprintf(g_am.error, sizeof(g_am.error), "%s", why ? why : "automatch failed");
+    fprintf(stderr, "snes_lobby: automatch failed: %s\n", g_am.error);
+}
+
+/* ── Latency probe ──────────────────────────────────────────────────────────
+ *
+ * Every online match goes through one relay, so the only latency that matters
+ * is each peer -> relay, and a ticket can be qualified on its own before any
+ * pairing. The relay answers packet type 200 with 201 -- the same 14 bytes
+ * back, nonce included -- BEFORE any session lookup, precisely so a client
+ * sitting in a queue with no session can measure the path.
+ *
+ * Fire-and-forget over an unconnected UDP socket, polled from the same pump
+ * as the WebSocket. A reply that never comes costs one socket and a number
+ * that stays -1: a ticket that has not measured is held out of pairing for a
+ * few seconds and then matches anyway, so a silent relay delays a match
+ * rather than preventing one.
+ *
+ * The value is CLIENT-REPORTED, and the server clamps it. Reporting high to
+ * force delay on an opponent is the grief case; reporting low only stalls the
+ * liar's own sim, which is its own answer.
+ */
+#define AUTOMATCH_PROBE_LEN 14
+
+static int set_nonblock(int fd);   /* defined with the WS socket helpers */
+static const char *effective_game_version(const char *override_ver);
+static void queue_send(const char *json);
+static const char *json_get_str(const char *json, const char *key, char *out, size_t cap);
+static int json_get_int(const char *json, const char *key, int def);
+static int json_extract_object(const char *json, const char *key, char *out, size_t out_cap);
+static size_t json_escape(const char *in, char *out, size_t cap);
+static void parse_match_caps_object(const char *obj, SnesLobbyMatchCaps *out);
+
+static void automatch_probe_close(void)
+{
+    if (g_am.probe_socket >= 0) {
+        close(g_am.probe_socket);
+        g_am.probe_socket = -1;
+    }
+    g_am.probe_sent_ms = 0;
+}
+
+/*
+ * The 14-byte probe: magic, type, then a nonce.
+ *
+ * LITTLE-ENDIAN, because that is what the relay's header is (`read_u32_le` /
+ * `read_u16_le` in input_relay.rs) -- and a big-endian magic is simply not
+ * this protocol's magic, so the packet is dropped on the `magic` counter
+ * with no reply and nothing to see from here but a timeout. The nonce sits at
+ * offset 6, where an ordinary packet carries its session id; the relay echoes
+ * those bytes untouched and only rewrites the type, so it comes back as sent.
+ */
+static void automatch_probe_pack(unsigned char *out, uint32_t nonce)
+{
+    const unsigned magic = g_am.probe_magic;
+    const int type = g_am.probe_type ? g_am.probe_type : 200;
+    memset(out, 0, AUTOMATCH_PROBE_LEN);
+    out[0] = (unsigned char)(magic & 0xFF);
+    out[1] = (unsigned char)((magic >> 8) & 0xFF);
+    out[2] = (unsigned char)((magic >> 16) & 0xFF);
+    out[3] = (unsigned char)((magic >> 24) & 0xFF);
+    out[4] = (unsigned char)(type & 0xFF);
+    out[5] = (unsigned char)((type >> 8) & 0xFF);
+    out[6] = (unsigned char)(nonce & 0xFF);
+    out[7] = (unsigned char)((nonce >> 8) & 0xFF);
+    out[8] = (unsigned char)((nonce >> 16) & 0xFF);
+    out[9] = (unsigned char)((nonce >> 24) & 0xFF);
+}
+
+static int automatch_probe_send(void)
+{
+    struct addrinfo hints, *res = NULL;
+    unsigned char pkt[AUTOMATCH_PROBE_LEN];
+    char portstr[16];
+    int fd;
+
+    if (!g_am.probe_host[0] || g_am.probe_port <= 0) return -1;
+    if (g_am.probe_sent_ms) return 0;   /* one outstanding at a time */
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    snprintf(portstr, sizeof(portstr), "%d", g_am.probe_port);
+    if (getaddrinfo(g_am.probe_host, portstr, &hints, &res) != 0 || !res)
+        return -1;
+
+    fd = (int)socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (fd < 0) { freeaddrinfo(res); return -1; }
+    set_nonblock(fd);
+
+    /* A fresh nonce per attempt, so a late reply to a previous probe cannot
+     * be timed against this one's clock and report an absurdly low number. */
+    g_am.probe_nonce = (uint32_t)(lobby_mono_ms() * 2654435761u) ^ 0x9E3779B9u;
+    automatch_probe_pack(pkt, g_am.probe_nonce);
+
+    if (sendto(fd, (const char *)pkt, (int)sizeof(pkt), 0,
+               res->ai_addr, (int)res->ai_addrlen) < 0) {
+        close(fd);
+        freeaddrinfo(res);
+        return -1;
+    }
+    freeaddrinfo(res);
+
+    automatch_probe_close();
+    g_am.probe_socket = fd;
+    g_am.probe_sent_ms = lobby_mono_ms();
+    return 0;
+}
+
+static void automatch_send_rtt(void);
+
+/* Polled every pump. Times the 201 reply, or gives up after 2 s. */
+static void automatch_probe_poll(void)
+{
+    unsigned char buf[64];
+    uint64_t now;
+
+    if (g_am.probe_socket < 0 || !g_am.probe_sent_ms) return;
+    now = lobby_mono_ms();
+
+    for (;;) {
+        int n = (int)recv(g_am.probe_socket, (char *)buf, (int)sizeof(buf), 0);
+        if (n < 0) break;
+        if (n < 10) continue;
+        /* Match the nonce: the socket is unconnected and anything can arrive
+         * on it, and an unrelated packet timed as our reply is a wrong number
+         * reported as fact. */
+        if (((uint32_t)buf[6] | (uint32_t)buf[7] << 8 |
+             (uint32_t)buf[8] << 16 | (uint32_t)buf[9] << 24) != g_am.probe_nonce)
+            continue;
+        g_am.rtt_ms = (int)(now - g_am.probe_sent_ms);
+        if (g_am.rtt_ms < 0) g_am.rtt_ms = 0;
+        if (g_am.rtt_ms > 2000) g_am.rtt_ms = 2000;   /* the server clamps here too */
+        fprintf(stderr, "snes_lobby: automatch probe %s:%d rtt=%d ms\n",
+                g_am.probe_host, g_am.probe_port, g_am.rtt_ms);
+        automatch_probe_close();
+        /* Queued already? Then the ticket was enqueued on an unknown latency
+         * and the server is holding it out of pairing for the probe grace --
+         * tell it now rather than letting the grace lapse. */
+        if (g_am.state == SNES_LOBBY_AUTOMATCH_QUEUED) automatch_send_rtt();
+        return;
+    }
+    if (now - g_am.probe_sent_ms > 2000) {
+        fprintf(stderr, "snes_lobby: automatch probe timed out (%s:%d) -- "
+                        "queueing without a latency estimate\n",
+                g_am.probe_host, g_am.probe_port);
+        automatch_probe_close();
+    }
+}
+
+static char g_disc_fp[65];
+
+void snes_lobby_set_disc_fp(const char *hex)
+{
+    size_t i;
+    g_disc_fp[0] = '\0';
+    if (!hex) return;
+    /* Validated, not trusted: the wire contract is 64 lower-case hex, and a
+     * malformed value would be refused by the server as need_disc_fp far from
+     * where it was set. Accept upper-case by folding it, refuse anything else
+     * outright rather than sending a fingerprint that names nothing. */
+    if (strlen(hex) != 64) return;
+    for (i = 0; i < 64; ++i) {
+        char c = hex[i];
+        if (c >= 'A' && c <= 'F') c = (char)(c - 'A' + 'a');
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+            g_disc_fp[0] = '\0';
+            return;
+        }
+        g_disc_fp[i] = c;
+    }
+    g_disc_fp[64] = '\0';
+    fprintf(stderr, "snes_lobby: rom fingerprint %.16s... (disc_fp)\n", g_disc_fp);
+}
+
+const char *snes_lobby_disc_fp(void) { return g_disc_fp; }
+
+/* Walk to the next {...} in an array, copying it out. Returns 0 at ']'. */
+static int automatch_next_object(const char **pp, char *out, size_t cap)
+{
+    const char *p = *pp;
+    const char *start;
+    int depth = 0;
+    size_t n;
+
+    while (*p && *p != '{') {
+        if (*p == ']') { *pp = p; return 0; }
+        ++p;
+    }
+    if (*p != '{') { *pp = p; return 0; }
+    start = p;
+    do {
+        if (*p == '{') ++depth;
+        else if (*p == '}') --depth;
+        ++p;
+    } while (*p && depth > 0);
+    n = (size_t)(p - start);
+    if (n >= cap) n = cap - 1;
+    memcpy(out, start, n);
+    out[n] = '\0';
+    *pp = p;
+    return 1;
+}
+
+/* `probe: { endpoint, magic, type }` -- where to measure the path. Published
+ * on both rulesets_ok and queued, and taken from whichever arrived last. */
+static void automatch_ingest_probe(const char *obj)
+{
+    char endpoint[160];
+    char *colon;
+    endpoint[0] = '\0';
+    json_get_str(obj, "endpoint", endpoint, sizeof(endpoint));
+    /* Rightmost colon: an IPv6 literal has several, and the port is last. */
+    colon = strrchr(endpoint, ':');
+    if (!colon || !colon[1]) return;
+    *colon = '\0';
+    snprintf(g_am.probe_host, sizeof(g_am.probe_host), "%s", endpoint);
+    g_am.probe_port = atoi(colon + 1);
+    g_am.probe_magic = (unsigned)json_get_int(obj, "magic", 0);
+    g_am.probe_type = json_get_int(obj, "type", 200);
+}
+
+/* `titles: [ { ..., pool: N } ]` -- this host queues one title, so the first
+ * row is the one the player is waiting in. */
+static int automatch_first_pool(const char *json)
+{
+    const char *p = strstr(json, "\"titles\"");
+    char obj[512];
+    if (!p) return g_am.pool;
+    p = strchr(p, '[');
+    if (!p) return g_am.pool;
+    ++p;
+    if (!automatch_next_object(&p, obj, sizeof(obj))) return 0;
+    return json_get_int(obj, "pool", 0);
+}
+
+static void automatch_send_rtt(void)
+{
+    char msg[128];
+    if (g_am.rtt_ms < 0 || g_am.rtt_reported) return;
+    snprintf(msg, sizeof(msg),
+             "{\"op\":\"automatch_rtt\",\"rtt_ms\":%d}", g_am.rtt_ms);
+    queue_send(msg);
+    g_am.rtt_reported = 1;
+}
+
+int snes_lobby_automatch_request_rulesets(void)
+{
+    char msg[256];
+    char gn_esc[SNES_LOBBY_NAME_LEN * 2 + 4];
+    const char *gn = g_lc.filter_game_name;
+    if (!gn || !gn[0]) return -1;
+    if (g_am.rulesets_in_flight) return 0;
+    json_escape(gn, gn_esc, sizeof(gn_esc));
+    snprintf(msg, sizeof(msg),
+             "{\"op\":\"automatch_rulesets\",\"game_name\":\"%s\"}", gn_esc);
+    queue_send(msg);
+    g_am.rulesets_in_flight = 1;
+    return 0;
+}
+
+int snes_lobby_automatch_available(void)
+{
+    /* Zero rulesets is a real answer and means the same as "no": this
+     * deployment has none loaded for this title. Not having ASKED yet is also
+     * no -- the button must not be offered on an assumption. */
+    return g_am.have_rulesets && g_am.ruleset_count > 0;
+}
+
+int snes_lobby_automatch_ruleset_count(void) { return g_am.ruleset_count; }
+
+int snes_lobby_automatch_ruleset_get(int index, SnesLobbyRuleset *out)
+{
+    if (!out || index < 0 || index >= g_am.ruleset_count) return 0;
+    *out = g_am.rulesets[index];
+    return 1;
+}
+
+int snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled)
+{
+    char msg[1024];
+    char gn_esc[SNES_LOBBY_NAME_LEN * 2 + 4];
+    char gv_esc[SNES_LOBBY_VERSION_LEN * 2 + 4];
+    char rid_esc[SNES_LOBBY_RULESET_ID_LEN * 2 + 4];
+    const char *rid = (ruleset_id && ruleset_id[0]) ? ruleset_id
+                      : (g_am.ruleset_count > 0 ? g_am.rulesets[0].id : "");
+    const char *disc_fp = snes_lobby_disc_fp();
+    char rtt[48];
+
+    if (!g_lc.connected) return -1;
+    if (!rid[0]) return -1;
+    if (g_am.state == SNES_LOBBY_AUTOMATCH_QUEUED ||
+        g_am.state == SNES_LOBBY_AUTOMATCH_FOUND)
+        return -1;
+    /* The queue key REQUIRES a fingerprint: in `join` an empty one means
+     * "legacy host, no check", and a wildcard in a queue silently pairs a
+     * different dump against this one. Refuse here rather than let the server
+     * answer need_disc_fp, so the reason is available before the round trip. */
+    if (!disc_fp || strlen(disc_fp) != 64) {
+        automatch_fail("this build cannot fingerprint its ROM, so it cannot queue");
+        return -1;
+    }
+
+    json_escape(g_lc.filter_game_name, gn_esc, sizeof(gn_esc));
+    json_escape(effective_game_version(NULL), gv_esc, sizeof(gv_esc));
+    json_escape(rid, rid_esc, sizeof(rid_esc));
+
+    /* Measure before queueing when we can: a client that probes first never
+     * waits out the server's probe grace at all. */
+    if (g_am.rtt_ms < 0) automatch_probe_send();
+    rtt[0] = '\0';
+    if (g_am.rtt_ms >= 0)
+        snprintf(rtt, sizeof(rtt), ",\"rtt_ms\":%d", g_am.rtt_ms);
+
+    /* One title: this host runs one game. A multi-title launcher sends
+     * several here, in preference order; the wire has always allowed it. */
+    snprintf(msg, sizeof(msg),
+             "{\"op\":\"automatch_queue\",\"titles\":[{"
+             "\"game_name\":\"%s\",\"game_version\":\"%s\","
+             "\"disc_fp\":\"%s\",\"ruleset_id\":\"%s\",\"max_slots\":2}],"
+             "\"mods_enabled\":%s%s}",
+             gn_esc, gv_esc, disc_fp, rid_esc,
+             mods_enabled ? "true" : "false", rtt);
+    queue_send(msg);
+    g_am.error[0] = '\0';
+    g_am.queue_in_flight = 1;
+    g_am.rtt_reported = (g_am.rtt_ms >= 0);
+    return 0;
+}
+
+int snes_lobby_automatch_cancel(void)
+{
+    if (!g_lc.connected) return -1;
+    queue_send("{\"op\":\"automatch_cancel\"}");
+    return 0;
+}
+
+int snes_lobby_automatch_state(void) { return g_am.state; }
+int snes_lobby_automatch_queued_secs(void) { return g_am.queued_secs; }
+int snes_lobby_automatch_pool(void) { return g_am.pool; }
+
+int snes_lobby_automatch_found_get(SnesLobbyAutomatchFound *out)
+{
+    if (!out || g_am.state != SNES_LOBBY_AUTOMATCH_FOUND) return 0;
+    *out = g_am.found;
+    return 1;
+}
+
+int snes_lobby_automatch_accept(int accept)
+{
+    char msg[160];
+    char tid_esc[SNES_LOBBY_ID_LEN * 2 + 4];
+    if (!g_lc.connected) return -1;
+    if (g_am.state != SNES_LOBBY_AUTOMATCH_FOUND) return -1;
+    /* The ticket id is echoed so a late answer to a LAPSED offer is discarded
+     * rather than applied to whatever offer is current by then. */
+    json_escape(g_am.ticket_id, tid_esc, sizeof(tid_esc));
+    snprintf(msg, sizeof(msg),
+             "{\"op\":\"automatch_accept\",\"ticket_id\":\"%s\","
+             "\"accept\":%s}", tid_esc, accept ? "true" : "false");
+    queue_send(msg);
+    if (accept) {
+        g_am.state = SNES_LOBBY_AUTOMATCH_ACCEPTED;
+    } else {
+        /* Declining ends the ticket. The strike is the server's to record. */
+        automatch_reset_queue_state();
+    }
+    return 0;
+}
+
+void snes_lobby_automatch_refuse_local(const char *why)
+{
+    automatch_fail(why);
+}
+
+const char *snes_lobby_automatch_error(void) { return g_am.error; }
 
 static void member_rtt_clear(void)
 {
@@ -455,17 +912,38 @@ static const char *effective_game_version(const char *override_ver)
     return SNES_GAME_VERSION;
 }
 
+static const char *identity_version_override(void);   /* fwd */
+
 static int list_filter_version_strict(void)
 {
-    /* Any dev build lists UNFILTERED, including the "dev+<sha>" ones.
+    /* A run under SNES_NET_GAME_VERSION lists UNFILTERED whatever the pin
+     * looks like. The override exists to put two development machines in one
+     * pool, and the mistake that session invites is setting it on ONE of them
+     * -- at which point strict filtering hides the other's lobby and hands
+     * back exactly the "my friend's lobby isn't showing up" symptom the rest
+     * of this function exists to prevent, in the situation least able to
+     * afford it. Show every lobby and let the join explain the mismatch. */
+    if (identity_version_override()) return 0;
+
+    /* Otherwise: any build that is not a plain released version lists
+     * UNFILTERED.
      *
      * The version pin is still enforced -- the server refuses the join with
      * version_mismatch -- but a filtered list would hide the mismatched lobby
      * instead of explaining it, and "my friend's lobby isn't showing up" is a
-     * much worse thing to debug than "this lobby is a different build". Prefix,
-     * not equality: dev+abc12345 and dev+abc12345-dirty are both dev. */
+     * much worse thing to debug than "this lobby is a different build".
+     *
+     * The test is the QUALIFIER, not a "dev" prefix. A pin is unqualified only
+     * for a clean release build ("0.1.5"); every other shape carries a '+' and
+     * what follows it: "dev+abc12345", "dev+abc12345-dirty.1234abcd", and --
+     * the case the old prefix test missed -- "0.1.5+abc12345-dirty.1234abcd",
+     * which is what CMake stamps for a Release-TYPE build from a modified
+     * tree. That is an ordinary local build, and it was being classified as a
+     * release and silently filtering every other build out of its own lobby
+     * list, which is precisely the debugging pain this function exists to
+     * prevent. */
     const char *gv = effective_game_version(NULL);
-    return gv && gv[0] && strncmp(gv, "dev", 3) != 0;
+    return gv && gv[0] && strchr(gv, '+') == NULL;
 }
 
 static void queue_send(const char *json);
@@ -1639,6 +2117,16 @@ static void handle_server_json(const char *json)
     }
     if (strcmp(op, "joined") == 0) {
         snes_lobby_chat_clear();
+        /* A ticket that reached a room is spent. `joined` is that moment for
+         * automatch (docs/AUTOMATCH.md 8: automatch_accept_ok -> both accepted
+         * -> joined -> lobby_update -> launch), and nothing else used to leave
+         * ACCEPTED: the state survived the whole match and the accept gate
+         * reopened over the lobby list on the way out, offering to wait for a
+         * peer to answer an offer the server had closed to create this room.
+         * Not an automatch special case -- the server refuses to queue an
+         * account that is already in a lobby (`already_in_lobby`), so holding
+         * a ticket and being seated are mutually exclusive either way. */
+        automatch_reset_queue_state();
         g_lc.in_lobby = 1;
         g_lc.is_host = 0;
         g_lc.join.ok = 1;
@@ -1901,8 +2389,148 @@ static void handle_server_json(const char *json)
                     "a plan it could not parse -- check the host's build\n");
         return;
     }
+    /* ── automatch ─────────────────────────────────────────────────────── */
+    if (strcmp(op, "automatch_rulesets_ok") == 0) {
+        const char *p2 = strstr(json, "\"rulesets\"");
+        char probe[256];
+        int n = 0;
+        g_am.have_rulesets = 1;
+        g_am.rulesets_in_flight = 0;
+        g_am.ruleset_count = 0;
+        if (json_extract_object(json, "probe", probe, sizeof(probe)))
+            automatch_ingest_probe(probe);
+        if (!p2) return;
+        p2 = strchr(p2, '[');
+        if (!p2) return;
+        ++p2;
+        while (*p2 && n < SNES_LOBBY_MAX_RULESETS) {
+            char obj[1024];
+            if (!automatch_next_object(&p2, obj, sizeof(obj))) break;
+            {
+                SnesLobbyRuleset *r = &g_am.rulesets[n];
+                char caps[512];
+                memset(r, 0, sizeof(*r));
+                json_get_str(obj, "id", r->id, sizeof(r->id));
+                json_get_str(obj, "label", r->label, sizeof(r->label));
+                json_get_str(obj, "caps_summary", r->caps_summary,
+                             sizeof(r->caps_summary));
+                json_get_str(obj, "game_version", r->game_version,
+                             sizeof(r->game_version));
+                if (json_extract_object(obj, "match_caps", caps, sizeof(caps)))
+                    parse_match_caps_object(caps, &r->caps);
+                if (r->id[0]) ++n;
+            }
+        }
+        g_am.ruleset_count = n;
+        fprintf(stderr, "snes_lobby: automatch %d ruleset(s) for \"%s\"\n",
+                n, g_lc.filter_game_name);
+        /* Measure now rather than at queue time: a client that has already
+         * probed never waits out the server's probe grace. */
+        if (n > 0 && g_am.rtt_ms < 0) automatch_probe_send();
+        return;
+    }
+    if (strcmp(op, "automatch_queued") == 0) {
+        char probe[256];
+        g_am.state = SNES_LOBBY_AUTOMATCH_QUEUED;
+        g_am.error[0] = '\0';
+        g_am.queue_in_flight = 0;
+        json_get_str(json, "ticket_id", g_am.ticket_id, sizeof(g_am.ticket_id));
+        g_am.queued_secs = 0;
+        g_am.pool = automatch_first_pool(json);
+        if (json_extract_object(json, "probe", probe, sizeof(probe)))
+            automatch_ingest_probe(probe);
+        if (g_am.rtt_ms < 0) automatch_probe_send();
+        else automatch_send_rtt();
+        fprintf(stderr, "snes_lobby: automatch queued (pool=%d)\n", g_am.pool);
+        return;
+    }
+    if (strcmp(op, "automatch_status") == 0) {
+        /* Pushed at most 1 Hz while queued. Not a state change: a status for
+         * a ticket we already gave up on must not resurrect the queue. */
+        if (g_am.state != SNES_LOBBY_AUTOMATCH_QUEUED) return;
+        g_am.queued_secs = json_get_int(json, "queued_secs", g_am.queued_secs);
+        g_am.pool = automatch_first_pool(json);
+        return;
+    }
+    if (strcmp(op, "automatch_found") == 0) {
+        memset(&g_am.found, 0, sizeof(g_am.found));
+        json_get_str(json, "ticket_id", g_am.ticket_id, sizeof(g_am.ticket_id));
+        json_get_str(json, "opponent", g_am.found.opponent,
+                     sizeof(g_am.found.opponent));
+        json_get_str(json, "opponent_country", g_am.found.opponent_country,
+                     sizeof(g_am.found.opponent_country));
+        json_get_str(json, "ruleset_id", g_am.found.ruleset_id,
+                     sizeof(g_am.found.ruleset_id));
+        json_get_str(json, "label", g_am.found.ruleset_label,
+                     sizeof(g_am.found.ruleset_label));
+        g_am.found.est_rtt_ms = json_get_int(json, "est_rtt_ms", 0);
+        g_am.found.accept_secs = json_get_int(json, "accept_secs", 15);
+        g_am.state = SNES_LOBBY_AUTOMATCH_FOUND;
+        fprintf(stderr, "snes_lobby: automatch found opponent=\"%s\" "
+                        "est_rtt=%d ms, %d s to answer\n",
+                g_am.found.opponent, g_am.found.est_rtt_ms,
+                g_am.found.accept_secs);
+        return;
+    }
+    if (strcmp(op, "automatch_accept_ok") == 0) {
+        g_am.state = SNES_LOBBY_AUTOMATCH_ACCEPTED;
+        return;
+    }
+    if (strcmp(op, "automatch_requeue") == 0) {
+        /* The other side declined or let it lapse. Back to waiting, with the
+         * ticket intact -- this is not a failure and must not read as one. */
+        g_am.state = SNES_LOBBY_AUTOMATCH_QUEUED;
+        memset(&g_am.found, 0, sizeof(g_am.found));
+        g_am.pool = automatch_first_pool(json);
+        fprintf(stderr, "snes_lobby: automatch re-queued (the offer lapsed)\n");
+        return;
+    }
+    if (strcmp(op, "automatch_cancelled") == 0) {
+        automatch_reset_queue_state();
+        return;
+    }
+    if (strcmp(op, "automatch_rtt_ok") == 0) {
+        return;   /* acknowledgement only */
+    }
     if (strcmp(op, "error") == 0) {
         json_get_str(json, "code", g_lc.join.last_error, sizeof(g_lc.join.last_error));
+        /* An automatch refusal arrives as a plain error, so it has to be
+         * claimed here or it would be filed as a join failure and the queue
+         * would sit waiting for a pairing that was never going to come. Only
+         * while an automatch attempt is actually in flight: these codes are
+         * automatch's, but `error` is everyone's. */
+        if (g_am.queue_in_flight ||
+            g_am.state == SNES_LOBBY_AUTOMATCH_QUEUED ||
+            g_am.state == SNES_LOBBY_AUTOMATCH_FOUND ||
+            g_am.state == SNES_LOBBY_AUTOMATCH_ACCEPTED) {
+            const char *code = g_lc.join.last_error;
+            const char *why = NULL;
+            char line[160];
+            if      (!strcmp(code, "need_account"))       why = "Sign in to use automatch";
+            else if (!strcmp(code, "automatch_off"))      why = "This server has no automatch queues";
+            else if (!strcmp(code, "already_queued"))     why = "This account is already in a queue";
+            else if (!strcmp(code, "already_in_lobby"))   why = "Leave the room first";
+            else if (!strcmp(code, "unknown_ruleset"))    why = "That queue type is gone -- refresh";
+            else if (!strcmp(code, "need_disc_fp"))       why = "The server needs a ROM fingerprint this build did not send";
+            else if (!strcmp(code, "version_not_pooled")) why = "This release is not the one this queue pools";
+            else if (!strcmp(code, "mods_not_pooled"))    why = "Turn off sim-affecting mods to queue";
+            else if (!strcmp(code, "slots_not_pooled"))   why = "Automatch is two-player only";
+            else if (!strcmp(code, "queue_full"))         why = "The queue is full -- try again shortly";
+            else if (!strcmp(code, "cooldown")) {
+                int retry = json_get_int(json, "retry_secs", 0);
+                if (retry > 0)
+                    snprintf(line, sizeof(line),
+                             "Declining put you on a %d s cooldown", retry);
+                else
+                    snprintf(line, sizeof(line), "You are on a queue cooldown");
+                why = line;
+            }
+            if (why) {
+                g_am.queue_in_flight = 0;
+                automatch_fail(why);
+                return;
+            }
+        }
         /* Keep seating valid: start/need_players/etc. must not block a later
          * successful op:launch from filling netplay_launch. */
         if (!g_lc.in_lobby)
@@ -1912,6 +2540,10 @@ static void handle_server_json(const char *json)
     if (strcmp(op, "lobby_closed") == 0 || strcmp(op, "left") == 0 ||
         strcmp(op, "kicked") == 0) {
         snes_lobby_chat_clear();
+        /* Leaving a room must never leave a queue ticket looking live. The
+         * reset on `joined` above should already have done this; repeating it
+         * here means a missed or reordered `joined` cannot strand the gate. */
+        automatch_reset_queue_state();
         g_lc.swap_in_valid = 0;
         g_lc.swap_out = 0;
         g_lc.in_lobby = 0;
@@ -2135,6 +2767,11 @@ void snes_lobby_pump(void)
      * before the connected() check: an agent mid-handshake still has to be
      * pumped so it can fail cleanly rather than hang if the WS drops. */
     snes_lobby_mod_xfer_pump();
+    /* Same reasoning as the transfer above: the probe runs while the player
+     * sits in a queue, which is a state with no session and no room, so
+     * nothing else would drive it. Before the connected() check so an
+     * outstanding probe still times out cleanly if the WS drops. */
+    automatch_probe_poll();
     if (!snes_lobby_connected()) {
         return;
     }
@@ -2220,15 +2857,61 @@ void snes_lobby_pump(void)
     }
 }
 
+/*
+ * SNES_NET_GAME_VERSION -- pin the announced version for one run.
+ *
+ * The derived pin deliberately makes two builds match ONLY when they really
+ * are the same build: a clean release is its tag, and a development build
+ * carries its commit plus a hash of its uncommitted diff. That is what stops
+ * two peers whose trees differ from pairing and then desyncing, and it must
+ * stay the default for anyone who does not ask otherwise.
+ *
+ * But it also makes DEVELOPMENT testing awkward. Two machines mid-change are
+ * exactly the pair that will not match, and reconfiguring both to agree means
+ * a CMake cache edit and a rebuild on each -- for a run whose whole purpose is
+ * to test the change that made them differ.
+ *
+ * So the override is here, deliberately as an environment variable: it is
+ * per-run rather than baked into an artifact, it takes an explicit act on both
+ * machines, and it announces itself loudly enough that nobody mistakes an
+ * overridden build for an honest one. It is a TESTING tool. Two peers who set
+ * it to the same string are asserting their builds agree; the runtime cannot
+ * check that for them, and a desync under an override is the answer to a
+ * question the override asked.
+ */
+static const char *identity_version_override(void)
+{
+    const char *e = getenv("SNES_NET_GAME_VERSION");
+    return (e && e[0]) ? e : NULL;
+}
+
 void snes_lobby_set_game_identity(const char *game_name,
                                   const char *game_version)
 {
+    const char *forced = identity_version_override();
+
     if (game_name) {
         strncpy(g_lc.filter_game_name, game_name,
                 sizeof(g_lc.filter_game_name) - 1);
         g_lc.filter_game_name[sizeof(g_lc.filter_game_name) - 1] = '\0';
     } else {
         g_lc.filter_game_name[0] = '\0';
+    }
+    if (forced) {
+        strncpy(g_lc.filter_game_version, forced,
+                sizeof(g_lc.filter_game_version) - 1);
+        g_lc.filter_game_version[sizeof(g_lc.filter_game_version) - 1] = '\0';
+        /* Said on every identity change, not once: the honest pin this is
+         * standing in for is the thing a later desync report needs, and a
+         * line printed only at startup is the line nobody scrolls back to. */
+        fprintf(stderr,
+                "snes_lobby: game_version FORCED to \"%s\" by "
+                "SNES_NET_GAME_VERSION (this build is really \"%s\"). "
+                "Testing override -- both peers must be the same build.\n",
+                g_lc.filter_game_version,
+                (game_version && game_version[0]) ? game_version
+                                                  : SNES_GAME_VERSION);
+        return;
     }
     if (game_version && game_version[0]) {
         strncpy(g_lc.filter_game_version, game_version,

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -63,6 +63,10 @@ typedef struct SnesLobbyOnlinePlayer {
     /* First 8 characters of the player's connection id: enough to tell
      * "which row is me" without publishing whole ids to browsers. */
     char tag[12];
+    /* Opaque account id behind this player; "" for a guest. Not a name and
+     * not a Discord identifier -- a key a local ignore/block list can use
+     * because it survives the player reconnecting and renaming. */
+    char account[SNES_LOBBY_ID_LEN];
     /* The title that player is browsing for; rows of other titles are
      * dropped at parse time when this client has a game identity. */
     char game_name[SNES_LOBBY_NAME_LEN];
@@ -79,6 +83,10 @@ typedef struct SnesLobbyOnlinePlayer {
 #define SNES_LOBBY_CHAT_RING 64
 typedef struct SnesLobbyChatMsg {
     char     player_id[SNES_LOBBY_ID_LEN];
+    /* Opaque account id behind this player; "" for a guest. Not a name and
+     * not a Discord identifier -- a key a local ignore/block list can use
+     * because it survives the player reconnecting and renaming. */
+    char     account[SNES_LOBBY_ID_LEN];
     char     from[SNES_LOBBY_NAME_LEN];
     char     text[SNES_LOBBY_CHAT_TEXT_LEN];
     int      is_local;

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -683,6 +683,20 @@ typedef struct SnesLobbyDesyncReport {
 
 int  snes_lobby_report_desync(const SnesLobbyDesyncReport *r);
 
+/*
+ * Tell the server which accounts this player has blocked.
+ *
+ * ';'-separated opaque account ids, replacing the whole set -- the client's
+ * own file is the authority, so an unblock needs no separate op.
+ *
+ * Sent to the SERVER rather than applied only here, because two of the three
+ * things a block has to do cannot be done from this side: the matchmaker must
+ * not pair the two, and the blocked player must not see or be able to join
+ * the blocker's room. A client can hide what it was sent; it cannot know it
+ * was blocked by somebody else, and that is the direction that matters.
+ */
+int  snes_lobby_set_blocks(const char *accounts);
+
 int  snes_lobby_automatch_request_rulesets(void);
 int  snes_lobby_automatch_available(void);
 int  snes_lobby_automatch_ruleset_count(void);

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -89,6 +89,15 @@ typedef struct SnesLobbyChatMsg {
     char     account[SNES_LOBBY_ID_LEN];
     char     from[SNES_LOBBY_NAME_LEN];
     char     text[SNES_LOBBY_CHAT_TEXT_LEN];
+    /* The SERVER's id for this line, and what snes_lobby_report_chat names.
+     * Empty for a system line, for a locally generated one, and for anything
+     * relayed by a server too old to assign one -- in all three cases the
+     * line cannot be reported, because there is no agreed referent for it.
+     *
+     * A report carries this and NOT the text: the server writes down what it
+     * relayed under this id. Sending the words would let a client fabricate a
+     * message and have somebody sanctioned for it. */
+    char     mid[40];
     int      is_local;
     int      is_system;
     uint32_t seq;
@@ -381,6 +390,25 @@ int  snes_lobby_local_wire_slot(void);
 /* ---- lobby chat --------------------------------------------------------
  * Spectators take part: the server fans a line out to everyone in the room,
  * and talking is not affecting the match. */
+/* Report somebody's chat line to the server for moderation.
+ *
+ * `mids` are SnesLobbyChatMsg.mid values -- several at once, because
+ * harassment is usually a burst rather than a line. An entry with an empty id
+ * is skipped; a line with no id cannot be reported at all. `reason` is one of
+ * RNET_REPORT_* (anything unrecognised is filed as "other" rather than
+ * refused); `note` is an optional sentence for whoever reads the queue.
+ *
+ * The text is never sent: see SnesLobbyChatMsg.mid.
+ *
+ * Returns 0 if the report was handed to the server. That is not the same as
+ * accepted -- the server refuses a line that has scrolled out of its ring
+ * ("message_expired"), one from a signed-out sender, one that is your own, and
+ * anything over the per-account rate limit. */
+/* Categories live in recomp_net/chat_report.h (RNET_REPORT_*), because they
+ * are the same list on every console and the server matches on them. */
+int  snes_lobby_report_chat(const char *const *mids, int mid_count,
+                            const char *reason, const char *note);
+
 int  snes_lobby_send_chat(const char *text);
 
 /* Server chat: per-game, outside any room (op server_chat). Its own ring,

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -207,6 +207,23 @@ typedef struct SnesLobbyMatchCaps {
      * Carried so a guest can match the host BEFORE launching rather than
      * discovering the difference from a refused match. */
     char mod_set[512];
+    /* Which packages this match's AUTHORITY grants the presentation-only
+     * exemption to: ';'-separated `id@version` or `id@version#sha256`.
+     *
+     * A mod declaring `presentation_only` in its own manifest is only asking.
+     * This is the grant, and it comes from the server (in an automatch
+     * ruleset) or from the host (in a lobby) -- never from the machine that
+     * wants the exemption, because a cheat author writes manifests too.
+     *
+     * EMPTY MEANS NOTHING IS EXEMPT, which is what an older host and a
+     * ruleset without the key both produce, and is the answer that fails
+     * safe: an ungranted claim is treated as an ordinary simulation mod, so
+     * it must match or be switched off.
+     *
+     * Names bytes, not just a string, when the `#sha256` form is used --
+     * otherwise the list is keyed on an id the client picks for itself, and a
+     * mod gets exempted by calling itself something allowlisted. */
+    char mod_cosmetic_allow[512];
 } SnesLobbyMatchCaps;
 
 typedef struct SnesLobbyJoinInfo {
@@ -597,6 +614,25 @@ typedef struct SnesLobbyAutomatchFound {
 
 /* Ask the server what queues it offers for this title. Answered into
  * snes_lobby_ruleset_count/get; 0 of them means automatch is off here. */
+/*
+ * One simulation-state fork, as reported to the server.
+ *
+ * Evidence, not a verdict: both digests, from both peers independently. See
+ * snes_lobby_report_desync for why a fork is never an accusation on its own.
+ */
+typedef struct SnesLobbyDesyncReport {
+    uint32_t tick;
+    const char *partition;   /* "wram", "apu", "ppu", "post", "other" */
+    uint32_t mine;           /* local master digest */
+    uint32_t theirs;         /* the peer's, as received */
+    int is_host;
+    /* The cosmetic exemptions this peer was running, so a report can be read
+     * beside what the match approved. ';'-separated `id@version#sha256`. */
+    const char *mod_exempt;
+} SnesLobbyDesyncReport;
+
+int  snes_lobby_report_desync(const SnesLobbyDesyncReport *r);
+
 int  snes_lobby_automatch_request_rulesets(void);
 int  snes_lobby_automatch_available(void);
 int  snes_lobby_automatch_ruleset_count(void);
@@ -616,7 +652,19 @@ int  snes_lobby_automatch_ruleset_get(int index, SnesLobbyRuleset *out);
  * A server refusal arrives asynchronously as state FAILED with a reason in
  * snes_lobby_automatch_error().
  */
-int  snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled);
+/*
+ * `mod_exempt` is the EVIDENCE for every cosmetic exemption this build is
+ * taking: ';'-separated `id@version#sha256`, from
+ * snes_mod_runtime_exempted_packages_c. NULL or "" means none.
+ *
+ * It is sent so the SERVER can check those exemptions against its own
+ * allowlist. `mods_enabled` beside it is still this client's own verdict and
+ * still refused when true -- the two are layers, not alternatives: an old
+ * server ignores the evidence and the boolean keeps working, a new server
+ * checks the evidence and stops trusting the boolean to be the whole story.
+ */
+int  snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled,
+                                const char *mod_exempt);
 int  snes_lobby_automatch_cancel(void);
 int  snes_lobby_automatch_state(void);
 int  snes_lobby_automatch_queued_secs(void);

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -263,9 +263,18 @@ const char *snes_lobby_player_id(void);
 /* Non-blocking pump — call every frame from the launcher. */
 void snes_lobby_pump(void);
 
-/* Title + release pin used for create/join matching and list filters. */
+/* Title + release pin used for create/join matching and list filters.
+ *
+ * SNES_NET_GAME_VERSION overrides the pin for one run, for TESTING two
+ * development builds against each other without reconfiguring and rebuilding
+ * both. Set the same string on both machines. It is announced on stderr with
+ * the real pin beside it every time the identity is set, because a build
+ * lying about which build it is has to be visible in the log a desync report
+ * is written from. Unset (the normal case) keeps the derived pin, which
+ * matches only builds that really are the same build. */
 void snes_lobby_set_game_identity(const char *game_name,
                                   const char *game_version);
+/* The pin actually presented on the wire -- the override when one is set. */
 const char *snes_lobby_game_version(void);
 
 void snes_lobby_request_list(void);
@@ -520,6 +529,107 @@ typedef struct SnesLobbyTurnCredentials {
 int  snes_lobby_request_turn_credentials(void);
 /* Non-NULL; valid==0 when unavailable / expired / STUN-only. */
 const SnesLobbyTurnCredentials *snes_lobby_turn_credentials(void);
+
+/* ── ROM fingerprint ────────────────────────────────────────────────────────
+ *
+ * Lower-case hex SHA-256 of the guest image this build is actually running,
+ * 64 characters. The host sets it once at startup; "" means unknown.
+ *
+ * In `join` an empty fingerprint means "legacy host, no check" -- a wildcard.
+ * That is tolerable between two people who chose each other's room and can
+ * talk about it. It is NOT tolerable in a queue: a wildcard there silently
+ * pairs a Track-01-only dump against a full one, which is exactly what the
+ * fingerprint was added to catch, so automatch refuses to queue without a
+ * real one.
+ */
+void snes_lobby_set_disc_fp(const char *hex64);
+const char *snes_lobby_disc_fp(void);
+
+/* ── Automatch ──────────────────────────────────────────────────────────────
+ *
+ * Server-run pairing: the player asks for a match and the SERVER creates the
+ * room, is its host, and owns its match_caps from a named ruleset. Protocol:
+ * recomp-net-server docs/AUTOMATCH.md. Everything downstream of the pairing is
+ * the ordinary `joined` / `lobby_update` / `launch` path already in this file,
+ * so this adds a queue and an accept gate and nothing else.
+ *
+ * Requires a signed-in account: the accept gate charges a dodge cooldown, and
+ * a cost that reconnecting erases is not a cost.
+ */
+#define SNES_LOBBY_MAX_RULESETS 8
+#define SNES_LOBBY_RULESET_ID_LEN 48
+#define SNES_LOBBY_RULESET_LABEL_LEN 64
+#define SNES_LOBBY_CAPS_SUMMARY_LEN 96
+
+/* One queue type this server offers for this title. */
+typedef struct SnesLobbyRuleset {
+    char id[SNES_LOBBY_RULESET_ID_LEN];
+    char label[SNES_LOBBY_RULESET_LABEL_LEN];
+    /* Server-derived one-liner ("Delay 2 - Rollback on"). Derived from the
+     * caps rather than authored, so it cannot drift from what the match runs. */
+    char caps_summary[SNES_LOBBY_CAPS_SUMMARY_LEN];
+    /* The caps the match will run. Parsed like a host's blob, because that is
+     * exactly what it is -- the server is the host of an automatch room. */
+    SnesLobbyMatchCaps caps;
+    /* Empty = any release may queue (still only pooling with its own). */
+    char game_version[SNES_LOBBY_VERSION_LEN];
+} SnesLobbyRuleset;
+
+/* Matches RECOMP_LAUNCHER_AUTOMATCH_* so the host layer can hand these
+ * straight to the launcher without a translation table that could drift. */
+enum {
+    SNES_LOBBY_AUTOMATCH_IDLE = 0,
+    SNES_LOBBY_AUTOMATCH_QUEUED = 1,
+    SNES_LOBBY_AUTOMATCH_FOUND = 2,
+    SNES_LOBBY_AUTOMATCH_ACCEPTED = 3,
+    SNES_LOBBY_AUTOMATCH_FAILED = 4
+};
+
+/* The offer on the table while state is FOUND. */
+typedef struct SnesLobbyAutomatchFound {
+    char opponent[SNES_LOBBY_NAME_LEN];
+    char opponent_country[8];
+    char ruleset_id[SNES_LOBBY_RULESET_ID_LEN];
+    char ruleset_label[SNES_LOBBY_RULESET_LABEL_LEN];
+    int  est_rtt_ms;      /* the pair's estimate: rtt_a + rtt_b */
+    int  accept_secs;     /* seconds left to answer */
+} SnesLobbyAutomatchFound;
+
+/* Ask the server what queues it offers for this title. Answered into
+ * snes_lobby_ruleset_count/get; 0 of them means automatch is off here. */
+int  snes_lobby_automatch_request_rulesets(void);
+int  snes_lobby_automatch_available(void);
+int  snes_lobby_automatch_ruleset_count(void);
+int  snes_lobby_automatch_ruleset_get(int index, SnesLobbyRuleset *out);
+
+/*
+ * Join the queue. `ruleset_id` NULL/"" takes the first one.
+ *
+ * `mods_enabled` is the caller's assertion that a SIM-AFFECTING mod feature is
+ * on locally, beyond whatever the ruleset itself imposes. The server refuses a
+ * true with mods_not_pooled and cannot check it -- the assertion exists so a
+ * modified client makes a deliberate false statement rather than exploiting an
+ * omission (AUTOMATCH.md §5). The host layer decides it; this file only
+ * carries it.
+ *
+ * 0 = sent. <0 = refused locally (not connected, no account, already queued).
+ * A server refusal arrives asynchronously as state FAILED with a reason in
+ * snes_lobby_automatch_error().
+ */
+int  snes_lobby_automatch_queue(const char *ruleset_id, int mods_enabled);
+int  snes_lobby_automatch_cancel(void);
+int  snes_lobby_automatch_state(void);
+int  snes_lobby_automatch_queued_secs(void);
+int  snes_lobby_automatch_pool(void);
+int  snes_lobby_automatch_found_get(SnesLobbyAutomatchFound *out);
+/* accept != 0 accepts; 0 declines and takes the dodge strike. */
+int  snes_lobby_automatch_accept(int accept);
+/* Refuse a queue locally, with the reason the player sees. Used when the HOST
+ * already knows the server would bounce the ticket -- there is no value in a
+ * round trip that ends in a generic code when the client can name the actual
+ * feature that is in the way. */
+void snes_lobby_automatch_refuse_local(const char *why);
+const char *snes_lobby_automatch_error(void);
 
 #ifdef __cplusplus
 }

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -628,6 +628,19 @@ int  snes_lobby_automatch_accept(int accept);
  * already knows the server would bounce the ticket -- there is no value in a
  * round trip that ends in a generic code when the client can name the actual
  * feature that is in the way. */
+/*
+ * Non-zero while the room this client is seated in was created by AUTOMATCH.
+ *
+ * The distinction matters on the way OUT of a match. A human-hosted room is
+ * somebody's room: it survives the match, and staying seated is how a rematch
+ * happens. An automatch room is the server's, it is created at both-accept
+ * and is not joinable by anyone, and there is no host to rematch with -- so
+ * staying in it leaves the player parked in a room that can never fill, and
+ * the server refuses their next ticket with `already_in_lobby`.
+ *
+ * Cleared by leaving, and by anything else that ends the seating.
+ */
+int snes_lobby_automatch_room(void);
 void snes_lobby_automatch_refuse_local(const char *why);
 const char *snes_lobby_automatch_error(void);
 

--- a/runner/src/lobby/snes_lobby_client.h
+++ b/runner/src/lobby/snes_lobby_client.h
@@ -293,6 +293,20 @@ void snes_lobby_set_game_identity(const char *game_name,
                                   const char *game_version);
 /* The pin actually presented on the wire -- the override when one is set. */
 const char *snes_lobby_game_version(void);
+/*
+ * Should a browser hide rooms whose game_version differs from ours?
+ *
+ * True only for a plain RELEASED version. Every development build carries a
+ * qualifier ("dev+abc12345", "0.1.5+abc12345-dirty.1234abcd") and lists
+ * UNFILTERED: the pin is still enforced at the join, but hiding the room robs
+ * the player of the explanation, and "my friend's lobby isn't showing up" is
+ * far worse to debug than "this lobby is a different build".
+ *
+ * Exported so the LAN beacon browser applies the SAME rule as the lobby-server
+ * browser. It did not, and two developers on one LAN -- whose dirty-diff
+ * hashes necessarily differ -- silently could not see each other at all.
+ */
+int snes_lobby_version_filter_strict(void);
 
 void snes_lobby_request_list(void);
 int  snes_lobby_list_count(void);

--- a/runner/src/mod_runtime.cpp
+++ b/runner/src/mod_runtime.cpp
@@ -62,6 +62,30 @@ struct Feature {
     std::string description;
     std::string group = "General";
     bool default_enabled = false;
+    /* This feature changes only what the local machine DRAWS, never what it
+     * simulates -- so it is left out of the effective set two netplay peers
+     * compare, and the two of them may differ on it freely.
+     *
+     * snes_mod_runtime_effective_set_c has always said that peers "must agree
+     * on every mod that touches guest memory"; this is the flag that finally
+     * lets a manifest say a mod does not. It was added for an accessibility
+     * filter (a photosensitivity flash guard), where requiring both sides to
+     * match would have made the feature useless in exactly the situation it
+     * exists for: a player who needs it does not get to pick their opponent,
+     * and should not have to ask one for permission to see fewer strobes.
+     *
+     * Declaring it is a CLAIM, and a false one desyncs a match. Set it only
+     * where the feature demonstrably touches no CPU, WRAM, VRAM, OAM, CGRAM,
+     * APU or save state -- a post-process on the presented framebuffer, a
+     * window or viewport policy, an overlay drawn after the guest frame. A
+     * mod that patches ROM text, freezes a RAM address or moves a sprite
+     * bound is simulation state whatever it looks like, and must NOT set it.
+     *
+     * Note that widescreen deliberately does NOT set this even though it is
+     * presentation-only: it negotiates a shared margin through the lobby's
+     * match caps so both peers run the same geometry, so agreement there is
+     * wanted rather than merely tolerated. */
+    bool presentation_only = false;
     std::vector<std::string> plugins;
 };
 
@@ -135,6 +159,20 @@ struct Validation {
 
 struct RegisteredPlugin {
     SNESModActivationCallback activation = nullptr;
+    /* The EXECUTABLE's word that this plugin only ever changes what is drawn.
+     *
+     * Set by snes_mod_register_presentation_plugin, i.e. by a line of C in a
+     * build somebody reviewed -- never by a manifest. That asymmetry is the
+     * whole value of the field: a manifest is authored by whoever authored the
+     * mod, so `presentation_only` there is the mod vouching for itself, while
+     * this is the program vouching for a function it contains.
+     *
+     * A manifest may therefore only ever claim the exemption for behaviour the
+     * shipped binary ALREADY implements and has already classified. It cannot
+     * introduce a new cosmetic behaviour, because it cannot introduce code at
+     * all: activation runs registered callbacks, and an unregistered id
+     * resolves to nothing. */
+    bool presentation = false;
 };
 
 std::map<std::string, RegisteredPlugin>& registered_plugins() {
@@ -172,6 +210,19 @@ struct Runtime {
     Validation committed;
     std::string error;
     bool initialized = false;
+
+    /* The cosmetic allowlist in force for this session -- see
+     * snes_mod_runtime_set_cosmetic_allow_c. EMPTY MEANS NOTHING IS EXEMPT,
+     * which is the only safe default: a manifest saying presentation_only is
+     * the mod's own claim about itself, and absent an authority to grant it,
+     * an unrecognised claim has to be worth nothing. */
+    std::string cosmetic_allow;
+    /* package id -> "version\0digest" memo, so a queue gate can pin package
+     * bytes without re-zipping a tree per check. Keyed by id@version. */
+    std::map<std::string, std::string> digest_cache;
+    /* id@version -> "carries nothing but manifest.toml", memoised for the same
+     * reason the digest is: it walks a directory. */
+    std::map<std::string, bool> manifest_only_cache;
 };
 
 Runtime& state() {
@@ -495,6 +546,9 @@ bool read_manifest(const fs::path& path, Package& out, std::string* error) {
                 else if (key == "default_enabled") {
                     parsed = parse_bool(value, bool_value);
                     if (parsed) feature->default_enabled = bool_value;
+                } else if (key == "presentation_only") {
+                    parsed = parse_bool(value, bool_value);
+                    if (parsed) feature->presentation_only = bool_value;
                 } else known = false;
                 break;
             case Section::Option:
@@ -669,6 +723,192 @@ bool feature_enabled(Runtime& runtime, const Package& package,
     if (!selection.has_enabled)
         selection.enabled = feature.default_enabled;
     return selection.enabled;
+}
+
+/* Deterministic content digest of an installed package, memoised.
+ *
+ * zip_store_tree sorts its file list precisely so that the same package packs
+ * to byte-identical bytes on any machine, which is what makes a digest of it
+ * mean the same thing to a server and to a client. Declared before its use in
+ * cosmetic_allowed; defined further down, next to the packing code. */
+bool package_digest(Runtime& runtime, const std::string& package_id,
+                    const std::string& version, std::string& out);
+
+/*
+ * Does the session's allowlist grant this package the cosmetic exemption?
+ *
+ * The allowlist is ';'-separated, each entry one of:
+ *
+ *     <package_id>@<version>
+ *     <package_id>@<version>#<sha256 of the packed package>
+ *
+ * The digest form is the one worth using. Without it the list is keyed on a
+ * string the client chooses for itself, so a mod that wants the exemption
+ * simply calls itself by an allowlisted id -- which is not a whitelist, it is
+ * a naming convention. With it, the entry names specific bytes.
+ *
+ * What this can and cannot do is worth being exact about, because the
+ * difference decides whether anyone is misled. It stops a player from
+ * REDISTRIBUTING something that claims to be cosmetic and is not: a "flash
+ * guard" with a wallhack in it packs to different bytes and is refused on
+ * every machine that installs it. It does NOT stop someone who patches their
+ * own executable, because a patched client can report whatever it likes --
+ * defending against that needs server-side verification of the simulation,
+ * which does not exist here. The purpose is to close the omission, so that
+ * getting an unapproved mod into a match requires deliberate forgery rather
+ * than merely declaring a flag in a manifest nobody checks.
+ */
+bool cosmetic_allowed(Runtime& runtime, const Package& package) {
+    if (runtime.cosmetic_allow.empty()) return false;
+
+    /* The RESOLVED package's own id and version, not the selection map's.
+     * selected_package falls back to the newest installed version when a
+     * selection names none, so reading the selection here could check the
+     * allowlist against one version while the match runs another. */
+    const std::string& package_id = package.id;
+    const std::string& version = package.version;
+    if (package_id.empty() || version.empty()) return false;
+
+    const std::string want = package_id + "@" + version;
+    const std::string& list = runtime.cosmetic_allow;
+    std::size_t pos = 0;
+    while (pos <= list.size()) {
+        std::size_t end = list.find(';', pos);
+        if (end == std::string::npos) end = list.size();
+        std::string entry = trim(list.substr(pos, end - pos));
+        pos = end + 1;
+        if (entry.empty()) continue;
+
+        std::string pinned;
+        const std::size_t hash = entry.find('#');
+        if (hash != std::string::npos) {
+            pinned = trim(entry.substr(hash + 1));
+            entry = trim(entry.substr(0, hash));
+        }
+        if (entry != want) continue;
+
+        if (pinned.empty())
+            return true;        /* named, not pinned */
+
+        std::string have;
+        if (!package_digest(runtime, package_id, version, have))
+            return false;       /* cannot prove it: refuse, never assume */
+        /* Case-insensitive on the hex, so a list written in either case works;
+         * the comparison is still the whole 64 characters. */
+        if (pinned.size() != have.size()) continue;
+        bool same = true;
+        for (std::size_t i = 0; i < have.size() && same; ++i)
+            same = std::tolower((unsigned char)pinned[i]) ==
+                   std::tolower((unsigned char)have[i]);
+        if (same) return true;
+    }
+    return false;
+}
+
+/*
+ * Does this package carry ANYTHING but its manifest?
+ *
+ * A package eligible for the cosmetic exemption may carry no payload at all --
+ * no data file, no patch table, no image, nothing. It may only SELECT among
+ * behaviour the executable already ships.
+ *
+ * This is the check that makes "presentation only" a property rather than a
+ * promise. A manifest cannot introduce code (activation runs only callbacks
+ * the binary registered, and an unregistered plugin id resolves to nothing),
+ * so the one way a package can still influence the guest is by shipping data
+ * that some built-in feature consumes -- which is exactly how localization
+ * patches ROM text, from a .toml inside its own package. A package with no
+ * files has no such lever, and the property is verifiable here rather than
+ * taken on trust.
+ *
+ * Note it is deliberately stricter than "declares no [[resource]]": the
+ * localization table is not a declared resource, it is simply a file the
+ * plugin opens by path. Counting declarations would have missed it.
+ */
+bool package_is_manifest_only(Runtime& runtime, const Package& package) {
+    const std::string key = package.id + "@" + package.version;
+    const auto hit = runtime.manifest_only_cache.find(key);
+    if (hit != runtime.manifest_only_cache.end()) return hit->second;
+
+    bool only = true;
+    std::error_code ec;
+    for (fs::recursive_directory_iterator it(package.root, ec), end;
+         it != end; it.increment(ec)) {
+        if (ec) { only = false; break; }   /* cannot see it: do not vouch */
+        if (!it->is_regular_file(ec) || ec) continue;
+        const std::string name = it->path().filename().string();
+        if (name != "manifest.toml") { only = false; break; }
+    }
+    runtime.manifest_only_cache[key] = only;
+    return only;
+}
+
+/*
+ * Is the CLAIM even admissible, before asking whether anyone granted it?
+ *
+ * Three things, and none of them is the manifest's opinion of itself:
+ *
+ *   1. the manifest asks (feature.presentation_only) -- necessary, worthless
+ *      alone, because a cheat author writes manifests too;
+ *   2. every plugin the feature turns on was registered by the EXECUTABLE as
+ *      presentation-only. A manifest can only name plugins; whether a named
+ *      plugin merely draws is a fact about compiled code that a reviewer
+ *      classified, not something the package gets a say in. A feature naming a
+ *      plugin the binary registered normally -- or one it does not have at all
+ *      -- is not admissible however loudly its manifest claims otherwise;
+ *   3. the package carries nothing but its manifest, so it cannot feed data to
+ *      a built-in feature that patches the guest.
+ *
+ * This runs BEFORE the allowlist, so it holds even against a server that
+ * allowlists something it should not have. The grant decides whether an
+ * admissible claim is honoured; this decides whether it was ever a real claim.
+ */
+bool claim_admissible(Runtime& runtime, const Package& package,
+                      const Feature& feature) {
+    if (!feature.presentation_only) return false;
+    for (const std::string& plugin_id : feature.plugins) {
+        const auto registered = registered_plugins().find(plugin_id);
+        if (registered == registered_plugins().end() ||
+            !registered->second.activation ||
+            !registered->second.presentation) {
+            /* Loud, because this is what an attempt to smuggle a
+             * simulation-affecting feature past the mod comparison looks
+             * like, and it is otherwise indistinguishable from a typo. */
+            std::fprintf(stderr,
+                "mods: %s/%s claims presentation_only, but this build does not "
+                "classify plugin '%s' as presentation -- the claim is refused "
+                "and the feature is treated as simulation-affecting\n",
+                package.id.c_str(), feature.id.c_str(), plugin_id.c_str());
+            return false;
+        }
+    }
+    if (!package_is_manifest_only(runtime, package)) {
+        std::fprintf(stderr,
+            "mods: %s claims presentation_only but ships files beyond its "
+            "manifest -- the claim is refused\n", package.id.c_str());
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Is this enabled feature exempt from everything netplay compares?
+ *
+ * TWO conditions, and both are needed. The manifest's presentation_only is the
+ * mod ASKING; the session's allowlist is the authority GRANTING. A claim with
+ * no grant behind it is treated as an ordinary simulation-affecting feature --
+ * it appears in the compared set, it is published in the plan rows, and an
+ * adopt sweeps it off -- which is exactly how an unrecognised mod should be
+ * handled and is the behaviour that predates the flag.
+ *
+ * Every consumer that used to test `feature.presentation_only` directly must
+ * go through here instead. Testing the flag alone is the bug this function
+ * exists to prevent: it would let any manifest exempt itself.
+ */
+bool feature_exempt(Runtime& runtime, const Package& package,
+                    const Feature& feature) {
+    if (!claim_admissible(runtime, package, feature)) return false;
+    return cosmetic_allowed(runtime, package);
 }
 
 std::string option_value(Runtime& runtime, const Package& package,
@@ -1635,6 +1875,40 @@ bool zip_store_tree(const fs::path& root, std::vector<uint8_t>& out,
     return true;
 }
 
+std::string hex32(const uint8_t digest[32]);
+
+/* See the forward declaration above cosmetic_allowed for why this is stable
+ * across machines. Memoised because a queue gate asks once per attempt and
+ * packing a tree is real work; the cache is keyed by id@version, so an
+ * install or a version change cannot be answered from a stale entry. */
+bool package_digest(Runtime& runtime, const std::string& package_id,
+                    const std::string& version, std::string& out) {
+    const std::string key = package_id + "@" + version;
+    const auto hit = runtime.digest_cache.find(key);
+    if (hit != runtime.digest_cache.end()) {
+        out = hit->second;
+        return !out.empty();
+    }
+    /* Cache the failure too, as an empty string: a package that cannot be
+     * packed will not start packing on the next call either, and a queue gate
+     * that retries every frame should not retry the walk every frame. */
+    runtime.digest_cache[key] = std::string();
+
+    const auto by_id = runtime.packages.find(package_id);
+    if (by_id == runtime.packages.end()) return false;
+    const auto by_ver = by_id->second.find(version);
+    if (by_ver == by_id->second.end()) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!zip_store_tree(by_ver->second.root, bytes, nullptr)) return false;
+
+    uint8_t digest[32];
+    sha256_compute(bytes.data(), bytes.size(), digest);
+    out = hex32(digest);
+    runtime.digest_cache[key] = out;
+    return true;
+}
+
 std::string hex32(const uint8_t digest[32]) {
     static const char* kHex = "0123456789abcdef";
     std::string s;
@@ -2289,6 +2563,17 @@ extern "C" int snes_mod_register_activation_plugin(
     if (prior != plugins.end() && prior->second.activation != callback)
         return 0;
     plugins[id].activation = callback;
+    /* Never clears an existing classification, and never sets one: a plugin
+     * is presentation-only because a build said so through the call below,
+     * and registering the ordinary way leaves it unclassified, which is the
+     * safe answer for every plugin that predates the distinction. */
+    return 1;
+}
+
+extern "C" int snes_mod_register_presentation_plugin(
+    const char* id, SNESModActivationCallback callback) {
+    if (!snes_mod_register_activation_plugin(id, callback)) return 0;
+    SNESRecomp::registered_plugins()[id].presentation = true;
     return 1;
 }
 
@@ -2419,6 +2704,12 @@ extern "C" int snes_mod_runtime_feature_option_value_c(
  *
  *   - only ENABLED features appear; a disabled feature and an absent package
  *     are the same thing to the simulation, and must hash alike
+ *   - only features that AFFECT THE SIMULATION appear. A feature whose
+ *     manifest declares presentation_only draws differently and simulates
+ *     identically, so including it would refuse a match over a difference
+ *     that cannot desync one -- and would make an accessibility filter
+ *     something a player has to negotiate with their opponent. See the flag's
+ *     definition for what may and may not claim it
  *   - packages, features and options are emitted in sorted order, which
  *     std::map gives us, so map iteration order cannot leak into the value
  *   - the package VERSION is included: the same mod at a different version can
@@ -2430,6 +2721,179 @@ extern "C" int snes_mod_runtime_feature_option_value_c(
  * Returns the number of bytes that WOULD be written, so a caller can detect
  * truncation rather than silently compare prefixes.
  */
+/*
+ * The cosmetic allowlist in force for this session.
+ *
+ * WHO SETS IT. Not this machine. It comes from whoever is authoritative for
+ * the match: the automatch ruleset the SERVER published, or -- in a lobby --
+ * the host's match caps. The local build's own opinion of which of its mods
+ * are harmless is exactly the opinion that cannot be trusted, because writing
+ * `presentation_only = true` in a manifest costs a cheat author nothing.
+ *
+ * Format: ';'-separated `id@version` or `id@version#sha256`. See
+ * cosmetic_allowed for the matching rules and for the honest limits of what
+ * pinning bytes does and does not prevent.
+ *
+ * NULL or "" REVOKES EVERY EXEMPTION, and that is the correct default rather
+ * than a degenerate case. An older host, a ruleset with no such key, a server
+ * that has never heard of cosmetic mods -- each of those means "no authority
+ * has granted anything here", and the answer to that has to be no. The cost
+ * is that a player's filter counts as an ordinary mod against such a host and
+ * has to match or be switched off; the cost of the other default is that any
+ * mod on earth exempts itself by saying so.
+ *
+ * Offline, nobody calls this, nothing is exempt, and it does not matter: the
+ * exemption only ever affects what netplay compares.
+ */
+extern "C" void snes_mod_runtime_set_cosmetic_allow_c(const char* allow) {
+    SNESRecomp::Runtime& runtime = SNESRecomp::state();
+    const std::string next = allow ? allow : "";
+    if (next == runtime.cosmetic_allow) return;
+    runtime.cosmetic_allow = next;
+    /* Say it, once per change. Which mods a match treated as cosmetic is the
+     * first thing anyone will want to know after an argument about one. */
+    std::fprintf(stderr, "mods: cosmetic allowlist = %s\n",
+                 next.empty() ? "(nothing exempt)" : next.c_str());
+}
+
+extern "C" int snes_mod_runtime_get_cosmetic_allow_c(char* out, uint32_t cap) {
+    SNESRecomp::Runtime& runtime = SNESRecomp::state();
+    const std::string& text = runtime.cosmetic_allow;
+    if (out && cap) std::snprintf(out, cap, "%s", text.c_str());
+    return (int)text.size();
+}
+
+extern "C" int snes_mod_runtime_package_digest_c(const char* package_id,
+                                                 const char* version,
+                                                 char* out, uint32_t cap) {
+    SNESRecomp::Runtime& runtime = SNESRecomp::state();
+    std::string digest;
+    if (out && cap) out[0] = '\0';
+    if (!package_id || !runtime.initialized) return 0;
+
+    std::string ver = version ? version : "";
+    if (ver.empty()) {
+        const SNESRecomp::Package* package =
+            SNESRecomp::selected_package(runtime, package_id);
+        if (!package) return 0;
+        ver = package->version;
+    }
+    if (!SNESRecomp::package_digest(runtime, package_id, ver, digest))
+        return 0;
+    if (out && cap) {
+        if (cap < digest.size() + 1) return 0;
+        std::memcpy(out, digest.c_str(), digest.size() + 1);
+    }
+    return 1;
+}
+
+/*
+ * The enabled features that CLAIM the cosmetic exemption and have not been
+ * granted it, one `package@version/feature` per line.
+ *
+ * This is the queue gate's evidence. An automatch ticket asserts that no
+ * simulation-affecting mod is on beyond what the ruleset imposes, and an
+ * ungranted cosmetic claim has to count as simulation-affecting -- not
+ * because it necessarily is, but because nobody in a position to know has
+ * said otherwise. Reporting them individually is what lets the refusal name
+ * the mod instead of saying "turn off your mods".
+ *
+ * Returns the number of bytes that WOULD be written, so a caller can tell
+ * truncation from emptiness.
+ */
+/*
+ * The EVIDENCE for every exemption this build is taking, one
+ * `id@version#sha256` per package, for the server to check against its own
+ * allowlist.
+ *
+ * This exists because the automatch ticket used to carry a VERDICT -- a single
+ * `mods_enabled` boolean -- and a verdict is computed by the one machine with
+ * an interest in the answer. The server could not see what had been claimed,
+ * only whether this build had decided it was acceptable, so every rule about
+ * which mods are cosmetic ran on the client and could be changed by changing
+ * the client.
+ *
+ * Reporting the packages instead moves the DECISION to the server: it holds
+ * the allowlist, it matches these digests against it, and a package it has
+ * not approved is refused however this build classified it. A stale or
+ * patched client cannot widen its own exemptions, only misreport them -- and
+ * a misreport is now a specific false factual claim about named bytes rather
+ * than an invisible flip of a boolean.
+ *
+ * Only packages with at least one ACTUALLY exempted feature appear: the list
+ * is what is being relied on, not what might have been. Sorted (std::map
+ * iteration) so two machines in the same state produce identical text.
+ */
+extern "C" int snes_mod_runtime_exempted_packages_c(char* out, uint32_t cap) {
+    SNESRecomp::Runtime& runtime = SNESRecomp::state();
+    std::string text;
+    if (runtime.initialized) {
+        for (const auto& sel_entry : runtime.selections) {
+            const SNESRecomp::Package* package =
+                SNESRecomp::selected_package(runtime, sel_entry.first.c_str());
+            if (!package) continue;
+            bool any = false;
+            for (const SNESRecomp::Feature& feature : package->features) {
+                if (!SNESRecomp::feature_enabled(runtime, *package, feature))
+                    continue;
+                if (SNESRecomp::feature_exempt(runtime, *package, feature)) {
+                    any = true;
+                    break;
+                }
+            }
+            if (!any) continue;
+            std::string digest;
+            /* A digest we cannot compute is reported as empty rather than
+             * omitted. Dropping the row would hide an exemption from the very
+             * check this function exists to feed; an empty digest matches no
+             * pinned allowlist entry, so it fails closed at the server. */
+            SNESRecomp::package_digest(runtime, package->id, package->version,
+                                       digest);
+            text += package->id;
+            text += '@';
+            text += package->version;
+            text += '#';
+            text += digest;
+            text += '\n';
+        }
+    }
+    if (out && cap) std::snprintf(out, cap, "%s", text.c_str());
+    return (int)text.size();
+}
+
+extern "C" int snes_mod_runtime_unapproved_cosmetics_c(char* out,
+                                                       uint32_t cap) {
+    SNESRecomp::Runtime& runtime = SNESRecomp::state();
+    std::string text;
+    if (runtime.initialized) {
+        for (const auto& sel_entry : runtime.selections) {
+            const SNESRecomp::Package* package =
+                SNESRecomp::selected_package(runtime, sel_entry.first.c_str());
+            if (!package) continue;
+            for (const SNESRecomp::Feature& feature : package->features) {
+                if (!SNESRecomp::feature_enabled(runtime, *package, feature))
+                    continue;
+                /* Admissible-but-ungranted only. An INADMISSIBLE claim is
+                 * already an ordinary simulation feature everywhere that
+                 * matters -- it is in the compared set, and the set comparison
+                 * refuses it with its own message. Listing it here too would
+                 * report the same mod twice under two different reasons. */
+                if (!SNESRecomp::claim_admissible(runtime, *package, feature))
+                    continue;
+                if (SNESRecomp::cosmetic_allowed(runtime, *package)) continue;
+                text += sel_entry.first;
+                text += '@';
+                text += sel_entry.second.version;
+                text += '/';
+                text += feature.id;
+                text += '\n';
+            }
+        }
+    }
+    if (out && cap) std::snprintf(out, cap, "%s", text.c_str());
+    return (int)text.size();
+}
+
 extern "C" int snes_mod_runtime_effective_set_c(char* out, uint32_t cap) {
     SNESRecomp::Runtime& runtime = SNESRecomp::state();
     std::string text;
@@ -2443,6 +2907,8 @@ extern "C" int snes_mod_runtime_effective_set_c(char* out, uint32_t cap) {
                 continue;
             for (const SNESRecomp::Feature& feature : package->features) {
                 if (!SNESRecomp::feature_enabled(runtime, *package, feature))
+                    continue;
+                if (SNESRecomp::feature_exempt(runtime, *package, feature))
                     continue;
                 text += package_id;
                 text += '@';
@@ -2731,6 +3197,16 @@ extern "C" int snes_mod_runtime_plan_rows_c(SnesModPkgRow* out, int max) {
         for (const SNESRecomp::Feature& feature : package->features) {
             if (!SNESRecomp::feature_enabled(runtime, *package, feature))
                 continue;
+            /* Presentation-only features are not part of the plan, for the
+             * same reason they are not part of the effective set: this row is
+             * what the lobby server matches a joiner's offer against, so a row
+             * here tells a joiner to go and install something. A filter that
+             * changes only what THIS machine draws is not something to send
+             * anyone shopping for -- and refusing a joiner who lacks it would
+             * reintroduce, at the package grain, exactly the barrier the flag
+             * exists to remove at the feature grain. */
+            if (SNESRecomp::feature_exempt(runtime, *package, feature))
+                continue;
             if (!feats.empty()) feats += ',';
             feats += feature.id;
         }
@@ -2904,14 +3380,26 @@ extern "C" int snes_mod_runtime_adopt_set_c(const char* want, char* reason,
     }
 
     SNESRecomp::Runtime& runtime = SNESRecomp::state();
-    /* Disable everything first: the host's set is the whole truth. */
+    /* Disable everything first: the host's set is the whole truth.
+     *
+     * Everything the host's set can SPEAK for, that is. A presentation_only
+     * feature is deliberately absent from that set, so sweeping it off here
+     * and waiting for the set to turn it back on would switch it off for good
+     * the moment its owner joined a lobby -- and the first such feature is a
+     * photosensitivity filter, which failing silently and invisibly at the
+     * exact moment a player enters a match is the worst way it could fail.
+     * The host is authoritative over the simulation, not over what this
+     * machine's owner needs to look at. */
     for (auto& sel : runtime.selections) {
         const SNESRecomp::Package* package =
             SNESRecomp::selected_package(runtime, sel.first.c_str());
         if (!package) continue;
-        for (const SNESRecomp::Feature& feature : package->features)
+        for (const SNESRecomp::Feature& feature : package->features) {
+            if (SNESRecomp::feature_exempt(runtime, *package, feature))
+                continue;
             SNESRecomp::provider_feature_enable(nullptr, sel.first.c_str(),
                                     feature.id.c_str(), 0);
+        }
     }
 
     std::istringstream in{std::string(want)};

--- a/runner/src/mod_runtime.h
+++ b/runner/src/mod_runtime.h
@@ -177,6 +177,44 @@ int snes_mod_runtime_check_set_c(const char* want, char* reason, uint32_t cap);
  *
  * This is what netplay peers must agree on: a mod that patches guest memory is
  * simulation state, and two peers running different sets cannot stay in sync. */
+/*
+ * The cosmetic allowlist in force for this session: which packages the
+ * AUTHORITY for this match (the automatch ruleset the server published, or
+ * the lobby host's caps) has granted the presentation-only exemption to.
+ *
+ * ';'-separated, each entry `id@version` or `id@version#sha256`, the digest
+ * being of the package packed by the runtime's own deterministic zip.
+ *
+ * NULL or "" revokes every exemption -- the safe default, and the one an
+ * older host or a ruleset without the key must produce. A manifest's
+ * `presentation_only = true` is only the mod asking; this is the grant.
+ */
+void snes_mod_runtime_set_cosmetic_allow_c(const char* allow);
+int snes_mod_runtime_get_cosmetic_allow_c(char* out, uint32_t cap);
+
+/* Deterministic content digest of an installed package, as 64 lowercase hex
+ * characters. Pass NULL/"" for `version` to use the selected one. 1 on
+ * success. Use it to WRITE an allowlist entry; matching one is the runtime's
+ * job. */
+int snes_mod_runtime_package_digest_c(const char* package_id,
+                                      const char* version,
+                                      char* out, uint32_t cap);
+
+/* The evidence for every exemption this build is actually taking, one
+ * `id@version#sha256` per package. Send it with an automatch ticket so the
+ * SERVER checks the exemptions against its own allowlist, instead of being
+ * handed this client's verdict and having to take it on faith. A package whose
+ * digest cannot be computed reports an empty one, which matches no pinned
+ * entry and so fails closed. Returns the bytes that WOULD be written. */
+int snes_mod_runtime_exempted_packages_c(char* out, uint32_t cap);
+
+/* Enabled features claiming the cosmetic exemption without a grant, one/* Enabled features claiming the cosmetic exemption without a grant, one
+ * `package@version/feature` per line; empty when there are none. A queue gate
+ * must treat these as simulation-affecting -- not because they necessarily
+ * are, but because no authority has said they are not. Returns the bytes that
+ * WOULD be written, so truncation is distinguishable from emptiness. */
+int snes_mod_runtime_unapproved_cosmetics_c(char* out, uint32_t cap);
+
 int snes_mod_runtime_effective_set_c(char* out, uint32_t cap);
 
 int snes_mod_runtime_feature_option_value_c(const char* package_id,
@@ -189,6 +227,26 @@ int snes_mod_runtime_feature_option_value_c(const char* package_id,
  * Register a trusted implementation. A .snesmod archive may select only this
  * stable id; archives never provide native code, symbols, or library paths.
  */
+/*
+ * Register a plugin AND classify it as presentation-only: this callback
+ * changes what the machine draws and touches no CPU, WRAM, VRAM, OAM, CGRAM,
+ * APU or save state.
+ *
+ * This is the EXECUTABLE vouching for a function it contains, and it is the
+ * only way that classification can be made. A manifest's
+ * `presentation_only = true` is the mod vouching for itself, which is worth
+ * nothing on its own -- a feature whose plugins were registered the ordinary
+ * way is refused the exemption however its manifest is written. So a package
+ * can only ever claim the exemption for behaviour this build already ships and
+ * has already classified; it cannot describe new cosmetic behaviour into
+ * existence, because it cannot introduce code at all.
+ *
+ * Use it only where that is demonstrably true. It is a security boundary, not
+ * a label.
+ */
+int snes_mod_register_presentation_plugin(const char* id,
+                                          SNESModActivationCallback callback);
+
 int snes_mod_register_activation_plugin(const char* id,
                                         SNESModActivationCallback callback);
 

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -971,14 +971,41 @@ static void cb_request_list(void *ctx)
 /* The list is: hub rows, then the same-machine registry row (if any), then
  * the rooms heard on the LAN beacon. The registry row's endpoint is passed to
  * the beacon filter so a host on THIS machine is listed once, not twice. */
+/* Which sources the browser is currently asking for. The UI sets it from the
+ * fork the player took; 0 keeps the old merge-everything behaviour for a
+ * launcher that never calls the setter. */
+static int g_list_scope;
+
+#if defined(RECOMP_LAUNCHER_HAS_LIST_SCOPE)
+static int cb_list_scope_set(void *ctx, int scope)
+{
+  (void)ctx;
+  g_list_scope = scope;
+  return 0;
+}
+#endif
+
+static int list_want_online(void)
+{
+  return g_list_scope != RECOMP_LAUNCHER_LIST_SCOPE_LAN;
+}
+
+static int list_want_lan(void)
+{
+  return g_list_scope != RECOMP_LAUNCHER_LIST_SCOPE_ONLINE;
+}
+
 static int cb_list_count(void *ctx)
 {
   RecompLauncherCNetplayLobby lan;
   int have_lan;
   (void)ctx;
-  have_lan = fill_lan_row(&lan);
-  return snes_lobby_list_count() + (have_lan ? 1 : 0) +
-         beacon_row_count(have_lan ? lan.lobby_id + 4 : "");
+  have_lan = list_want_lan() && fill_lan_row(&lan);
+  return (list_want_online() ? snes_lobby_list_count() : 0) +
+         (have_lan ? 1 : 0) +
+         (list_want_lan()
+              ? beacon_row_count(have_lan ? lan.lobby_id + 4 : "")
+              : 0);
 }
 
 static int cb_list_get(void *ctx, int index, RecompLauncherCNetplayLobby *out)
@@ -988,10 +1015,12 @@ static int cb_list_get(void *ctx, int index, RecompLauncherCNetplayLobby *out)
   (void)ctx;
   if (!out || index < 0)
     return 0;
-  remote_count = snes_lobby_list_count();
+  remote_count = list_want_online() ? snes_lobby_list_count() : 0;
   if (index >= remote_count) {
     RecompLauncherCNetplayLobby lan;
-    int have_lan = fill_lan_row(&lan);
+    int have_lan = list_want_lan() && fill_lan_row(&lan);
+    if (!list_want_lan())
+      return 0;
     index -= remote_count;
     if (have_lan) {
       if (index == 0) {
@@ -2668,6 +2697,9 @@ static RecompLauncherCNetplayCallbacks g_callbacks = {
     .account_error = cb_account_error,
     .account_sign_out = cb_account_sign_out,
     .account_set_handle = cb_account_set_handle,
+#endif
+#if defined(RECOMP_LAUNCHER_HAS_LIST_SCOPE)
+    .list_scope_set = cb_list_scope_set,
 #endif
 #if defined(RECOMP_LAUNCHER_HAS_AUTOMATCH)
     /* Guarded like the account block above, and for the same reason: this

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -985,6 +985,18 @@ static void cb_request_list(void *ctx)
  * launcher that never calls the setter. */
 static int g_list_scope;
 
+#if defined(RECOMP_LAUNCHER_HAS_CHAT_REPORT)
+static int cb_chat_report(void *ctx, const char *const *mids, int mid_count,
+                          const char *reason, const char *note)
+{
+  (void)ctx;
+  /* Thin on purpose: the frame is built once in recomp-net so the rule about
+   * what may be reported does not end up written five times, and this layer's
+   * whole job is to pass it on. */
+  return snes_lobby_report_chat(mids, mid_count, reason, note);
+}
+#endif
+
 #if defined(RECOMP_LAUNCHER_HAS_LIST_SCOPE)
 static int cb_list_scope_set(void *ctx, int scope)
 {
@@ -1508,6 +1520,12 @@ static int cb_chat_get(void *ctx, int index,
 #if defined(RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT)
   snprintf(out->account, sizeof(out->account), "%s", msg.account);
 #endif
+#if defined(RECOMP_LAUNCHER_HAS_CHAT_REPORT)
+  /* Empty against a server that predates message ids, which the UI reads as
+   * "this line cannot be reported" rather than offering an action that would
+   * be refused. */
+  snprintf(out->mid, sizeof(out->mid), "%s", msg.mid);
+#endif
   snprintf(out->text, sizeof(out->text), "%s", msg.text);
   out->is_local = msg.is_local;
   out->is_system = msg.is_system;
@@ -1759,6 +1777,12 @@ static int cb_server_chat_get(void *ctx, int index,
   snprintf(out->from, sizeof(out->from), "%s", msg.from);
 #if defined(RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT)
   snprintf(out->account, sizeof(out->account), "%s", msg.account);
+#endif
+#if defined(RECOMP_LAUNCHER_HAS_CHAT_REPORT)
+  /* Empty against a server that predates message ids, which the UI reads as
+   * "this line cannot be reported" rather than offering an action that would
+   * be refused. */
+  snprintf(out->mid, sizeof(out->mid), "%s", msg.mid);
 #endif
   snprintf(out->text, sizeof(out->text), "%s", msg.text);
   out->is_local = msg.is_local;
@@ -2744,6 +2768,9 @@ static RecompLauncherCNetplayCallbacks g_callbacks = {
     .account_error = cb_account_error,
     .account_sign_out = cb_account_sign_out,
     .account_set_handle = cb_account_set_handle,
+#endif
+#if defined(RECOMP_LAUNCHER_HAS_CHAT_REPORT)
+    .chat_report = cb_chat_report,
 #endif
 #if defined(RECOMP_LAUNCHER_HAS_LIST_SCOPE)
     .list_scope_set = cb_list_scope_set,

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -985,6 +985,14 @@ static void cb_request_list(void *ctx)
  * launcher that never calls the setter. */
 static int g_list_scope;
 
+#if defined(RECOMP_LAUNCHER_HAS_SET_BLOCKS)
+static int cb_set_blocks(void *ctx, const char *accounts)
+{
+  (void)ctx;
+  return snes_lobby_set_blocks(accounts);
+}
+#endif
+
 #if defined(RECOMP_LAUNCHER_HAS_CHAT_REPORT)
 static int cb_chat_report(void *ctx, const char *const *mids, int mid_count,
                           const char *reason, const char *note)
@@ -2768,6 +2776,9 @@ static RecompLauncherCNetplayCallbacks g_callbacks = {
     .account_error = cb_account_error,
     .account_sign_out = cb_account_sign_out,
     .account_set_handle = cb_account_set_handle,
+#endif
+#if defined(RECOMP_LAUNCHER_HAS_SET_BLOCKS)
+    .set_blocks = cb_set_blocks,
 #endif
 #if defined(RECOMP_LAUNCHER_HAS_CHAT_REPORT)
     .chat_report = cb_chat_report,

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>   /* getenv: SNESRECOMP_LOBBY_LIST_DEBUG */
 #include <stdint.h>
 #include <time.h>
 
@@ -246,7 +247,15 @@ static int beacon_row_listed(const RNetLanBeaconRoom *room,
 {
   if (strcmp(room->game_name, game_name()) != 0)
     return 0;
-  if (room->game_version[0] && strcmp(room->game_version, game_version()) != 0)
+  /* Same rule the lobby-server browser applies, and for the same reason.
+   * This used to be an unconditional exact match, which is right for two
+   * shipped releases and wrong for everything else: every development build
+   * carries a dirty-diff hash of its own working tree, so two developers on
+   * one LAN could never see each other's rooms -- the beacon arrived, the
+   * row was dropped, and nothing said why. The join still refuses a real
+   * mismatch; it just gets to explain itself. */
+  if (snes_lobby_version_filter_strict() && room->game_version[0] &&
+      strcmp(room->game_version, game_version()) != 0)
     return 0;
   if (room->started)
     return 0;
@@ -1001,6 +1010,34 @@ static int cb_list_count(void *ctx)
   int have_lan;
   (void)ctx;
   have_lan = list_want_lan() && fill_lan_row(&lan);
+  /* SNESRECOMP_LOBBY_LIST_DEBUG=1: say where the browser's rows come from,
+   * once per change. "The list is empty" has four possible causes -- wrong
+   * scope, nothing on the server, no registry row, no beacons heard -- and
+   * they are indistinguishable from the screen. Off by default; this is a
+   * line to ask a player for, not one to print at everybody. */
+  {
+    static int enabled = -1;
+    if (enabled < 0) {
+      const char *e = getenv("SNESRECOMP_LOBBY_LIST_DEBUG");
+      enabled = (e && e[0] && e[0] != '0') ? 1 : 0;
+    }
+    if (enabled) {
+      static int last_scope = -1, last_remote = -1, last_lan = -1, last_beacon = -1;
+      int remote = snes_lobby_list_count();
+      int beacons = beacon_row_count(have_lan ? lan.lobby_id + 4 : "");
+      if (last_scope != g_list_scope || last_remote != remote ||
+          last_lan != have_lan || last_beacon != beacons) {
+        last_scope = g_list_scope; last_remote = remote;
+        last_lan = have_lan; last_beacon = beacons;
+        fprintf(stderr,
+                "[lobby-list] scope=%s server_rows=%d local_registry=%d "
+                "lan_beacons=%d version=\"%s\" strict=%d\n",
+                g_list_scope == 1 ? "LAN" : g_list_scope == 2 ? "ONLINE" : "ANY",
+                remote, have_lan, beacons, game_version(),
+                snes_lobby_version_filter_strict());
+      }
+    }
+  }
   return (list_want_online() ? snes_lobby_list_count() : 0) +
          (have_lan ? 1 : 0) +
          (list_want_lan()

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -1102,6 +1102,10 @@ static int cb_online_get(void *ctx, int index, RecompLauncherCNetplayOnlinePlaye
     return 0;
   memset(out, 0, sizeof(*out));
   snprintf(out->display_name, sizeof(out->display_name), "%s", p.display_name);
+#if defined(RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT)
+  /* The key a local ignore/block list uses. Empty for a guest. */
+  snprintf(out->account, sizeof(out->account), "%s", p.account);
+#endif
   snprintf(out->country, sizeof(out->country), "%s", p.country);
   snprintf(out->lobby_name, sizeof(out->lobby_name), "%s", p.lobby_name);
   out->in_lobby = p.lobby_id[0] != '\0';
@@ -1501,6 +1505,9 @@ static int cb_chat_get(void *ctx, int index,
     return 0;
   }
   snprintf(out->from, sizeof(out->from), "%s", msg.from);
+#if defined(RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT)
+  snprintf(out->account, sizeof(out->account), "%s", msg.account);
+#endif
   snprintf(out->text, sizeof(out->text), "%s", msg.text);
   out->is_local = msg.is_local;
   out->is_system = msg.is_system;
@@ -1750,6 +1757,9 @@ static int cb_server_chat_get(void *ctx, int index,
     return 0;
   memset(out, 0, sizeof(*out));
   snprintf(out->from, sizeof(out->from), "%s", msg.from);
+#if defined(RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT)
+  snprintf(out->account, sizeof(out->account), "%s", msg.account);
+#endif
   snprintf(out->text, sizeof(out->text), "%s", msg.text);
   out->is_local = msg.is_local;
   out->is_system = msg.is_system;

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -838,7 +838,7 @@ static void cb_pump(void *ctx)
    * rnet_account_init, and its own comment says "Init runs from the netplay
    * pump" -- but nothing called it. The linker then dead-stripped
    * rnet_account_init out of the binary entirely, so g.host stayed the
-   * zero-initialised empty string and every /auth/* POST died in
+   * zero-initialised empty string and every "/auth" POST died in
    * getaddrinfo("", "0"). That surfaces as "couldn't reach the lobby server
    * to sign in" no matter which host is configured, which is exactly the
    * wrong place to go looking.
@@ -1441,6 +1441,135 @@ static const char *cb_account_handle(void *ctx) { (void)ctx; return rnet_account
 static const char *cb_account_username(void *ctx) { (void)ctx; return rnet_account_username(); }
 static const char *cb_account_error(void *ctx) { (void)ctx; return rnet_account_error(); }
 static int cb_account_sign_out(void *ctx) { (void)ctx; return rnet_account_sign_out(); }
+/* ── automatch ──────────────────────────────────────────────────────────────
+ *
+ * Thin: the lobby client owns the protocol and the state machine, and this
+ * layer only translates its vocabulary into the launcher's. The one piece of
+ * POLICY here is mods_enabled -- see cb_automatch_queue.
+ */
+#if defined(RECOMP_LAUNCHER_HAS_AUTOMATCH)
+static int cb_automatch_available(void *ctx)
+{
+    (void)ctx;
+    /* Ask once the answer could exist. The launcher polls this every frame
+     * while the netplay page is up, which is exactly when a reply is useful,
+     * and the client refuses to re-send while one is outstanding. */
+    if (snes_lobby_connected() && !snes_lobby_automatch_available())
+        snes_lobby_automatch_request_rulesets();
+    return snes_lobby_automatch_available();
+}
+
+static int cb_automatch_ruleset_count(void *ctx)
+{
+    (void)ctx;
+    return snes_lobby_automatch_ruleset_count();
+}
+
+static int cb_automatch_ruleset_get(void *ctx, int index,
+                                    RecompLauncherCNetplayRuleset *out)
+{
+    SnesLobbyRuleset r;
+    (void)ctx;
+    if (!out || !snes_lobby_automatch_ruleset_get(index, &r)) return 0;
+    memset(out, 0, sizeof(*out));
+    snprintf(out->id, sizeof(out->id), "%s", r.id);
+    snprintf(out->label, sizeof(out->label), "%s", r.label);
+    snprintf(out->caps_summary, sizeof(out->caps_summary), "%s", r.caps_summary);
+    snprintf(out->game_version, sizeof(out->game_version), "%s", r.game_version);
+    out->max_slots = 2;
+    return 1;
+}
+
+static int cb_automatch_queue(void *ctx, const char *ruleset_id)
+{
+    (void)ctx;
+    /*
+     * mods_enabled asserts that a SIM-AFFECTING mod feature is on locally
+     * BEYOND whatever the chosen ruleset itself imposes.
+     *
+     * The distinction matters and is not pedantry. A ruleset that pins the
+     * widescreen margin has both peers running the same patched sim by the
+     * server's own instruction -- that is the ruleset, not a divergence. A
+     * feature the ruleset says nothing about is a divergence, and it is the
+     * desync §5 is about.
+     *
+     * The server cannot check either one. It takes this client's word, and
+     * the assertion exists so that a modified client is making a deliberate
+     * false statement rather than exploiting an omission. Which is why the
+     * answer is computed by the GAME (SnesHostLobbyOpts.mods_enabled) rather
+     * than assumed here: only the game knows what its own features do.
+     */
+    char why[160];
+    int mods;
+    why[0] = '\0';
+    mods = g_opts.mods_enabled
+               ? g_opts.mods_enabled(g_opts.mods_ctx, ruleset_id, why, sizeof(why))
+               : 0;
+    if (mods) {
+        /* Refuse here rather than sending a ticket the server will certainly
+         * bounce: mods_not_pooled comes back as one generic line, and this
+         * side knows exactly which feature caused it. */
+        snes_lobby_automatch_refuse_local(
+            why[0] ? why : "Turn off sim-affecting mods to queue");
+        return -1;
+    }
+    return snes_lobby_automatch_queue(ruleset_id, 0) == 0 ? 0 : -1;
+}
+
+static int cb_automatch_cancel(void *ctx)
+{
+    (void)ctx;
+    return snes_lobby_automatch_cancel();
+}
+
+static int cb_automatch_state(void *ctx)
+{
+    (void)ctx;
+    return snes_lobby_automatch_state();
+}
+
+static int cb_automatch_queued_secs(void *ctx)
+{
+    (void)ctx;
+    return snes_lobby_automatch_queued_secs();
+}
+
+static int cb_automatch_pool(void *ctx)
+{
+    (void)ctx;
+    return snes_lobby_automatch_pool();
+}
+
+static int cb_automatch_found_get(void *ctx, RecompLauncherCNetplayFound *out)
+{
+    SnesLobbyAutomatchFound f;
+    (void)ctx;
+    if (!out || !snes_lobby_automatch_found_get(&f)) return 0;
+    memset(out, 0, sizeof(*out));
+    snprintf(out->handle, sizeof(out->handle), "%s", f.opponent);
+    snprintf(out->country, sizeof(out->country), "%s", f.opponent_country);
+    snprintf(out->ruleset_label, sizeof(out->ruleset_label), "%s",
+             f.ruleset_label);
+    /* <0 rather than 0 when the server offered none: zero is a legitimate
+     * estimate on a LAN and must not read as "unknown". */
+    out->est_rtt_ms = f.est_rtt_ms > 0 ? f.est_rtt_ms : -1;
+    out->accept_secs_left = f.accept_secs;
+    return 1;
+}
+
+static int cb_automatch_accept(void *ctx, int accept)
+{
+    (void)ctx;
+    return snes_lobby_automatch_accept(accept);
+}
+
+static const char *cb_automatch_error(void *ctx)
+{
+    (void)ctx;
+    return snes_lobby_automatch_error();
+}
+#endif /* RECOMP_LAUNCHER_HAS_AUTOMATCH */
+
 static int cb_account_set_handle(void *ctx, const char *h) {
     (void)ctx;
     return rnet_account_set_handle(h);
@@ -2374,6 +2503,21 @@ static RecompLauncherCNetplayCallbacks g_callbacks = {
     .account_error = cb_account_error,
     .account_sign_out = cb_account_sign_out,
     .account_set_handle = cb_account_set_handle,
+#endif
+#if defined(RECOMP_LAUNCHER_HAS_AUTOMATCH)
+    /* Guarded like the account block above, and for the same reason: this
+     * runner still builds against a recomp-ui that predates the callbacks. */
+    .automatch_available = cb_automatch_available,
+    .automatch_ruleset_count = cb_automatch_ruleset_count,
+    .automatch_ruleset_get = cb_automatch_ruleset_get,
+    .automatch_queue = cb_automatch_queue,
+    .automatch_cancel = cb_automatch_cancel,
+    .automatch_state = cb_automatch_state,
+    .automatch_queued_secs = cb_automatch_queued_secs,
+    .automatch_pool = cb_automatch_pool,
+    .automatch_found_get = cb_automatch_found_get,
+    .automatch_accept = cb_automatch_accept,
+    .automatch_error = cb_automatch_error,
 #endif
 };
 

--- a/runner/src/netplay/snes_host_lobby.c
+++ b/runner/src/netplay/snes_host_lobby.c
@@ -1,6 +1,10 @@
 #include "snes_host_lobby.h"
 #include "recomp_net/auth.h"
 #include "snes_netplay_identity.h"
+/* Fork detection lives in the rollback engine; this file only reports what it
+ * already found. Included unconditionally: the accessors compile to a "no
+ * fork" answer in a build without rollback. */
+#include "snes_netplay_rb.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -314,6 +318,7 @@ static const char *game_version(void)
 
 static void dl_queue_step(void);
 static void mod_set_sync_step(void);
+static void desync_report_step(void);
 static void cb_push_match_caps(void *ctx);
 static void host_caps_watch_step(void);
 
@@ -339,6 +344,13 @@ static void fill_caps_mods(SnesLobbyMatchCaps *caps)
 
   if (!caps)
     return;
+  /* Apply our own grant FIRST, because both the plan rows and the effective
+   * set below are computed through it: a host that publishes an allowlist and
+   * then reports a set built without it would advertise its own cosmetic mods
+   * as requirements, and guests would be told to install them. */
+  snprintf(caps->mod_cosmetic_allow, sizeof(caps->mod_cosmetic_allow), "%s",
+           g_opts.cosmetic_allow ? g_opts.cosmetic_allow : "");
+  snes_mod_runtime_set_cosmetic_allow_c(caps->mod_cosmetic_allow);
   caps->mod_count = 0;
   n = snes_mod_runtime_plan_rows_c(rows, SNES_LOBBY_MAX_MODS);
   for (i = 0; i < n && i < SNES_LOBBY_MAX_MODS; ++i) {
@@ -892,6 +904,7 @@ static void cb_pump(void *ctx)
   dl_queue_step();
   host_caps_watch_step();
   mod_set_sync_step();
+  desync_report_step();
   lan_chat_drain();
   beacon_listen_step();
   beacon_publish_step();
@@ -1502,6 +1515,60 @@ static int cb_automatch_queue(void *ctx, const char *ruleset_id)
     char why[160];
     int mods;
     why[0] = '\0';
+
+    /*
+     * The SERVER's grant, not ours, and applied before the game is asked
+     * anything -- the whole assertion below is computed through it.
+     *
+     * An automatch room is the server's room. Whatever this build would allow
+     * as a host is irrelevant here: a player queueing for a public pool does
+     * not get to decide which of their own mods are harmless, because that is
+     * precisely the decision a cheat would make in its own favour. A ruleset
+     * with no list grants nothing, so an unapproved cosmetic claim counts as
+     * simulation-affecting and the queue is refused.
+     */
+    {
+        SnesLobbyRuleset r;
+        char allow[512];
+        int i, n = snes_lobby_automatch_ruleset_count();
+        allow[0] = '\0';
+        for (i = 0; i < n; ++i) {
+            if (!snes_lobby_automatch_ruleset_get(i, &r)) continue;
+            /* NULL/"" selects the first, matching the client's own rule. */
+            if (ruleset_id && ruleset_id[0] && strcmp(r.id, ruleset_id) != 0)
+                continue;
+            snprintf(allow, sizeof(allow), "%s", r.caps.mod_cosmetic_allow);
+            break;
+        }
+        snes_mod_runtime_set_cosmetic_allow_c(allow);
+    }
+
+    /*
+     * Refuse an ungranted cosmetic claim here, by name, before the game's own
+     * assertion runs.
+     *
+     * The game's answer is derived from the effective set, which now excludes
+     * anything the server DID grant -- so without this check a mod the server
+     * never approved would simply be absent from the game's view and pass
+     * unnoticed. It is checked here rather than in the game because it is the
+     * framework's rule, not a per-title one, and a title that forgot to
+     * implement it would be the hole.
+     */
+#if SNESRECOMP_ENABLE_MODS
+    {
+        char bad[512];
+        if (snes_mod_runtime_unapproved_cosmetics_c(bad, sizeof(bad)) > 0 &&
+            bad[0]) {
+            char *nl = strchr(bad, '\n');
+            if (nl) *nl = '\0';
+            snprintf(why, sizeof(why),
+                     "%s is not on this queue's approved list", bad);
+            snes_lobby_automatch_refuse_local(why);
+            return -1;
+        }
+    }
+#endif
+
     mods = g_opts.mods_enabled
                ? g_opts.mods_enabled(g_opts.mods_ctx, ruleset_id, why, sizeof(why))
                : 0;
@@ -1513,7 +1580,24 @@ static int cb_automatch_queue(void *ctx, const char *ruleset_id)
             why[0] ? why : "Turn off sim-affecting mods to queue");
         return -1;
     }
-    return snes_lobby_automatch_queue(ruleset_id, 0) == 0 ? 0 : -1;
+    /* Declare the exemptions we are relying on, so the SERVER checks them
+     * against its own allowlist rather than taking the verdict above on
+     * trust. The two gates are layers: an old server ignores this field and
+     * the assertion still holds, a new one stops needing to believe us. */
+    {
+        char exempt[768];
+        exempt[0] = '\0';
+#if SNESRECOMP_ENABLE_MODS
+        if (snes_mod_runtime_exempted_packages_c(exempt, sizeof(exempt)) >=
+            (int)sizeof(exempt)) {
+            /* Never queue having declared less than we rely on. */
+            snes_lobby_automatch_refuse_local(
+                "too many mod exemptions to declare to the server");
+            return -1;
+        }
+#endif
+        return snes_lobby_automatch_queue(ruleset_id, 0, exempt) == 0 ? 0 : -1;
+    }
 }
 
 static int cb_automatch_cancel(void *ctx)
@@ -2214,10 +2298,23 @@ static void mod_set_sync_step(void)
 
   if (!snes_lobby_in_lobby() || snes_lobby_is_host()) {
     g_adopted_set[0] = '\0';
+    /* Out of a lobby, no authority is granting anything, so the exemption
+     * lapses rather than lingering from the last host we spoke to. A host
+     * sets its own grant in fill_caps_mods and must not be cleared here. */
+    if (!snes_lobby_in_lobby())
+      snes_mod_runtime_set_cosmetic_allow_c(NULL);
     return;
   }
   caps = snes_lobby_match_caps();
-  if (!caps || !caps->valid || !caps->mod_set[0])
+  if (!caps || !caps->valid)
+    return;
+  /* The host is the authority here, so its grant governs before anything is
+   * compared or adopted. Applied even when the host's own mod set is empty --
+   * a vanilla host that permits an accessibility filter is the ordinary case,
+   * and returning early on an empty set would leave a stale allowlist from a
+   * previous lobby in force. */
+  snes_mod_runtime_set_cosmetic_allow_c(caps->mod_cosmetic_allow);
+  if (!caps->mod_set[0])
     return;
   if (!strcmp(g_adopted_set, caps->mod_set))
     return;                      /* already tried this exact set */
@@ -2244,6 +2341,74 @@ static void mod_set_sync_step(void)
 #else
 static void mod_set_sync_step(void) {}
 #endif
+
+/*
+ * Report a simulation fork once per session, promptly.
+ *
+ * Promptly, not at teardown: a desync usually ENDS the match, and often takes
+ * the connection with it, so a report deferred to a clean shutdown is a report
+ * that mostly never gets sent. Once per session because the interesting fact
+ * is that the peers diverged and where -- a hundred rows from one broken match
+ * would drown the signal the rows exist to carry.
+ *
+ * Best-effort throughout. Nothing here may hold up a teardown or change what
+ * the player sees; it is a diagnostic, and a diagnostic that costs a match is
+ * not worth having.
+ */
+static void desync_report_step(void)
+{
+#if SNES_HAS_LOBBY_CLIENT
+  static int reported;
+  SnesLobbyDesyncReport r;
+  uint32_t tick = 0;
+  uint32_t mine = 0, theirs = 0;
+  const char *partition = "?";
+  char exempt[512];
+
+  if (!snes_lobby_connected()) {
+    /* A fresh connection is a fresh session: arm again so the next match can
+     * report its own fork. */
+    reported = 0;
+    return;
+  }
+  if (reported)
+    return;
+  if (!snes_netplay_rb_last_fork(&tick, &partition))
+    return;
+  snes_netplay_rb_fork_digests(&mine, &theirs);
+
+  exempt[0] = '\0';
+#if SNESRECOMP_ENABLE_MODS
+  /* What this peer was running, so the row can be read beside what the match
+   * approved. A fork under an unapproved exemption and a fork under none are
+   * different facts, and the row is worth little without which it was. */
+  (void)snes_mod_runtime_exempted_packages_c(exempt, sizeof(exempt));
+  {
+    /* Newlines to ';' -- the wire carries one line. */
+    char *p;
+    for (p = exempt; *p; ++p)
+      if (*p == '\n') *p = ';';
+    if (p > exempt && p[-1] == ';') p[-1] = '\0';
+  }
+#endif
+
+  memset(&r, 0, sizeof(r));
+  r.tick = tick;
+  r.partition = partition;
+  r.mine = mine;
+  r.theirs = theirs;
+  r.is_host = snes_lobby_is_host() ? 1 : 0;
+  r.mod_exempt = exempt;
+
+  reported = 1;    /* set before the send: a failed send must not retry */
+  if (snes_lobby_report_desync(&r) == 0)
+    fprintf(stderr,
+            "netplay: reported a state fork at tick %u (%s), local %08x vs "
+            "peer %08x -- this records that the two peers DIFFERED, not who "
+            "was wrong\n",
+            (unsigned)tick, partition, (unsigned)mine, (unsigned)theirs);
+#endif
+}
 
 static int cb_lobby_mods_can_download(void *ctx)
 {

--- a/runner/src/netplay/snes_host_lobby.h
+++ b/runner/src/netplay/snes_host_lobby.h
@@ -31,11 +31,42 @@ typedef void (*SnesHostFillMatchCapsFn)(void *ctx,
                                         const void *settings /* RecompLauncherCSettings* */,
                                         SnesLobbyMatchCaps *out);
 
+/*
+ * "Is a SIM-AFFECTING mod feature on locally, beyond what `ruleset_id` itself
+ * imposes?" Answered by the GAME, because only the game knows which of its
+ * features touch the sim and which are presentation.
+ *
+ * It becomes the ticket's `mods_enabled` assertion. A true is refused by the
+ * server with mods_not_pooled, which is correct: a player with an extra
+ * sim-affecting feature on boots a different sim from a vanilla opponent, and
+ * that is a desync rather than a fairness complaint.
+ *
+ * Note the "beyond what the ruleset imposes". A ruleset that pins, say, a
+ * widescreen margin has BOTH peers running that patched sim on the server's
+ * instruction -- it is the ruleset, not a divergence, and answering 1 for it
+ * would make the queue permanently unusable for the very feature it exists to
+ * standardize. `ruleset_id` is passed so the game can make that distinction;
+ * NULL/"" means the first ruleset.
+ *
+ * NULL leaves the assertion at 0, which is right for a game with no
+ * sim-affecting mods at all.
+ */
+/* `why` receives a player-facing reason when the answer is 1 -- the FEATURE in
+ * the way, not the fact that something is. "Turn off sim-affecting mods" sends
+ * a player to a Mods page with several toggles and no indication which one
+ * matters; naming it is the difference between a fixable message and a
+ * mystery. May be left empty. */
+typedef int (*SnesHostModsEnabledFn)(void *ctx, const char *ruleset_id,
+                                     char *why, size_t why_cap);
+
 typedef struct SnesHostLobbyOpts {
   int auto_ready_guests;  /* 1: set_ready(1) for non-hosts in Pump (SMW) */
   int rematch_set_ready;  /* 1: set_ready(1) on soft-return prepare (MW) */
   SnesHostFillMatchCapsFn fill_match_caps; /* NULL → delay=2, no ws */
   void *caps_ctx;
+  /* Appended: a runner built before this field zero-fills it and asserts 0. */
+  SnesHostModsEnabledFn mods_enabled;
+  void *mods_ctx;
 } SnesHostLobbyOpts;
 
 /* Init once before first launcher open. Returns 0 on success. */

--- a/runner/src/netplay/snes_host_lobby.h
+++ b/runner/src/netplay/snes_host_lobby.h
@@ -67,6 +67,22 @@ typedef struct SnesHostLobbyOpts {
   /* Appended: a runner built before this field zero-fills it and asserts 0. */
   SnesHostModsEnabledFn mods_enabled;
   void *mods_ctx;
+  /*
+   * What THIS BUILD grants the presentation-only exemption to when it is the
+   * host: ';'-separated `id@version` or `id@version#sha256`, published in
+   * match_caps.mod_cosmetic_allow.
+   *
+   * A host is an authority over its own lobby, so it may say which cosmetic
+   * mods its guests are free to run unilaterally -- an accessibility filter
+   * being the case this exists for. It is NOT a statement about the host's own
+   * mods, and it does not travel: in an automatch room the SERVER's ruleset
+   * supplies the list instead and this is ignored.
+   *
+   * NULL or "" grants nothing, which is the behaviour of every build that
+   * predates the field and the correct default: a mod's own manifest claiming
+   * `presentation_only` is only a request.
+   */
+  const char *cosmetic_allow;
 } SnesHostLobbyOpts;
 
 /* Init once before first launcher open. Returns 0 on success. */

--- a/runner/src/netplay/snes_netplay_rb.c
+++ b/runner/src/netplay/snes_netplay_rb.c
@@ -112,6 +112,14 @@ static struct {
     uint32_t fork_tick;
     int      fork_seen;
     const char *fork_partition;
+    /* The two digests that disagreed, kept so a report can be CORROBORATED.
+     * A fork says "these two peers differ", never "the other one cheated" --
+     * the only way to tell those apart is to put both sides' numbers next to
+     * each other, across many matches and many opponents. A report carrying
+     * one peer's verdict would be the same mistake the automatch ticket made
+     * with mods_enabled. */
+    uint32_t fork_mine;
+    uint32_t fork_theirs;
     const char *stall_tag;
     uint32_t snap_interval;
     uint32_t snap_depth;
@@ -1917,6 +1925,8 @@ static void rb_baseline_try_compare(void)
      * moved — "the state differs" is not a diagnosis. */
     g_rb.fork_seen = 1;
     g_rb.fork_tick = g_rb.corr.load_tick;
+    g_rb.fork_mine = mine->master;
+    g_rb.fork_theirs = g_rb.peer_base_master;
     if (mine->wram != g_rb.peer_base_wram)
         g_rb.fork_partition = snes_state_digest_part_name(SNES_DIGEST_PART_WRAM);
     else if (mine->apu != g_rb.peer_base_apu)
@@ -2255,6 +2265,8 @@ static void rb_pump_episode(void)
                 g_rb.desync_count++;
                 g_rb.fork_seen = 1;
                 g_rb.fork_tick = g_rb.corr.target_tick;
+                g_rb.fork_mine = local;
+                g_rb.fork_theirs = g_rb.peer_post_digest;
                 g_rb.fork_partition = "post";
                 fprintf(stderr,
                         "snes_netplay: RB POST FORK tick=%u local=%08x "
@@ -2783,5 +2795,16 @@ int snes_netplay_rb_last_fork(uint32_t *tick, const char **partition)
         *tick = g_rb.fork_tick;
     if (partition)
         *partition = g_rb.fork_partition ? g_rb.fork_partition : "?";
+    return 1;
+}
+
+int snes_netplay_rb_fork_digests(uint32_t *mine, uint32_t *theirs)
+{
+    if (!g_rb.fork_seen)
+        return 0;
+    if (mine)
+        *mine = g_rb.fork_mine;
+    if (theirs)
+        *theirs = g_rb.fork_theirs;
     return 1;
 }

--- a/runner/src/netplay/snes_netplay_rb.h
+++ b/runner/src/netplay/snes_netplay_rb.h
@@ -135,6 +135,16 @@ const char *snes_netplay_rb_stall_tag(void);
  * and tick. Partition naming comes from snes_state_digest_part_name. */
 int  snes_netplay_rb_last_fork(uint32_t *tick, const char **partition);
 
+/* The two master digests that disagreed at that fork: ours and the peer's.
+ * 0 if no fork has happened.
+ *
+ * Both numbers, always. A fork means the two peers differ; which of them
+ * MOVED is not knowable from one side, and is only ever answerable by putting
+ * many matches against many opponents side by side. Anything that reports one
+ * peer's conclusion instead of both peers' evidence is repeating the mistake
+ * the automatch ticket made when it sent a verdict instead of its inputs. */
+int  snes_netplay_rb_fork_digests(uint32_t *mine, uint32_t *theirs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/netplay/mod_presentation_only_test.c
+++ b/tests/netplay/mod_presentation_only_test.c
@@ -1,0 +1,438 @@
+/*
+ * presentation_only: a mod that changes what a machine DRAWS, not what it
+ * simulates, may be invisible to the set two netplay peers compare -- but ONLY
+ * where the match's authority has granted it.
+ *
+ *   cc tests/netplay/mod_presentation_only_test.c runner/src/mod_runtime.cpp \
+ *      runner/src/crc32.c runner/src/sha256.c -Irunner/src -o /tmp/t && /tmp/t
+ *
+ * Writes its own catalog and its own selection file, so it needs neither a
+ * ROM nor recomp-ui: everything it drives goes through the runtime's own
+ * extern "C" surface. Enabling a feature through state.toml rather than
+ * through the launcher provider is deliberate twice over -- it keeps this
+ * test buildable in a standalone snesrecomp checkout, where recomp-ui's
+ * headers are not present, and it exercises the selection loader that a real
+ * launch uses rather than a path only the GUI takes.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * snes_mod_runtime_effective_set_c refuses a match whose mod set is not
+ * byte-identical, because a mod that patches guest memory means the two sides
+ * are running different games. A presentation filter is not that, and the
+ * first one to need saying so is an accessibility feature -- a
+ * photosensitivity flash guard. Requiring both peers to agree on it would
+ * make it unavailable in precisely the matches it exists for, since a player
+ * who needs it does not choose their opponent.
+ *
+ * THE FLAG ALONE GRANTS NOTHING. `presentation_only = true` is written by
+ * whoever wrote the mod, so a cheat wanting out of the comparison writes it
+ * too, and nothing in the client can tell the two apart. The exemption needs a
+ * second key: the session's cosmetic allowlist, which comes from the automatch
+ * ruleset the SERVER published or from the lobby host -- never from the
+ * machine that wants the exemption. An ungranted claim is an ordinary
+ * simulation-affecting mod, which is the behaviour that predates the flag.
+ *
+ * So the first case below is the security one: flag set, nothing granted,
+ * treated as an ordinary mod. The rest check that a grant works, that it can
+ * be pinned to package bytes, and that the exemption reaches all three places
+ * netplay looks.
+ *
+ * Three things have to hold once granted, and the last two are the ones that
+ * would fail quietly:
+ *
+ *   1. the feature never appears in the effective set, so a peer without it
+ *      and a peer with it compare equal;
+ *   2. nor in the PLAN ROWS, which are the other grain -- one row per
+ *      package, and what the lobby server matches a joiner's offer against.
+ *      A row there tells a joiner to go and install something, so publishing
+ *      one for a local-only filter would rebuild the same barrier one level
+ *      up. GWED's automatch assertion also reads the effective set
+ *      (GwedSimAffectingModSet in src/main.c), and defaults to treating an
+ *      UNKNOWN package as simulation-affecting -- which would refuse the
+ *      queue outright -- so being absent upstream is what keeps automatch
+ *      working rather than any allowlist entry;
+ *   3. ADOPTING a host's set does not switch it off. adopt_set disables every
+ *      feature before re-enabling what the host names, and a feature the host
+ *      can never name would be swept off and never restored -- turning a
+ *      player's accessibility filter off at the moment they join a lobby,
+ *      with nothing on screen to say so.
+ *
+ * An ordinary feature must keep behaving exactly as before, which is what the
+ * `sim` control is for in every case below. A test that only proved the new
+ * flag suppresses things would pass just as well if it suppressed everything.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+#include "mod_runtime.h"
+
+#define PKG "test.presentation"
+#define SHA "0000000000000000000000000000000000000000000000000000000000000000"
+
+/* Bounded well under the buffers below so the fixture paths cannot truncate. */
+#define ROOT_MAX 256
+
+static int fails;
+
+static void check(const char *what, int ok)
+{
+    printf("  %-56s %s\n", what, ok ? "ok" : "FAIL");
+    if (!ok) ++fails;
+}
+
+static void make_dirs(const char *path)
+{
+    char acc[1024];
+    size_t i;
+    const size_t n = strlen(path);
+    if (n >= sizeof(acc)) return;
+    for (i = 0; i <= n; ++i) {
+        if (path[i] == '/' || path[i] == '\0') {
+            memcpy(acc, path, i);
+            acc[i] = '\0';
+            if (acc[0]) {
+#ifdef _WIN32
+                _mkdir(acc);
+#else
+                mkdir(acc, 0777);
+#endif
+            }
+        }
+    }
+}
+
+/* The fixture is written rather than committed so the test carries it: a
+ * checked-in manifest that drifts from the parser it exercises is worse than
+ * no fixture at all. */
+static int write_fixture(const char *root)
+{
+    char dir[ROOT_MAX + 64];
+    char path[ROOT_MAX + 96];
+    FILE *f;
+
+    snprintf(dir, sizeof(dir), "%s/packages/" PKG "/1.0.0", root);
+    make_dirs(dir);
+    snprintf(path, sizeof(path), "%s/manifest.toml", dir);
+    if (!(f = fopen(path, "wb"))) return 0;
+    fprintf(f,
+        "format_version = 1\n"
+        "id = \"" PKG "\"\n"
+        "version = \"1.0.0\"\n"
+        "name = \"presentation_only fixture\"\n"
+        "resolver = \"declarative\"\n"
+        "\n"
+        "[[target]]\n"
+        "game_id = \"test\"\n"
+        "rom_sha256 = \"" SHA "\"\n"
+        "\n"
+        /* The control: an ordinary feature, which must keep appearing in the
+         * set and must keep being swept off by an adopt. */
+        "[[feature]]\n"
+        "id = \"sim\"\n"
+        "name = \"Simulation feature\"\n"
+        "default_enabled = false\n"
+        "\n"
+        "[[feature]]\n"
+        "id = \"draw\"\n"
+        "name = \"Presentation feature\"\n"
+        "default_enabled = false\n"
+        "presentation_only = true\n"
+        "\n"
+        "[[plugin]]\n"
+        "feature = \"draw\"\n"
+        "id = \"test.draw.plugin\"\n"
+        "\n"
+        /* A second presentation feature whose plugin this "build" registers
+         * the ORDINARY way -- the smuggling case. Its manifest claims exactly
+         * what the real one claims; only the executable's classification
+         * differs, which is the whole point of the test. */
+        "[[feature]]\n"
+        "id = \"sneaky\"\n"
+        "name = \"Claims to be presentation\"\n"
+        "default_enabled = false\n"
+        "presentation_only = true\n"
+        "\n"
+        "[[plugin]]\n"
+        "feature = \"sneaky\"\n"
+        "id = \"test.sneaky.plugin\"\n");
+    fclose(f);
+
+    return 1;
+}
+
+/* The selection a launch starts from. `draw` on and `sim` off is a
+ * photosensitive player who has switched their filter on and nothing else --
+ * and it is the state that makes the adopt cases take the sweeping path
+ * rather than returning OK unchanged. */
+static int write_state(const char *root, int draw_on, int sneaky_on)
+{
+    char path[ROOT_MAX + 96];
+    FILE *f;
+    snprintf(path, sizeof(path), "%s/state.toml", root);
+    if (!(f = fopen(path, "wb"))) return 0;
+    fprintf(f,
+        "format_version = 1\n"
+        "\n"
+        "[[package]]\n"
+        "id = \"" PKG "\"\n"
+        "version = \"1.0.0\"\n"
+        "\n"
+        "[[feature]]\n"
+        "package_id = \"" PKG "\"\n"
+        "id = \"draw\"\n"
+        "enabled = %s\n"
+        "\n"
+        "[[feature]]\n"
+        "package_id = \"" PKG "\"\n"
+        "id = \"sneaky\"\n"
+        "enabled = %s\n"
+        "\n"
+        "[[feature]]\n"
+        "package_id = \"" PKG "\"\n"
+        "id = \"sim\"\n"
+        "enabled = false\n",
+        draw_on ? "true" : "false", sneaky_on ? "true" : "false");
+    fclose(f);
+    return 1;
+}
+
+/* Grant the fixture package, pinned to whatever bytes it currently has. */
+static void grant_this_package(const char *root)
+{
+    char digest[72];
+    char entry[256];
+    (void)root;
+    if (!snes_mod_runtime_package_digest_c(PKG, "1.0.0", digest,
+                                           sizeof(digest))) {
+        snes_mod_runtime_set_cosmetic_allow_c("");
+        return;
+    }
+    snprintf(entry, sizeof(entry), PKG "@1.0.0#%s", digest);
+    snes_mod_runtime_set_cosmetic_allow_c(entry);
+}
+
+static void noop_plugin(void) {}
+
+int main(int argc, char **argv)
+{
+    const char *host = PKG "@1.0.0/sim\n";
+    char root[ROOT_MAX];
+    char set[4096];
+    char why[256];
+
+    snprintf(root, sizeof(root), "%s",
+             argc > 1 ? argv[1] : "./mod_presentation_only_fixture");
+    if (!write_fixture(root) || !write_state(root, 1, 0)) {
+        printf("could not write the fixture under %s\n", root);
+        return 1;
+    }
+    /* The executable's classifications, which is the only place they can be
+     * made. One plugin vouched for; one registered the ordinary way. */
+    snes_mod_register_presentation_plugin("test.draw.plugin", noop_plugin);
+    snes_mod_register_activation_plugin("test.sneaky.plugin", noop_plugin);
+
+    if (!snes_mod_runtime_initialize_c(root, "test", SHA)) {
+        printf("initialize failed: %s\n", snes_mod_runtime_last_error_c());
+        return 1;
+    }
+
+    printf("\n0. WITHOUT A GRANT the claim counts for nothing\n");
+    {
+        /* The security case. No allowlist has been set, which is the state of
+         * an older host, a ruleset with no such key, and a fresh process --
+         * and the state a cheat would like to be exempt in. */
+        char bad[512];
+        check("the runtime reports the feature enabled locally",
+              snes_mod_runtime_feature_enabled_c(PKG, "draw") == 1);
+        check("the ordinary feature is off, as the fixture asked",
+              snes_mod_runtime_feature_enabled_c(PKG, "sim") == 0);
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("IT APPEARS IN THE COMPARED SET, like any other mod",
+              strstr(set, "/draw") != NULL);
+        check("so a peer running nothing REFUSES us",
+              snes_mod_runtime_check_set_c("(none)\n", why, sizeof(why))
+                  != SNES_MODSET_OK);
+        check("and it is reported as an unapproved cosmetic claim, by name",
+              snes_mod_runtime_unapproved_cosmetics_c(bad, sizeof(bad)) > 0 &&
+              strstr(bad, "/draw") != NULL);
+    }
+
+    printf("\n0b. a grant for SOMETHING ELSE does not help it\n");
+    {
+        snes_mod_runtime_set_cosmetic_allow_c("other.package@1.0.0");
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("still in the compared set", strstr(set, "/draw") != NULL);
+    }
+
+    printf("\n0c. a grant with the WRONG DIGEST does not help it either\n");
+    {
+        /* The case that makes the list a whitelist rather than a naming
+         * convention: right id, right version, different bytes. */
+        snes_mod_runtime_set_cosmetic_allow_c(
+            PKG "@1.0.0#"
+            "1111111111111111111111111111111111111111111111111111111111111111");
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("still in the compared set", strstr(set, "/draw") != NULL);
+    }
+
+    printf("\n0d. the right digest DOES grant it\n");
+    {
+        char digest[72];
+        char entry[256];
+        check("the runtime can digest the installed package",
+              snes_mod_runtime_package_digest_c(PKG, "1.0.0", digest,
+                                                sizeof(digest)) == 1 &&
+              strlen(digest) == 64);
+        snprintf(entry, sizeof(entry), PKG "@1.0.0#%s", digest);
+        snes_mod_runtime_set_cosmetic_allow_c(entry);
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("NOW it is exempt from the compared set",
+              strstr(set, "/draw") == NULL);
+        check("and nothing is reported as unapproved",
+              snes_mod_runtime_unapproved_cosmetics_c(set, sizeof(set)) == 0);
+    }
+
+    printf("\n1. granted, it is absent from the compared set\n");
+    snes_mod_runtime_effective_set_c(set, sizeof(set));
+    check("effective set is \"(none)\": equal to a peer without it",
+          strcmp(set, "(none)\n") == 0);
+    check("so a peer running nothing accepts us",
+          snes_mod_runtime_check_set_c("(none)\n", why, sizeof(why))
+              == SNES_MODSET_OK);
+
+    printf("\n2. adopting a host's set leaves it alone\n");
+    check("precondition: check_set says OPTION, so the adopt will sweep",
+          snes_mod_runtime_check_set_c(host, why, sizeof(why))
+              == SNES_MODSET_OPTION);
+    check("adopt succeeded",
+          snes_mod_runtime_adopt_set_c(host, why, sizeof(why))
+              == SNES_MODSET_OK);
+    check("the ordinary feature was turned ON by the adopt",
+          snes_mod_runtime_feature_enabled_c(PKG, "sim") == 1);
+    check("THE PRESENTATION FEATURE SURVIVED THE ADOPT",
+          snes_mod_runtime_feature_enabled_c(PKG, "draw") == 1);
+
+    printf("\n3. nor in the plan rows the lobby publishes\n");
+    {
+        /* At this point the adopt above has turned the ordinary feature on,
+         * so a row for the package SHOULD exist -- and must list only the
+         * ordinary feature. Asserting the row is present, not merely that the
+         * feature is missing from it, is what stops this passing if plan_rows
+         * ever started returning nothing at all. */
+        SnesModPkgRow rows[8];
+        int n = snes_mod_runtime_plan_rows_c(rows, 8);
+        int i, row = -1;
+        for (i = 0; i < n; ++i)
+            if (strcmp(rows[i].id, PKG) == 0) row = i;
+        check("the package has a row, because its ordinary feature is on",
+              row >= 0);
+        check("the row lists the ordinary feature",
+              row >= 0 && strstr(rows[row].features, "sim") != NULL);
+        check("THE ROW DOES NOT LIST THE PRESENTATION FEATURE",
+              row >= 0 && strstr(rows[row].features, "draw") == NULL);
+    }
+
+    printf("\n4. a package contributing ONLY a presentation feature has no row\n");
+    {
+        /* The case that matters: a player whose entire mod selection is an
+         * accessibility filter must look, to a joiner, exactly like a player
+         * running nothing at all. */
+        SnesModPkgRow rows[8];
+        int n, i, found = 0;
+        check("adopt to vanilla succeeded",
+              snes_mod_runtime_adopt_set_c("(none)\n", why, sizeof(why))
+                  == SNES_MODSET_OK);
+        check("precondition: only the presentation feature is left on",
+              snes_mod_runtime_feature_enabled_c(PKG, "draw") == 1 &&
+              snes_mod_runtime_feature_enabled_c(PKG, "sim") == 0);
+        n = snes_mod_runtime_plan_rows_c(rows, 8);
+        for (i = 0; i < n; ++i)
+            if (strcmp(rows[i].id, PKG) == 0) found = 1;
+        check("no row is published for it at all", !found);
+    }
+
+    printf("\n5. and an ordinary feature is still compared as it always was\n");
+    check("re-adopting the host's set succeeded",
+          snes_mod_runtime_adopt_set_c(host, why, sizeof(why))
+              == SNES_MODSET_OK);
+    snes_mod_runtime_effective_set_c(set, sizeof(set));
+    check("the ordinary feature IS in the set", strstr(set, "/sim") != NULL);
+    check("the presentation feature still is not",
+          strstr(set, "/draw") == NULL);
+    check("we match the host byte for byte", strcmp(set, host) == 0);
+
+    printf("\n6. revoking the grant puts it back under the comparison\n");
+    {
+        /* Leaving a lobby lapses the grant, and the exemption must lapse with
+         * it rather than persisting into the next match. */
+        snes_mod_runtime_set_cosmetic_allow_c(NULL);
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("it is in the compared set again", strstr(set, "/draw") != NULL);
+        check("and unapproved again",
+              snes_mod_runtime_unapproved_cosmetics_c(set, sizeof(set)) > 0);
+    }
+
+    printf("\n7. a manifest cannot classify ITSELF as presentation\n");
+    {
+        /* `sneaky` claims presentation_only in exactly the words `draw` uses,
+         * and is granted by the same allowlist entry -- the package is the
+         * same package. The ONLY difference is that this build vouched for
+         * one plugin and not the other, and that has to be enough, because
+         * the manifest is the half an attacker writes.
+         *
+         * Its own launch state, because the adopts above legitimately swept
+         * it off and a precondition that quietly depends on a previous case
+         * is how a security test starts passing for the wrong reason. */
+        check("re-armed both claiming features", write_state(root, 1, 1) == 1);
+        check("re-initialize",
+              snes_mod_runtime_initialize_c(root, "test", SHA) == 1);
+        grant_this_package(root);
+        check("precondition: sneaky is enabled and claims presentation_only",
+              snes_mod_runtime_feature_enabled_c(PKG, "sneaky") == 1);
+        check("precondition: so is the vouched-for one",
+              snes_mod_runtime_feature_enabled_c(PKG, "draw") == 1);
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("IT IS STILL COMPARED, despite the claim and the grant",
+              strstr(set, "/sneaky") != NULL);
+        check("while the vouched-for feature beside it IS exempt",
+              strstr(set, "/draw") == NULL);
+    }
+
+    printf("\n8. a package that ships files cannot be cosmetic at all\n");
+    {
+        /* Drop one extra file into the package and the claim lapses --
+         * including for the plugin this build DID vouch for. A payload is a
+         * lever over the guest whatever the manifest says, because a built-in
+         * feature may consume it (localization patches ROM text from exactly
+         * such a file). */
+        char extra[ROOT_MAX + 128];
+        FILE *f;
+        write_state(root, 1, 0);
+        snprintf(extra, sizeof(extra),
+                 "%s/packages/" PKG "/1.0.0/payload.bin", root);
+        f = fopen(extra, "wb");
+        check("wrote a payload into the package", f != NULL);
+        if (f) { fputs("x", f); fclose(f); }
+
+        /* Re-initialize: the manifest-only answer is memoised per run, as it
+         * is in a real process, so this models the next LAUNCH rather than a
+         * file appearing mid-session. The grant is recomputed from the NEW
+         * bytes, so this is not the digest test over again -- the allowlist
+         * matches perfectly and the claim still fails. */
+        snes_mod_runtime_initialize_c(root, "test", SHA);
+        grant_this_package(root);
+        snes_mod_runtime_effective_set_c(set, sizeof(set));
+        check("THE VOUCHED-FOR FEATURE IS NO LONGER EXEMPT",
+              strstr(set, "/draw") != NULL);
+        remove(extra);
+    }
+
+    printf("\n%s (%d failure%s)\n", fails ? "FAILED" : "PASSED",
+           fails, fails == 1 ? "" : "s");
+    return fails ? 1 : 0;
+}

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -214,6 +214,22 @@ echo "=== lobby mod plan (match_caps.mods wire shape) ==="
     -o "$OUT/lobby_mod_plan_test"
 "$OUT/lobby_mod_plan_test"
 
+echo "=== mod runtime: presentation_only is not compared by netplay ==="
+# C++ because mod_runtime is C++, and it is compiled here rather than mocked so
+# the real manifest parser, the real effective-set text and the real adopt
+# sweep are what the cases run against. The fixture catalog is written into
+# $OUT by the test itself, so this stays ROM-free and leaves nothing in the
+# source tree.
+"${CXX:-g++}" -std=c++17 -Wall -Wextra -O1 \
+    -I "$ROOT/runner/src" \
+    -x c++ "$ROOT/tests/netplay/mod_presentation_only_test.c" \
+    "$ROOT/runner/src/mod_runtime.cpp" \
+    "$ROOT/runner/src/crc32.c" \
+    "$ROOT/runner/src/sha256.c" \
+    -o "$OUT/mod_presentation_only_test"
+rm -rf "$OUT/mod_presentation_only_fixture"
+"$OUT/mod_presentation_only_test" "$OUT/mod_presentation_only_fixture"
+
 echo "=== host OSD (FPS readout / turbo / toasts) ==="
 # Needs SDL for its clock only (no window; SDL_INIT_TIMER). Skipped rather than
 # failed where SDL headers are absent, so this stays a ROM-free harness that


### PR DESCRIPTION
**Part 2 of 2.** Stacks on #72 — review that first, or read this diff against `pr/1-runtime-rewind-runahead`, which is what the base is set to. Ten commits, all in `runner/src/netplay` and `runner/src/lobby`.

### Automatch

- The accept countdown ticks, an automatch room is recognisable by sight, and the accept ack honours the answer it is acknowledging.
- LAN and server netplay are isolated from each other rather than sharing state.

### Accessibility, and who decides what is cosmetic

A photosensitivity flash filter is presentation-only, so a player must be able to run it when their opponent does not — an accessibility feature that needs the other side's agreement is unavailable in exactly the matches it exists for.

That needed a way to say so which a mod cannot say about itself:

- `Feature::presentation_only` in the manifest is the mod **asking**. On its own it grants nothing, because a cheat author writes manifests too.
- The **grant** comes from the match's authority — the automatch ruleset the server published, or the lobby host — naming the package on `match_caps.mod_cosmetic_allow`, ideally pinned to the package's content digest (`zip_store_tree` is deterministic precisely so a digest means the same thing on two machines).
- Two further conditions are checked locally and hold even against a server that approves something it should not: every plugin the feature enables must be registered by the **executable** as presentation-only (`snes_mod_register_presentation_plugin`), and the package must carry nothing but its manifest, so it cannot feed data to a built-in feature that patches the guest.
- One predicate, `feature_exempt()`, gates all three places netplay looks: `effective_set`, `plan_rows`, and the `adopt_set` disable sweep. The last one mattered — without it a granted filter switched itself off the moment its owner joined a lobby, silently.
- The automatch ticket now carries `mod_exempt`, the evidence, so the **server** applies the allowlist instead of being handed this client's verdict.

Covered by `tests/netplay/mod_presentation_only_test.c` (ROM-free, wired into `tests/run_c_tests.sh`). The pointed cases: no grant approves nothing; a grant for another package or with the wrong digest approves nothing; a manifest cannot classify itself; a package that ships any file cannot be cosmetic at all.

### Moderation and reporting

- **Chat reporting.** A report names a message id; the server writes down what *it* relayed. Deliberately no text parameter — a report carrying its own copy would let anyone fabricate a message and have somebody sanctioned for it. The frame itself is built by recomp-net so it is not a copy per console.
- **Block list** pushed to the server.
- **Fork reports.** Rollback already digests the simulation every tick and names the subsystem that moved; that signal was written to a local log and discarded. It is now reported, with **both** peers' digests, because a fork says two peers differed and never which one moved — version skew and genuine emulation bugs produce these from honest players.

### Notes for review

- Depends on recomp-net for `recomp_net/chat_report.h`; that needs to land first or the chat-report glue will not compile.
- Companion launcher PR: RetroPortingToolKit/recomp-ui#53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoCenwWdTALkvzUtkr8coQ
