### PR TITLE
Fix Super FX save states and Star Fox beam progress

### DIFF
--- a/.github/workflows/native-analyzer.yml
+++ b/.github/workflows/native-analyzer.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -48,6 +50,7 @@ jobs:
       - name: Run Python compatibility tests
         if: runner.os == 'Linux'
         run: |
+          python -m pip install pytest
           python tests/run_tests.py
           python tests/v2/run_tests.py
       - name: Run C runtime tests

--- a/recompiler-rs/src/rom.rs
+++ b/recompiler-rs/src/rom.rs
@@ -254,23 +254,4 @@ mod tests {
         assert_eq!(rom_offset(RomMapping::Sdd1ExLoRom, 0x80, 0x8000), 0);
     }
 
-    #[test]
-    fn detects_and_maps_sdd1_exlorom_windows() {
-        let mut rom = vec![0u8; 0x600000];
-        rom[0x7FD5] = 0x32;
-        rom[0x7FFC..0x7FFE].copy_from_slice(&0xFEC1u16.to_le_bytes());
-        rom[0x7FDC..0x7FDE].copy_from_slice(&0xEC47u16.to_le_bytes());
-        rom[0x7FDE..0x7FE0].copy_from_slice(&0x13B8u16.to_le_bytes());
-        assert_eq!(detect_rom_mapping(&rom), RomMapping::Sdd1ExLoRom);
-        assert_eq!(vector_table_offset(&rom), 0x7FE0);
-        assert!(is_rom_address(RomMapping::Sdd1ExLoRom, 0xC0, 0x0000));
-        assert!(is_rom_address(RomMapping::Sdd1ExLoRom, 0xFF, 0xFFFF));
-        assert_eq!(rom_offset(RomMapping::Sdd1ExLoRom, 0xC0, 0x0000), 0);
-        assert_eq!(rom_offset(RomMapping::Sdd1ExLoRom, 0xD0, 0x0000), 0x100000);
-        assert_eq!(
-            rom_offset(RomMapping::Sdd1ExLoRom, 0xFF, 0xFFFF),
-            0x3FFFFF
-        );
-        assert_eq!(rom_offset(RomMapping::Sdd1ExLoRom, 0x80, 0x8000), 0);
-    }
 }

--- a/recompiler-rs/src/rom.rs
+++ b/recompiler-rs/src/rom.rs
@@ -253,5 +253,4 @@ mod tests {
         assert_eq!(rom_offset(RomMapping::Sdd1ExLoRom, 0xFF, 0xFFFF), 0x3FFFFF);
         assert_eq!(rom_offset(RomMapping::Sdd1ExLoRom, 0x80, 0x8000), 0);
     }
-
 }

