### PR TITLE
Preserve X1 display and MSU-1 settings in the shared host

### DIFF
--- a/runner/src/desktop/host_main.c
+++ b/runner/src/desktop/host_main.c
@@ -41,6 +41,7 @@
 #include "host_clock.h"
 
 #include "snes/ppu.h"
+#include "snes/msu1.h"
 #include "snes/apu.h"
 #include "snes/dsp.h"
 #include "snes/snes.h"
@@ -2178,6 +2179,9 @@ int snesrecomp_desktop_main(const SnesDesktopHostGame *game, int argc, char **ar
         ls.fullscreen    = g_config.fullscreen;
         ls.ignore_aspect = g_config.ignore_aspect_ratio;
         ls.linear_filter = g_config.linear_filtering;
+        ls.aspect_index = SnesDisplayAspect_Clamp(g_config.display_aspect);
+        if (g_config.shader)
+          snprintf(ls.shader_path, sizeof(ls.shader_path), "%s", g_config.shader);
         ls.enable_audio  = g_config.enable_audio;
         ls.audio_freq    = g_config.audio_freq;
         ls.volume        = g_config.volume;
@@ -2232,6 +2236,18 @@ int snesrecomp_desktop_main(const SnesDesktopHostGame *game, int argc, char **ar
 #if defined(SNESRECOMP_HOST_HAS_BLEND)
         gi.has_frame_blend  = 1;
 #endif
+        if (game->display_aspect_supported) {
+          static const char *const labels[] = {
+            "4:3 (CRT)", "8:7 (Square pixels)", "1:1 (Square frame)"
+          };
+          gi.aspect_labels = labels;
+          gi.num_aspect_labels = kSnesDisplayAspect_Count;
+          gi.aspect_setting_label = "Display aspect";
+          gi.aspect_setting_help =
+              "4:3 recreates a traditional TV. 8:7 uses square pixels. "
+              "1:1 presents the native picture in a square.";
+        }
+        gi.has_shader = game->shader_supported;
         gi.has_run_ahead    = 1;   /* the runtime snapshots a machine in a frame */
         gi.has_vsync        = 1;
         gi.has_renderer     = 1;
@@ -2284,6 +2300,13 @@ int snesrecomp_desktop_main(const SnesDesktopHostGame *game, int argc, char **ar
           g_config.fullscreen          = (uint8)ls.fullscreen;
           g_config.ignore_aspect_ratio = ls.ignore_aspect != 0;
           g_config.linear_filtering    = ls.linear_filter != 0;
+          if (game->display_aspect_supported)
+            g_config.display_aspect = (uint8)SnesDisplayAspect_Clamp(ls.aspect_index);
+          if (game->shader_supported) {
+            static char shader_path[sizeof(ls.shader_path)];
+            snprintf(shader_path, sizeof(shader_path), "%s", ls.shader_path);
+            g_config.shader = shader_path[0] ? shader_path : NULL;
+          }
           g_config.enable_audio        = true;   /* always on */
           g_config.audio_freq          = (uint16)ls.audio_freq;
           g_config.volume              = ls.volume;
@@ -2471,6 +2494,7 @@ int snesrecomp_desktop_main(const SnesDesktopHostGame *game, int argc, char **ar
   if (game->on_rom_loaded) game->on_rom_loaded(kRom, kRom_SIZE);
 
   RtlRegisterGame(game->game_info);
+  msu1_set_rom_path(rom_path_buf);
   Snes *snes = SnesInit(kRom, kRom_SIZE);
   host_report_breadcrumb("SnesInit: %s", snes ? "ok" : "FAILED");
   if (snes == NULL) {

--- a/runner/src/desktop/host_main.h
+++ b/runner/src/desktop/host_main.h
@@ -87,6 +87,8 @@ typedef struct SnesDesktopHostGame {
   int native_widescreen;
   /* F7/F8 menus, with legacy slot 7/8 loads moved to F11/F12. */
   int state_menu_hotkeys;
+  int display_aspect_supported; /* expose the three SNES pixel-aspect choices */
+  int shader_supported;        /* expose GLSL presets (OpenGL presenter) */
 
   /* ── Hooks. Every one is optional. ────────────────────────────────────── */
 

--- a/runner/tests/mmx_state_runtime.c
+++ b/runner/tests/mmx_state_runtime.c
@@ -1,4 +1,4 @@
-/* ROM-backed checks for the X2/X3 adapter and the real shared desktop host.
+/* ROM-backed checks for the MMX adapters and the real shared desktop host.
  * The caller supplies an empty working directory; only slot 12 is used. */
 #define MMX_DESKTOP_ENTRY MmxDesktopMain
 #include "../src/desktop/host_main.c"
@@ -62,6 +62,10 @@ int main(int argc, char **argv) {
   fseek(f, 0, SEEK_END); long rom_size = ftell(f); rewind(f);
   uint8 *rom = malloc(rom_size);
   check(fread(rom, 1, rom_size, f) == (size_t)rom_size, "ROM reads"); fclose(f);
+  if ((rom_size & 0x7fff) == 512) {
+    rom_size -= 512;
+    memmove(rom, rom + 512, rom_size);
+  }
   g_config.new_renderer = true; g_config.widescreen = true;
   g_last_drawable_width = 1280; g_last_drawable_height = 720;
   g_ppu_render_flags = kPpuRenderFlags_NewRenderer;


### PR DESCRIPTION
﻿X1 needs to keep its existing display-aspect and GLSL preset controls when moving to the shared desktop host. Add opt-in capability fields, round-trip those launcher settings, and provide the resolved ROM path to MSU-1 sidecar loading.

The existing MMX state harness now accepts SNES copier headers. Validated through X1: full snapshot restore, deterministic replay, fresh-process file load, F7/F8 migration and rebinding, rewind selection, and controller-driven modal open/close. USA/JP Windows SDL3 builds and ROM-free Linux SDL2 builds pass, as do X1 display geometry and widescreen policy checks.

Beads: beads-8wg.2.38.