--- a/runner/src/common_cpu_infra.c
+++ b/runner/src/common_cpu_infra.c
@@ -761,6 +761,7 @@ void RecompStackBalDumpJson(FILE *f) {
  * complete and (exit_s - entry_s) is a meaningful balance figure.
  * audit == 0: this exit is an LLE yield unwind — see RecompStackPopYield. */
 static void recomp_stack_pop_common(int audit) {
+  (void)audit; /* Only used when stack-balance diagnostics are compiled in. */
 #ifdef SNESRECOMP_INTERP_PROFILE
   if (g_aotprof_on < 0) aotprof_latch_env();
   if (g_aotprof_on == 1) {
@@ -1103,4 +1104,3 @@ Snes *SnesInit(const uint8 *data, int data_size) {
   return g_snes;
 #endif /* SNESRECOMP_SETUP_HOST */
 }
-

--- a/runner/src/common_cpu_infra.h
+++ b/runner/src/common_cpu_infra.h
@@ -138,6 +138,9 @@ typedef struct RtlGameInfo {
    * release runs do not create tier2_*.json/jsonl artifacts. Developers can
    * still opt in at launch with SNESRECOMP_TIER2_CAPTURE=1. */
   int tier2_capture;
+  /* Zero uses the framework minimum. A title can reject formats which
+   * predate required coprocessor or execution-state data before loading. */
+  uint32_t minimum_state_version;
 } RtlGameInfo;
 
 extern const RtlGameInfo *g_rtl_game_info;

--- a/runner/src/common_rtl.c
+++ b/runner/src/common_rtl.c
@@ -307,7 +307,7 @@ static uint64_t fp_fnv1a(const uint8_t *p, size_t n) {
  * v8: multitap chunk (seats, IOBit lines, per-bank shift counters, latched
  *     automatic-read words). Older files load with no multitap configured,
  *     which is the pre-multitap two-pad machine exactly. */
-#define RTL_SAV_VERSION 8u
+#define RTL_SAV_VERSION 9u /* Super FX architectural state in cart_saveload. */
 /* 4 and 5 described a Snes tail layout this struct no longer has; see
  * snes_saveload(). Loading one would mis-map the interrupt fields, so
  * they are rejected by the header check instead. */
@@ -836,7 +836,8 @@ bool RtlLoadSnapshot(const char *filename) {
   uint32 hdr[2];
   if (fread(hdr, sizeof(hdr), 1, f) != 1
       || hdr[0] != RTL_SAV_MAGIC
-      || hdr[1] < RTL_SAV_VERSION_MIN || hdr[1] > RTL_SAV_VERSION) {
+      || hdr[1] < RTL_SAV_VERSION_MIN || hdr[1] > RTL_SAV_VERSION
+      || (g_rtl_game_info && hdr[1] < g_rtl_game_info->minimum_state_version)) {
     printf("Save file %s: bad magic/version (legacy StateRecorder format no longer supported)\n", filename);
     fclose(f);
     return false;
@@ -893,7 +894,8 @@ bool RtlLoadSnapshotFromMemory(const void *data, size_t size) {
   uint32 hdr[2];
   memcpy(hdr, data, sizeof hdr);
   if (hdr[0] != RTL_SAV_MAGIC || hdr[1] < RTL_SAV_VERSION_MIN ||
-      hdr[1] > RTL_SAV_VERSION)
+      hdr[1] > RTL_SAV_VERSION ||
+      (g_rtl_game_info && hdr[1] < g_rtl_game_info->minimum_state_version))
     return false;
 
   MemorySli memory = {

--- a/runner/src/launcher.c
+++ b/runner/src/launcher.c
@@ -39,10 +39,6 @@ static int first_positional_arg(int argc, char **argv) {
     return 0;
 }
 
-static int has_positional_rom(int argc, char **argv) {
-    return first_positional_arg(argc, argv) != 0;
-}
-
 static void copy_path_fallback(const char *path,
                                char *out_path, size_t max_len) {
     strncpy(out_path, path, max_len - 1);

--- a/runner/src/snes/cart.c
+++ b/runner/src/snes/cart.c
@@ -54,6 +54,8 @@ void cart_reset(Cart* cart) {
 
 void cart_saveload(Cart *cart, SaveLoadInfo *sli) {
   sli->func(sli, cart->ram, cart->ramSize);
+  if (cart->superfx && snes_saveload_get_version() >= 9)
+    superfx_saveload(cart->superfx, sli);
   /* Cx4 games have no battery RAM, so the block above streams nothing; the
    * coprocessor's own 8 KB of working RAM is the guest-visible state that a
    * mid-game state must carry. */

--- a/runner/src/snes/snes.c
+++ b/runner/src/snes/snes.c
@@ -99,6 +99,8 @@ void snes_saveload_set_version(uint32_t version) {
   s_saveload_version = version ? version : 7;
 }
 
+uint32_t snes_saveload_get_version(void) { return s_saveload_version; }
+
 void snes_saveload(Snes *snes, SaveLoadInfo *sli) {
   cpu_saveload(snes->cpu, sli);
   apu_saveload(snes->apu, sli);
@@ -329,9 +331,10 @@ uint16_t SwapInputBits(uint16_t x) {
  * the handler returned, so walking it before the handler runs makes any split
  * the handler schedules close ahead land in the past (Gundam Wing schedules
  * VTIME=+2 lines from its line-21 handler; that split was lost ~85% of frames
- * and the gameplay demo rendered black at brightness 0). While inIrq is
- * pending the walk consumes nothing; the host frame loop dispatches promptly,
- * the handler runs under snes_beam_hold, and the walk resumes on release. */
+ * and the gameplay demo rendered black at brightness 0). Once an IRQ is
+ * already pending the beam must still progress: the CPU may have interrupts
+ * masked while polling a later beam position. Hosts which need to hold the
+ * beam during an interrupt handler use snes_beam_hold explicitly. */
 static uint32_t snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
   /* One NTSC scanline is 1364 master clocks, 262 scanlines per frame. Keep
    * the live beam counters moving while LLE code executes so SLHV/OPHCT/OPVCT
@@ -344,8 +347,6 @@ static uint32_t snes_advance_beam(Snes *snes, uint32_t clocks, bool check_irq) {
   uint32_t h = snes->hPos;
   uint32_t v = snes->vPos;
   uint32_t consumed = 0;
-  if (check_irq && snes->inIrq)
-    return 0;                      /* frozen until the pending IRQ is taken */
   while (clocks) {
     uint32_t span = 1364u - h;
     /* Stop at HBlank so the HDMA transfer occurs at its hardware edge rather

--- a/runner/src/snes/snes.h
+++ b/runner/src/snes/snes.h
@@ -124,6 +124,7 @@ uint16_t SwapInputBits(uint16_t x);
 bool snes_loadRom(Snes* snes, const uint8_t* data, int length);
 /* Savestate format version for snes_saveload layout (RTLS header). */
 void snes_saveload_set_version(uint32_t version);
+uint32_t snes_saveload_get_version(void);
 void snes_saveload(Snes *snes, SaveLoadInfo *sli);
 void snes_catchupApu(Snes *snes);
 void snes_advance_master_cycles(Snes *snes, uint32_t clocks);

--- a/runner/src/snes/superfx.c
+++ b/runner/src/snes/superfx.c
@@ -8,6 +8,8 @@
  * not include ares framework code.
  */
 #include "superfx.h"
+#include "saveload.h"
+#include <stddef.h>
 
 #include <limits.h>
 #include <stdio.h>
@@ -15,6 +17,14 @@
 #include <string.h>
 
 enum { kSuperFxWsMaxExtra = 288, kSuperFxWsMaxWidth = 800 };
+
+void superfx_saveload(SuperFx *fx, SaveLoadInfo *sli) {
+  /* ROM/RAM pointers precede r; diagnostics and private presentation replay
+   * follow irq_pending. Neither belongs to the emulated GSU state. */
+  _Static_assert(offsetof(SuperFx, instruction_count) - offsetof(SuperFx, r) == 696,
+                 "Super FX state layout changed: bump RTL_SAV_VERSION");
+  sli->func(sli, &fx->r, 696);
+}
 
 typedef struct SuperFxPresentationReplay {
   SuperFx clone;

--- a/runner/src/snes/superfx.h
+++ b/runner/src/snes/superfx.h
@@ -113,6 +113,9 @@ SuperFx *superfx_create(uint8_t *rom, uint32_t rom_size,
                         uint8_t *ram, uint32_t ram_size);
 void superfx_destroy(SuperFx *fx);
 void superfx_reset(SuperFx *fx);
+struct SaveLoadInfo;
+/* RTLS v9+: architectural state only. Cartridge RAM is streamed by cart. */
+void superfx_saveload(SuperFx *fx, struct SaveLoadInfo *sli);
 
 /* Synchronize to the S-CPU's monotonically increasing SNES master clock. */
 void superfx_sync(SuperFx *fx, uint64_t master_clock);

--- a/runner/src/snes_rewind.c
+++ b/runner/src/snes_rewind.c
@@ -108,6 +108,10 @@ void snes_rewind_shutdown(void) {
         s_ring = NULL;
     }
     s_count = s_head = s_sel = 0;
+    s_frame_tick = 0;
+    s_blob_size = 0;
+    s_have_live_thumb = 0;
+    s_enabled = 1;
     s_open = 0;
     s_configured = 0;
 }

--- a/runner/src/snes_savestate_menu.c
+++ b/runner/src/snes_savestate_menu.c
@@ -366,8 +366,14 @@ static void menu_move(int delta)
 
 static void menu_submit(int save)
 {
+    char path[256];
+    RtlEnsureSaveDir();
+    slot_path(s_selected, path, sizeof(path));
     if (save) {
-        RtlSaveLoad(kSaveLoad_Save, s_selected);
+        if (!RtlSaveSnapshot(path)) {
+            set_status("SAVE FAILED: SLOT %02d", s_selected);
+            return;
+        }
         if (s_have_live_thumb)
             write_thumb(s_selected, s_live_thumb);
         refresh_thumbs();
@@ -387,7 +393,10 @@ static void menu_submit(int save)
         snes_osd_push_slot_empty(s_selected);
         return;
     }
-    RtlSaveLoad(kSaveLoad_Load, s_selected);
+    if (!RtlLoadSnapshot(path)) {
+        set_status("LOAD FAILED: SLOT %02d", s_selected);
+        return;
+    }
     /* A load CLOSES the menu, so set_status() here would draw one frame of a
      * panel that is already gone. The toast outlives the menu, which is why
      * the load path needs it more than the save path does. */

--- a/tests/dma/hdma_timing_test.c
+++ b/tests/dma/hdma_timing_test.c
@@ -174,6 +174,30 @@ int main(void) {
     failures += check(dma->channel[0].tableAdr == 0x0203, "external beam owner consumed terminator");
     failures += check(dma->channel[0].hdmaActive, "external beam owner preserves HDMAEN state");
 
+    /* A masked, pending IRQ must not freeze beam polling (Star Fox boot
+     * waits for a later raster position before unmasking interrupts). */
+    dma_reset(dma);
+    snes.hPos = 100;
+    snes.vPos = 10;
+    snes.inIrq = true;
+    snes.hIrqEnabled = snes.vIrqEnabled = false;
+    snes_advance_master_cycles(&snes, 200);
+    failures += check(snes.hPos == 300 && snes.vPos == 10,
+                      "pending IRQ still allows beam progress");
+    failures += check(snes.inIrq, "beam advance does not acknowledge pending IRQ");
+
+    /* A NEW IRQ still yields at the comparator edge so hosts can service
+     * it promptly, before clocks after that edge have been consumed. */
+    snes.inIrq = false;
+    snes.hIrqEnabled = true;
+    snes.hTimer = 100;
+    snes_advance_master_cycles(&snes, 200);
+    failures += check(snes.inIrq && snes.hPos == 401,
+                      "new IRQ stops at its comparator edge");
+    snes_advance_master_cycles(&snes, 50);
+    failures += check(snes.hPos == 451,
+                      "subsequent clocks advance while IRQ remains pending");
+
     dma_free(dma);
     if (failures) return 1;
     puts("hdma_timing_test: ok");

--- a/tests/netplay/lobby_mod_plan_test.c
+++ b/tests/netplay/lobby_mod_plan_test.c
@@ -80,6 +80,11 @@ int rnet_ws_write_text(int fd, const char *text, int client_mask)
     abort();
 }
 
+const char *rnet_account_session(void)
+{
+    XFER_TRAP("rnet_account_session");
+}
+
 /* Stands in for the mod runtime: two installed packages. */
 static int two_pkg_offer(SnesLobbyModPkg *out, int max, void *ctx)
 {
@@ -684,9 +689,9 @@ static void case_chat_ring_keeps_room_order(void)
     memset(&g_lc, 0, sizeof(g_lc));
     snprintf(g_lc.player_id, sizeof(g_lc.player_id), "%s", "me");
 
-    chat_push("them", "Them", "first", 0);
-    chat_push("me",   "Me",   "second", 0);
-    chat_push("",     "",     "third", 1);
+    chat_push("them", "", "Them", "first", "", 0);
+    chat_push("me",   "", "Me",   "second", "", 0);
+    chat_push("",     "", "",     "third", "", 1);
 
     ck(snes_lobby_chat_count() == 3, "three lines land");
     ck(snes_lobby_chat_get(0, &got) && strcmp(got.text, "first") == 0,
@@ -726,7 +731,7 @@ static void case_chat_ring_wraps_oldest_first(void)
      * chat that discards what was just said is worse than no chat. */
     for (i = 0; i < SNES_LOBBY_CHAT_RING + 10; ++i) {
         snprintf(buf, sizeof(buf), "line%d", i);
-        chat_push("them", "Them", buf, 0);
+        chat_push("them", "", "Them", buf, "", 0);
     }
     ck(snes_lobby_chat_count() == SNES_LOBBY_CHAT_RING,
        "the ring stops at its capacity");
@@ -742,11 +747,11 @@ static void case_chat_ignores_empty_and_clears(void)
 {
     printf("  chat empty/clear\n");
     memset(&g_lc, 0, sizeof(g_lc));
-    chat_push("them", "Them", "", 0);
-    chat_push("them", "Them", NULL, 0);
+    chat_push("them", "", "Them", "", "", 0);
+    chat_push("them", "", "Them", NULL, "", 0);
     ck(snes_lobby_chat_count() == 0, "an empty line is not a line");
 
-    chat_push("them", "Them", "hello", 0);
+    chat_push("them", "", "Them", "hello", "", 0);
     ck(snes_lobby_chat_count() == 1, "a real line is");
     {
         SnesLobbyChatMsg m;
@@ -755,7 +760,7 @@ static void case_chat_ignores_empty_and_clears(void)
         before = m.seq;
         snes_lobby_chat_clear();
         ck(snes_lobby_chat_count() == 0, "clear empties the room log");
-        chat_push("them", "Them", "new room", 0);
+        chat_push("them", "", "Them", "new room", "", 0);
         (void)snes_lobby_chat_get(0, &m);
         /* seq must NOT restart: a UI tracking "newest seen" would otherwise
          * mistake the first line of a new room for one it already scrolled

--- a/tests/osd/osd_test.c
+++ b/tests/osd/osd_test.c
@@ -10,7 +10,7 @@
 
 #include "snes_osd.h"
 
-#include <SDL.h>
+#include "desktop/sdl_compat.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -22,14 +22,10 @@ static void check(int ok, const char *what) {
 }
 
 int main(void) {
-    /* SDL_GetTicks / SDL_GetPerformanceCounter need the timer subsystem; no
-     * video, so this runs headless in CI. */
-    if (!SDL_Init(SDL_INIT_TIMER)) {
-        /* SDL2 returns 0 on success, SDL3 returns true — accept either. */
-        if (SDL_Init(SDL_INIT_TIMER) != 0 && SDL_WasInit(SDL_INIT_TIMER) == 0) {
-            printf("SDL_Init failed: %s\n", SDL_GetError());
-            return 1;
-        }
+    /* The clocks work without a video device on both SDL backends. */
+    if (!snesrecomp_sdl_init(0)) {
+        printf("SDL_Init failed: %s\n", SDL_GetError());
+        return 1;
     }
 
     const uint32_t *px = NULL;

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -302,7 +302,8 @@ echo "=== lobby mod plan (match_caps.mods wire shape) ==="
     -I "$ROOT/runner/src" -I "$ROOT/runner/src/lobby" \
     -I "$ROOT/runner/src/lobby/ws" -I "$ROOT/lib/recomp-net/include" \
     "$ROOT/tests/netplay/lobby_mod_plan_test.c" \
-    "$ROOT"/runner/src/lobby/ws/*.c \
+    "$ROOT/lib/recomp-net/src/chat/rnet_chat_filter.c" \
+    "$ROOT/lib/recomp-net/src/chat/rnet_chat_report.c" \
     -o "$OUT/lobby_mod_plan_test"
 "$OUT/lobby_mod_plan_test"
 
@@ -355,11 +356,11 @@ OSD_SDL_BACKEND=""
 if pkg-config --exists sdl3 2>/dev/null; then
     OSD_SDL_CFLAGS="$(pkg-config --cflags sdl3)"
     OSD_SDL_LIBS="$(pkg-config --libs sdl3)"
-    OSD_SDL_BACKEND="-DSNESRECOMP_SDL_BACKEND=3"
+    OSD_SDL_BACKEND="-DSNESRECOMP_SDL3=1"
 elif pkg-config --exists sdl2 2>/dev/null; then
     OSD_SDL_CFLAGS="$(pkg-config --cflags sdl2)"
     OSD_SDL_LIBS="$(pkg-config --libs sdl2)"
-    OSD_SDL_BACKEND="-DSNESRECOMP_SDL_BACKEND=2"
+    OSD_SDL_BACKEND=""
 fi
 if [ -n "$OSD_SDL_LIBS" ]; then
     # shellcheck disable=SC2086
@@ -391,5 +392,14 @@ echo "=== rewind ring (ordering, clamping, what commit discards) ==="
     -I "$ROOT/runner/src" \
     "$ROOT/tests/rewind/rewind_test.c" \
     "$ROOT/runner/src/snes_rewind.c" \
+    "$ROOT/runner/src/snes_overlay_draw.c" \
     -o "$OUT/rewind_test"
 "$OUT/rewind_test"
+
+echo "=== Super FX state and presentation isolation ==="
+"$CC" -std=c11 -Wall -Wextra -Werror -O1 \
+    -I "$ROOT/runner/src" \
+    "$ROOT/tests/superfx/enhancement_opt_in_test.c" \
+    "$ROOT/runner/src/snes/superfx.c" \
+    -o "$OUT/superfx_state_test"
+"$OUT/superfx_state_test"

--- a/tests/superfx/enhancement_opt_in_test.c
+++ b/tests/superfx/enhancement_opt_in_test.c
@@ -7,6 +7,22 @@
 #include <string.h>
 
 #include "snes/superfx.h"
+#include "snes/saveload.h"
+
+typedef struct StateSink {
+  SaveLoadInfo base;
+  uint8_t bytes[1024];
+  size_t size;
+  int load;
+} StateSink;
+
+static void transfer_state(SaveLoadInfo *sli, void *data, size_t size) {
+  StateSink *sink = (StateSink *)sli;
+  if (size > sizeof(sink->bytes)) abort();
+  if (sink->load) memcpy(data, sink->bytes, size);
+  else memcpy(sink->bytes, data, size);
+  sink->size = size;
+}
 
 enum { kRomSize = 65536, kRamSize = 65536 };
 
@@ -170,6 +186,21 @@ int main(void) {
         "returning to faithful mode discards all enhanced presentation state");
   check(!superfx_get_widescreen_frame(optin, NULL, NULL, NULL, NULL),
         "faithful mode never exposes an enhanced frame");
+
+  StateSink state = {{transfer_state}, {0}, 0, 0};
+  native->master_clock = 123456;
+  native->clock_credit = -7;
+  native->irq_pending = true;
+  native->cache_valid[3] = true;
+  native->cache[48] = 0xa5;
+  superfx_saveload(native, &state.base);
+  check(state.size == 696, "versioned GSU state has the expected size");
+  state.load = 1;
+  superfx_saveload(optin, &state.base);
+  check(memcmp(&native->r, &optin->r, state.size) == 0,
+        "registers, pipeline, pixel/cache state, IRQ and clocks restore");
+  check(optin->rom == optin_rom && optin->ram == optin_ram,
+        "restore preserves the destination machine's memory pointers");
 
   destroy_fixture(native, native_rom, native_ram);
   destroy_fixture(optin, optin_rom, optin_ram);

--- a/tests/test_new_project.py
+++ b/tests/test_new_project.py
@@ -533,8 +533,8 @@ def test_mods_are_built_into_every_project():
         assert "set(SNESRECOMP_ENABLE_MODS ON" in cmake, "loader not enabled"
         assert cmake.index("SNESRECOMP_ENABLE_MODS ON") < cmake.index(
             "runner/runner.cmake)"), "must be set before runner.cmake reads it"
-        assert "snesrecomp_target_stage_dir(FixtureQuestSNESRecomp " \
-               "${CMAKE_SOURCE_DIR}/mods mods)" in cmake, "catalog not staged"
+        assert "snesrecomp_target_mod_catalog(FixtureQuestSNESRecomp " \
+               "${CMAKE_SOURCE_DIR}/mods/preloaded)" in cmake, "catalog not staged"
         assert cmake.count("snesrecomp_codegen_host.c") == 1, \
             "codegen host wired more than once"
 

--- a/tests/v2/test_emit_function_smoke.py
+++ b/tests/v2/test_emit_function_smoke.py
@@ -159,7 +159,7 @@ def test_wai_bounce_unwind_pops_generated_diagnostic_frame():
     needle = "return interp_bridge_lle_yield_unwind(cpu, 0x008001u);"
     assert needle in src, src
     before = src[:src.index(needle)]
-    assert before.rstrip().endswith("RecompStackPop();"), src
+    assert before.rstrip().endswith("RecompStackPopYield();"), src
 
 
 def test_function_entry_yields_when_lle_frame_deadline_is_reached():
@@ -172,7 +172,7 @@ def test_function_entry_yields_when_lle_frame_deadline_is_reached():
     assert check in src, src
     assert unwind in src, src
     before = src[:src.index(unwind)]
-    assert before.rstrip().endswith("RecompStackPop();"), src
+    assert before.rstrip().endswith("RecompStackPopYield();"), src
 
 
 def test_cfg_block_yields_at_an_architectural_resume_pc():
@@ -191,7 +191,7 @@ def test_cfg_block_yields_at_an_architectural_resume_pc():
     unwind = "return interp_bridge_lle_yield_unwind(cpu, 0x008004u);"
     assert unwind in src, src
     before = src[:src.index(unwind)]
-    assert before.rstrip().endswith("RecompStackPop();"), src
+    assert before.rstrip().endswith("RecompStackPopYield();"), src
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Star Fox could freeze during boot when the CPU masked an already pending IRQ, and save states omitted the Super FX registers, pipeline, cache and timing credit. Let an already pending IRQ continue advancing the beam, serialize the GSU architectural state in RTLS v9, and allow titles to reject incomplete older state versions before modifying the machine.

The shared save browser now reports failed I/O and keeps the menu open; rewind shutdown clears its capture cadence and thumbnails. Repair stale C test harness dependencies and API calls so the full suite runs against the current framework.

Validation: the full ROM-free `tests/run_c_tests.sh` passes. Star Fox integration checks pass on Windows/SDL3 and Linux/SDL2: exact snapshots and deterministic replay across three visible game phases, fresh-process file restore, save/load menu actions, rewind commit/cancel, and launcher hotkey persistence. The owner also confirmed both save states and rewind work interactively.
